### PR TITLE
feat: Make rich chat a bit richer

### DIFF
--- a/packages/angular/src/chat-resource.fn.ts
+++ b/packages/angular/src/chat-resource.fn.ts
@@ -231,14 +231,28 @@ function processToolCallMessage(
         map(
           (result): ToolMessage => ({
             role: 'tool',
-            content: JSON.stringify(result),
+            content: {
+              type: 'success',
+              /**
+               * @todo Mike Ryan - Make sure this is actually
+               * an object that can be serialized to JSON.
+               */
+              content: result as object,
+            },
             tool_call_id: toolCall.id,
           })
         ),
         catchError((err): Observable<ToolMessage> => {
           return of({
             role: 'tool',
-            content: JSON.stringify({ error: err.message }),
+            content: {
+              type: 'error',
+              /**
+               * @todo Mike Ryan - Find a more rigid way to serialize
+               * errors back to the LLM.
+               */
+              error: err.message,
+            },
             tool_call_id: toolCall.id,
           });
         })

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,6 +1,7 @@
 export * from './chat-resource.fn';
 export * from './create-tool.fn';
 export * from './prediction-resource.fn';
+export * from './render-component.directive';
 export * from './rich-chat-resource.fn';
 export * from './rich-chat/assistant-message.component';
 export * from './types';

--- a/packages/angular/src/render-component.directive.ts
+++ b/packages/angular/src/render-component.directive.ts
@@ -1,0 +1,41 @@
+import {
+  ComponentRef,
+  Directive,
+  inject,
+  input,
+  ViewContainerRef,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
+import { RichComponentMessage } from './rich-chat-resource.fn';
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: 'ng-template[hshRenderComponentMessage]',
+  standalone: true,
+})
+// eslint-disable-next-line @angular-eslint/directive-class-suffix
+export class RenderComponentMessage implements OnInit, OnDestroy {
+  hshRenderComponentMessage =
+    input.required<RichComponentMessage<string, unknown>>();
+  viewContainerRef = inject(ViewContainerRef);
+  componentRef: ComponentRef<unknown> | null = null;
+
+  ngOnInit() {
+    const componentMessage = this.hshRenderComponentMessage();
+    this.componentRef = this.viewContainerRef.createComponent(
+      componentMessage.component
+    );
+
+    for (const input of Object.keys(componentMessage.inputs)) {
+      this.componentRef.setInput(
+        input,
+        componentMessage.inputs[input as keyof typeof componentMessage.inputs]
+      );
+    }
+  }
+
+  ngOnDestroy() {
+    this.componentRef?.destroy();
+  }
+}

--- a/packages/angular/src/rich-chat-resource.fn.ts
+++ b/packages/angular/src/rich-chat-resource.fn.ts
@@ -1,15 +1,23 @@
 import { computed, Signal, Type } from '@angular/core';
 import { BoundTool, createToolWithArgs } from './create-tool.fn';
-import { ChatMessage } from './types';
-import { chatResource } from './chat-resource.fn';
+import { ChatMessage, SystemMessage, UserMessage, ToolMessage } from './types';
+import { ChatResource, chatResource } from './chat-resource.fn';
 import { s } from './schema';
 
-type ChatComponent<Name extends string, T> = {
+export interface RichChatResource extends ChatResource {
+  messages: Signal<RichChatMessage[]>;
+}
+
+type SignalInputs<T> = {
+  [K in keyof T]: T[K] extends Signal<infer U> ? U : never;
+};
+
+export type ChatComponent<Name extends string, T> = {
   name: Name;
   description: string;
   component: Type<T>;
   inputs: Partial<{
-    [K in keyof T]: T[K] extends Signal<infer U> ? s.Schema<U> : never;
+    [P in keyof SignalInputs<T>]: s.Schema<SignalInputs<T>[P]>;
   }>;
 };
 
@@ -18,12 +26,40 @@ export function exposeComponent<Name extends string, T>(config: {
   description: string;
   component: Type<T>;
   inputs: Partial<{
-    [K in keyof T]: T[K] extends Signal<infer U> ? s.Schema<U> : never;
+    [P in keyof SignalInputs<T>]: s.Schema<SignalInputs<T>[P]>;
   }>;
-}) {
+}): ChatComponent<Name, T> {
   console.log(config);
   return config;
 }
+
+export type RichAssistantMessage = {
+  role: 'assistant';
+  content: string;
+};
+
+export type RichComponentMessage<Name extends string, T> = {
+  role: 'component';
+  name: Name;
+  component: Type<T>;
+  inputs: Partial<SignalInputs<T>>;
+};
+
+export type RichToolCallMessage = {
+  role: 'tool';
+  name: string;
+  callId: string;
+  isPending: boolean;
+  result?: unknown;
+  error?: string;
+};
+
+export type RichChatMessage =
+  | RichComponentMessage<string, unknown>
+  | RichToolCallMessage
+  | RichAssistantMessage
+  | UserMessage
+  | SystemMessage;
 
 export function richChatResource(args: {
   components?: ChatComponent<string, unknown>[];
@@ -32,7 +68,7 @@ export function richChatResource(args: {
   maxTokens?: number | Signal<number>;
   messages?: ChatMessage[];
   tools?: BoundTool<string, any>[];
-}) {
+}): RichChatResource {
   const ui = s.object('UI', {
     ui: s.anyOf('Any one of the following components', [
       ...(args.components ?? []).map((component) => {
@@ -121,5 +157,101 @@ export function richChatResource(args: {
     ],
   });
 
-  return chat;
+  const messages = computed(() => {
+    const messages = chat.value();
+
+    return messages.flatMap((message): RichChatMessage[] => {
+      if (message.role === 'tool') {
+        return [];
+      }
+      if (message.role === 'assistant') {
+        const toolCalls = message.tool_calls ?? [];
+
+        if (toolCalls.length === 0) {
+          const simpleMessage: RichAssistantMessage = {
+            role: 'assistant',
+            content: message.content ?? '',
+          };
+          return [simpleMessage];
+        }
+        const toolCallMessages = toolCalls.flatMap(
+          (
+            toolCall
+          ): Array<
+            RichToolCallMessage | RichComponentMessage<string, unknown>
+          > => {
+            const toolCallMessage = messages.find(
+              (t): t is ToolMessage =>
+                t.role === 'tool' && t.tool_call_id === toolCall.id
+            );
+            const toolName = toolCall.function.name;
+            const content = toolCallMessage?.content;
+            const result =
+              content && content.type === 'success'
+                ? content.content
+                : undefined;
+            const error =
+              content && content.type === 'error' ? content.error : undefined;
+
+            if (toolName === 'showComponent') {
+              let uiValue: s.Infer<typeof ui>;
+              try {
+                uiValue = s.parse(ui, JSON.parse(toolCall.function.arguments));
+              } catch (error) {
+                console.error(error);
+                return [];
+              }
+              const componentName = uiValue.ui.name;
+              const componentInputs = uiValue.ui.inputs;
+              const componentType = args.components?.find(
+                (c) => c.name === componentName
+              )?.component;
+
+              if (
+                uiValue &&
+                componentName &&
+                componentInputs &&
+                componentType
+              ) {
+                const componentMessage: RichComponentMessage<string, unknown> =
+                  {
+                    role: 'component',
+                    name: componentName,
+                    component: componentType,
+                    inputs: componentInputs,
+                  };
+                return [componentMessage];
+              }
+            }
+
+            return [
+              {
+                role: 'tool',
+                result,
+                error,
+                name: toolCall.function.name,
+                callId: toolCall.id,
+                isPending: result === undefined,
+              },
+            ];
+          }
+        );
+
+        return toolCallMessages;
+      }
+      if (message.role === 'user') {
+        return [message];
+      }
+      if (message.role === 'system') {
+        return [];
+      }
+
+      throw new Error(`Unknown message role`);
+    });
+  });
+
+  return {
+    ...chat,
+    messages,
+  };
 }

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -41,10 +41,14 @@ export interface AssistantMessage {
   }[];
 }
 
+export type ToolCallResult =
+  | { type: 'success'; content: object }
+  | { type: 'error'; error: string };
+
 // Tool response message
 export interface ToolMessage {
   role: 'tool';
-  content: string;
+  content: ToolCallResult;
   tool_call_id: string;
 }
 

--- a/samples/smart-home/client/src/app/features/chat/chat-panel.component.ts
+++ b/samples/smart-home/client/src/app/features/chat/chat-panel.component.ts
@@ -41,10 +41,7 @@ import { MessagesComponent } from './components/messages.component';
     </div>
 
     <div class="chat-messages">
-      <app-chat-messages
-        [messages]="chat.value()"
-        [components]="components"
-      ></app-chat-messages>
+      <app-chat-messages [messages]="chat.messages()"></app-chat-messages>
     </div>
 
     <div class="chat-composer">
@@ -97,10 +94,6 @@ export class ChatPanelComponent {
   store = inject(Store);
   authService = inject(AuthService);
   smartHomeService = inject(SmartHomeService);
-
-  components = {
-    light: LightCardComponent,
-  };
 
   chat = richChatResource({
     model: 'gpt-4o',

--- a/samples/smart-home/client/src/app/features/chat/components/messages.component.ts
+++ b/samples/smart-home/client/src/app/features/chat/components/messages.component.ts
@@ -1,10 +1,10 @@
-import { Component, input, Type } from '@angular/core';
-import { AssistantMessageComponent, ChatMessage } from '@hashbrownai/angular';
+import { Component, input } from '@angular/core';
+import { RenderComponentMessage, RichChatMessage } from '@hashbrownai/angular';
 
 @Component({
   selector: 'app-chat-messages',
   standalone: true,
-  imports: [AssistantMessageComponent],
+  imports: [RenderComponentMessage],
   template: `
     @for (message of messages(); track $index) { @switch (message.role) { @case
     ('user') {
@@ -13,10 +13,11 @@ import { AssistantMessageComponent, ChatMessage } from '@hashbrownai/angular';
     </div>
     } @case ('assistant') {
     <div class="chat-message assistant">
-      <lib-assistant-message
-        [message]="message"
-        [components]="components()"
-      ></lib-assistant-message>
+      <p>{{ message.content }}</p>
+    </div>
+    } @case ('component') {
+    <div class="chat-message component">
+      <ng-template [hshRenderComponentMessage]="message" />
     </div>
     } } }
   `,
@@ -42,15 +43,19 @@ import { AssistantMessageComponent, ChatMessage } from '@hashbrownai/angular';
         width: 100%;
       }
 
-      lib-assistant-message {
+      .chat-message.component {
+        align-self: flex-start;
         width: 100%;
+      }
+
+      .chat-message.tool {
+        align-self: flex-start;
+        width: 100%;
+        font-style: italic;
       }
     `,
   ],
 })
 export class MessagesComponent {
-  components = input.required<{
-    [componentName: string]: Type<any>;
-  }>();
-  messages = input.required<ChatMessage[]>();
+  messages = input.required<RichChatMessage[]>();
 }

--- a/samples/smart-home/client/src/app/shared/predictions.component.ts
+++ b/samples/smart-home/client/src/app/shared/predictions.component.ts
@@ -390,15 +390,17 @@ Additional Rules:
         description: 'All scenes in the smart home',
       },
     },
-    outputSchema: s.array('The predictions', PREDICTIONS_SCHEMA),
+    outputSchema: s.object('The result', {
+      predictions: s.array('The predictions', PREDICTIONS_SCHEMA),
+    }),
   });
 
   output = linkedSignal({
     source: this.predictions.value,
     computation: (source): s.Infer<typeof PREDICTIONS_SCHEMA>[] => {
-      if (source === undefined || source.length === 0) return [];
+      if (source === undefined || source.predictions.length === 0) return [];
 
-      return source;
+      return source.predictions;
     },
   });
 

--- a/samples/smart-home/client/src/app/store/last-user-action.reducer.ts
+++ b/samples/smart-home/client/src/app/store/last-user-action.reducer.ts
@@ -21,13 +21,6 @@ export const lastUserActionReducer = createReducer(
       payload: action.light,
     },
   })),
-  on(LightsApiActions.updateLightSuccess, (state, action) => ({
-    ...state,
-    action: {
-      userAction: 'Update Light Success',
-      payload: action.light,
-    },
-  })),
   on(ScenesApiActions.addSceneSuccess, (state, action) => ({
     ...state,
     action: {


### PR DESCRIPTION
Previously, when rendering chat messages, it was really hard to get at the state of function calls. You could see that a function call existed in an assistant message, but the work to manually look up its status was hard.

This refactor makes it far simpler to render messages out using the `richChatResource`. It collapes all tool calls into friendlier tool messages that expose the state of the tool call (pending, success, or error). Additionally, this adds a more mature API for rendering components from the LLM by exposing a component message, along with a directive to render component messages. 

It's all still a bit naive at this point, but it's getting better!