### PR TITLE
Add empty streaming values

### DIFF
--- a/packages/core/src/schema/internal/streaming.ts
+++ b/packages/core/src/schema/internal/streaming.ts
@@ -2,9 +2,12 @@
 import {
   AnyOfType,
   ArrayType,
+  BooleanType,
   ConstStringType,
   EnumType,
   HashbrownType,
+  IntegerType,
+  NumberType,
   ObjectType,
   StringType,
 } from './base';
@@ -21,6 +24,18 @@ export function constString<T extends string>(value: T): ConstStringType<T> {
     value,
     streaming: true,
   }) as any;
+}
+
+export function number(description: string) {
+  return new NumberType({ type: 'number', description, streaming: true });
+}
+
+export function boolean(description: string) {
+  return new BooleanType({ type: 'boolean', description, streaming: true });
+}
+
+export function integer(description: string) {
+  return new IntegerType({ type: 'integer', description, streaming: true });
 }
 
 export function object<Shape extends Record<string, any>>(

--- a/packages/core/src/schema/internal/streaming.ts
+++ b/packages/core/src/schema/internal/streaming.ts
@@ -2,12 +2,9 @@
 import {
   AnyOfType,
   ArrayType,
-  BooleanType,
   ConstStringType,
   EnumType,
   HashbrownType,
-  IntegerType,
-  NumberType,
   ObjectType,
   StringType,
 } from './base';
@@ -24,18 +21,6 @@ export function constString<T extends string>(value: T): ConstStringType<T> {
     value,
     streaming: true,
   }) as any;
-}
-
-export function number(description: string) {
-  return new NumberType({ type: 'number', description, streaming: true });
-}
-
-export function boolean(description: string) {
-  return new BooleanType({ type: 'boolean', description, streaming: true });
-}
-
-export function integer(description: string) {
-  return new IntegerType({ type: 'integer', description, streaming: true });
 }
 
 export function object<Shape extends Record<string, any>>(

--- a/packages/core/src/streaming-json-parser/parser.ts
+++ b/packages/core/src/streaming-json-parser/parser.ts
@@ -29,7 +29,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
   logger.log('In _parseJson');
   // Since each parse run is effectively starting over, this string should indicate
   // how far we can expect to get this time
-  console.log(jsonString);
+  logger.log(jsonString);
 
   const length = jsonString.length;
   let index = 0;
@@ -174,8 +174,6 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
             );
 
             // Are all non-streaming fields present?
-
-            // TODO: add "empty" streaming properties
             if (
               Object.entries(
                 (currentContainer[internal].definition as any).shape,

--- a/packages/core/src/streaming-json-parser/parser.ts
+++ b/packages/core/src/streaming-json-parser/parser.ts
@@ -11,8 +11,6 @@ class MalformedJSON extends Error {}
 
 class IncompleteNonStreamingObject extends Error {}
 
-class UnexpectedStreamingType extends Error {}
-
 function parseJSON(jsonString: string, schema: s.HashbrownType): any {
   if (typeof jsonString !== 'string') {
     throw new TypeError(`expecting str, got ${typeof jsonString}`);
@@ -29,7 +27,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
   logger.log('In _parseJson');
   // Since each parse run is effectively starting over, this string should indicate
   // how far we can expect to get this time
-  console.log(jsonString);
+  logger.log(jsonString);
 
   const length = jsonString.length;
   let index = 0;
@@ -174,8 +172,6 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
             );
 
             // Are all non-streaming fields present?
-
-            // TODO: add "empty" streaming properties
             if (
               Object.entries(
                 (currentContainer[internal].definition as any).shape,
@@ -183,30 +179,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
                 logger.log(
                   `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
                 );
-
-                // if this key is streaming and not present, add an "empty" value
-                if (s.isStreaming(subSchema as any)) {
-                  if (!(key in obj)) {
-                    if (
-                      s.isStringType(subSchema as any) ||
-                      s.isConstStringType(subSchema as any) ||
-                      s.isEnumType(subSchema as any)
-                    ) {
-                      obj[key] = '';
-                    } else if (s.isArrayType(subSchema as any)) {
-                      obj[key] = [];
-                    } else if (s.isObjectType(subSchema as any)) {
-                      obj[key] = {};
-                    } else {
-                      throw new UnexpectedStreamingType(
-                        'Unexpected schema type for a streaming prop',
-                      );
-                    }
-                  }
-                  return true;
-                }
-
-                if (key in obj) {
+                if (s.isStreaming(subSchema as any) || key in obj) {
                   return true;
                 }
 
@@ -315,29 +288,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
                 logger.log(
                   `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
                 );
-                // if this key is streaming and not present, add an "empty" value
-                if (s.isStreaming(subSchema as any)) {
-                  if (!(key in obj)) {
-                    if (
-                      s.isStringType(subSchema as any) ||
-                      s.isConstStringType(subSchema as any) ||
-                      s.isEnumType(subSchema as any)
-                    ) {
-                      obj[key] = '';
-                    } else if (s.isArrayType(subSchema as any)) {
-                      obj[key] = [];
-                    } else if (s.isObjectType(subSchema as any)) {
-                      obj[key] = {};
-                    } else {
-                      throw new UnexpectedStreamingType(
-                        'Unexpected schema type for a streaming prop',
-                      );
-                    }
-                  }
-                  return true;
-                }
-
-                if (key in obj) {
+                if (s.isStreaming(subSchema as any) || key in obj) {
                   return true;
                 }
 
@@ -382,29 +333,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
             logger.log(
               `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
             );
-            // if this key is streaming and not present, add an "empty" value
-            if (s.isStreaming(subSchema as any)) {
-              if (!(key in obj)) {
-                if (
-                  s.isStringType(subSchema as any) ||
-                  s.isConstStringType(subSchema as any) ||
-                  s.isEnumType(subSchema as any)
-                ) {
-                  obj[key] = '';
-                } else if (s.isArrayType(subSchema as any)) {
-                  obj[key] = [];
-                } else if (s.isObjectType(subSchema as any)) {
-                  obj[key] = {};
-                } else {
-                  throw new UnexpectedStreamingType(
-                    'Unexpected schema type for a streaming prop',
-                  );
-                }
-              }
-              return true;
-            }
-
-            if (key in obj) {
+            if (s.isStreaming(subSchema as any) || key in obj) {
               return true;
             }
 

--- a/packages/core/src/streaming-json-parser/parser.ts
+++ b/packages/core/src/streaming-json-parser/parser.ts
@@ -11,6 +11,8 @@ class MalformedJSON extends Error {}
 
 class IncompleteNonStreamingObject extends Error {}
 
+class UnexpectedStreamingType extends Error {}
+
 function parseJSON(jsonString: string, schema: s.HashbrownType): any {
   if (typeof jsonString !== 'string') {
     throw new TypeError(`expecting str, got ${typeof jsonString}`);
@@ -27,7 +29,7 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
   logger.log('In _parseJson');
   // Since each parse run is effectively starting over, this string should indicate
   // how far we can expect to get this time
-  logger.log(jsonString);
+  console.log(jsonString);
 
   const length = jsonString.length;
   let index = 0;
@@ -172,6 +174,8 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
             );
 
             // Are all non-streaming fields present?
+
+            // TODO: add "empty" streaming properties
             if (
               Object.entries(
                 (currentContainer[internal].definition as any).shape,
@@ -179,7 +183,30 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
                 logger.log(
                   `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
                 );
-                if (s.isStreaming(subSchema as any) || key in obj) {
+
+                // if this key is streaming and not present, add an "empty" value
+                if (s.isStreaming(subSchema as any)) {
+                  if (!(key in obj)) {
+                    if (
+                      s.isStringType(subSchema as any) ||
+                      s.isConstStringType(subSchema as any) ||
+                      s.isEnumType(subSchema as any)
+                    ) {
+                      obj[key] = '';
+                    } else if (s.isArrayType(subSchema as any)) {
+                      obj[key] = [];
+                    } else if (s.isObjectType(subSchema as any)) {
+                      obj[key] = {};
+                    } else {
+                      throw new UnexpectedStreamingType(
+                        'Unexpected schema type for a streaming prop',
+                      );
+                    }
+                  }
+                  return true;
+                }
+
+                if (key in obj) {
                   return true;
                 }
 
@@ -288,7 +315,29 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
                 logger.log(
                   `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
                 );
-                if (s.isStreaming(subSchema as any) || key in obj) {
+                // if this key is streaming and not present, add an "empty" value
+                if (s.isStreaming(subSchema as any)) {
+                  if (!(key in obj)) {
+                    if (
+                      s.isStringType(subSchema as any) ||
+                      s.isConstStringType(subSchema as any) ||
+                      s.isEnumType(subSchema as any)
+                    ) {
+                      obj[key] = '';
+                    } else if (s.isArrayType(subSchema as any)) {
+                      obj[key] = [];
+                    } else if (s.isObjectType(subSchema as any)) {
+                      obj[key] = {};
+                    } else {
+                      throw new UnexpectedStreamingType(
+                        'Unexpected schema type for a streaming prop',
+                      );
+                    }
+                  }
+                  return true;
+                }
+
+                if (key in obj) {
                   return true;
                 }
 
@@ -333,7 +382,29 @@ const _parseJSON = (jsonString: string, schema: s.HashbrownType) => {
             logger.log(
               `key ${key} is streaming: ${s.isStreaming(subSchema as any)} and present: ${key in obj}`,
             );
-            if (s.isStreaming(subSchema as any) || key in obj) {
+            // if this key is streaming and not present, add an "empty" value
+            if (s.isStreaming(subSchema as any)) {
+              if (!(key in obj)) {
+                if (
+                  s.isStringType(subSchema as any) ||
+                  s.isConstStringType(subSchema as any) ||
+                  s.isEnumType(subSchema as any)
+                ) {
+                  obj[key] = '';
+                } else if (s.isArrayType(subSchema as any)) {
+                  obj[key] = [];
+                } else if (s.isObjectType(subSchema as any)) {
+                  obj[key] = {};
+                } else {
+                  throw new UnexpectedStreamingType(
+                    'Unexpected schema type for a streaming prop',
+                  );
+                }
+              }
+              return true;
+            }
+
+            if (key in obj) {
               return true;
             }
 

--- a/packages/core/src/streaming-json-parser/test/client.ts
+++ b/packages/core/src/streaming-json-parser/test/client.ts
@@ -12,86 +12,81 @@ import { s } from '../../schema';
     console.log('Connected');
   });
 
-  const responseSchema = s.object('root', {
-    booleanValue: s.boolean('a boolean'),
-    value: s.streaming.string('glossary name'),
-    array: s.streaming.array('array', s.string('array string')),
-    object: s.streaming.object('object', {
-      a: s.streaming.string('plan a'),
-      b: s.streaming.string('plan b'),
-    }),
-  });
-
   // const responseSchema = s.streaming.array(
   //   'root array',
-  //   s.object('root object', {
-  //     glossary: s.object('glossary', {
-  //       title: s.string('glossary.title'),
-  //       GlossDiv: s.object('GlossDiv', {
-  //         title: s.string('GlossDiv.title'),
-  //         GlossList: s.streaming.array(
-  //           'GlossDiv.GlossList',
-  //           s.object('', {
-  //             ID: s.string('GlossList.ID'),
-  //             SortAs: s.string('GlossList.SortAs'),
-  //             GlossTerm: s.string('GlossList.GlossTerm'),
-  //             Acronym: s.string('GlossList.Acronym'),
-  //             GlossDef: s.object('GlossList.GlossDef', {
-  //               para: s.string('GlossDef.para'),
-  //               GlossSeeAlso: s.array('GlossDef.GlossSeeAlso', s.string('')),
-  //             }),
-  //             GlossSee: s.string('GlossList.GlossSee'),
-  //             ExampleSentences: s.streaming.array(
-  //               'GlossList.ExampleSentences',
-  //               s.string('ExampleSentence'),
-  //             ),
-  //           }),
-  //         ),
-  //         SynonymList: s.streaming.array(
-  //           'GlossDiv.SynonymList',
-  //           s.object('Synonym', {
-  //             ID: s.string('Synonym.ID'),
-  //             GlossTerm: s.string('Synonym.GlossTerm'),
-  //             Acronym: s.string('Synonym.Acronym'),
-  //             SynonymDef: s.object('Synonym.SynonymDef', {
-  //               word: s.string('Synonym.word'),
-  //               meaning: s.string('SynonymDef.meaning'),
-  //             }),
-  //           }),
-  //         ),
-  //         anyOfListWithDiscriminator: s.streaming.array(
-  //           'GlossDiv.anyOfListDiscriminator',
-  //           s.anyOf([
-  //             // No streaming
-  //             s.object('7th Grade Teacher', {
-  //               __discriminator: s.constString('seventh'),
-  //               // Expectation: this will be moved to end of properties list
-  //               birthDate: s.streaming.object('7th.birthDate', {
-  //                 // Expectation: property order won't change, but incremental updates
-  //                 // will occur
-  //                 year: s.string('7th.birthDate.year'),
-  //                 month: s.string('7th.birthDate.month'),
-  //                 day: s.string('7th.birthDate.day'),
-  //                 time: s.object('7th.birthData.time', {
-  //                   hour: s.number('hour'),
-  //                   minute: s.number('minute'),
-  //                 }),
-  //               }),
-  //               firstName: s.string('7th.firstName'),
-  //               lastName: s.string('7th.lastName'),
-  //             }),
-  //             // Will stream
-  //             s.object('8th Grade Teacher', {
-  //               __discriminator: s.constString('eighth'),
-  //               firstName: s.streaming.string('8th.firstName'),
-  //               lastName: s.streaming.string('8th.lastName'),
-  //             }),
-  //           ]),
-  //         ),
-  //       }),
-  //     }),
-  //   }),
+  //   s.string('glossary name'),
   // );
+
+  const responseSchema = s.streaming.array(
+    'root array',
+    s.object('root object', {
+      glossary: s.object('glossary', {
+        title: s.string('glossary.title'),
+        GlossDiv: s.object('GlossDiv', {
+          title: s.string('GlossDiv.title'),
+          GlossList: s.streaming.array(
+            'GlossDiv.GlossList',
+            s.object('', {
+              ID: s.string('GlossList.ID'),
+              SortAs: s.string('GlossList.SortAs'),
+              GlossTerm: s.string('GlossList.GlossTerm'),
+              Acronym: s.string('GlossList.Acronym'),
+              GlossDef: s.object('GlossList.GlossDef', {
+                para: s.string('GlossDef.para'),
+                GlossSeeAlso: s.array('GlossDef.GlossSeeAlso', s.string('')),
+              }),
+              GlossSee: s.string('GlossList.GlossSee'),
+              ExampleSentences: s.streaming.array(
+                'GlossList.ExampleSentences',
+                s.string('ExampleSentence'),
+              ),
+            }),
+          ),
+          SynonymList: s.streaming.array(
+            'GlossDiv.SynonymList',
+            s.object('Synonym', {
+              ID: s.string('Synonym.ID'),
+              GlossTerm: s.string('Synonym.GlossTerm'),
+              Acronym: s.string('Synonym.Acronym'),
+              SynonymDef: s.object('Synonym.SynonymDef', {
+                word: s.string('Synonym.word'),
+                meaning: s.string('SynonymDef.meaning'),
+              }),
+            }),
+          ),
+          anyOfListWithDiscriminator: s.streaming.array(
+            'GlossDiv.anyOfListDiscriminator',
+            s.anyOf([
+              // No streaming
+              s.object('7th Grade Teacher', {
+                __discriminator: s.constString('seventh'),
+                // Expectation: this will be moved to end of properties list
+                birthDate: s.streaming.object('7th.birthDate', {
+                  // Expectation: property order won't change, but incremental updates
+                  // will occur
+                  year: s.string('7th.birthDate.year'),
+                  month: s.string('7th.birthDate.month'),
+                  day: s.string('7th.birthDate.day'),
+                  time: s.object('7th.birthData.time', {
+                    hour: s.number('hour'),
+                    minute: s.number('minute'),
+                  }),
+                }),
+                firstName: s.string('7th.firstName'),
+                lastName: s.string('7th.lastName'),
+              }),
+              // Will stream
+              s.object('8th Grade Teacher', {
+                __discriminator: s.constString('eighth'),
+                firstName: s.streaming.string('8th.firstName'),
+                lastName: s.streaming.string('8th.lastName'),
+              }),
+            ]),
+          ),
+        }),
+      }),
+    }),
+  );
 
   const iterable = new SocketAsyncIterable(client);
 
@@ -101,7 +96,7 @@ import { s } from '../../schema';
     for await (const data of parserIterable) {
       // To see how things are changing in a dynamic way, clear the console before
       // parsing update
-      // console.clear();
+      console.clear();
       console.log('new chunk');
       console.log(JSON.stringify(data, null, 4));
     }

--- a/packages/core/src/streaming-json-parser/test/client.ts
+++ b/packages/core/src/streaming-json-parser/test/client.ts
@@ -12,81 +12,86 @@ import { s } from '../../schema';
     console.log('Connected');
   });
 
+  const responseSchema = s.object('root', {
+    booleanValue: s.boolean('a boolean'),
+    value: s.streaming.string('glossary name'),
+    array: s.streaming.array('array', s.string('array string')),
+    object: s.streaming.object('object', {
+      a: s.streaming.string('plan a'),
+      b: s.streaming.string('plan b'),
+    }),
+  });
+
   // const responseSchema = s.streaming.array(
   //   'root array',
-  //   s.string('glossary name'),
+  //   s.object('root object', {
+  //     glossary: s.object('glossary', {
+  //       title: s.string('glossary.title'),
+  //       GlossDiv: s.object('GlossDiv', {
+  //         title: s.string('GlossDiv.title'),
+  //         GlossList: s.streaming.array(
+  //           'GlossDiv.GlossList',
+  //           s.object('', {
+  //             ID: s.string('GlossList.ID'),
+  //             SortAs: s.string('GlossList.SortAs'),
+  //             GlossTerm: s.string('GlossList.GlossTerm'),
+  //             Acronym: s.string('GlossList.Acronym'),
+  //             GlossDef: s.object('GlossList.GlossDef', {
+  //               para: s.string('GlossDef.para'),
+  //               GlossSeeAlso: s.array('GlossDef.GlossSeeAlso', s.string('')),
+  //             }),
+  //             GlossSee: s.string('GlossList.GlossSee'),
+  //             ExampleSentences: s.streaming.array(
+  //               'GlossList.ExampleSentences',
+  //               s.string('ExampleSentence'),
+  //             ),
+  //           }),
+  //         ),
+  //         SynonymList: s.streaming.array(
+  //           'GlossDiv.SynonymList',
+  //           s.object('Synonym', {
+  //             ID: s.string('Synonym.ID'),
+  //             GlossTerm: s.string('Synonym.GlossTerm'),
+  //             Acronym: s.string('Synonym.Acronym'),
+  //             SynonymDef: s.object('Synonym.SynonymDef', {
+  //               word: s.string('Synonym.word'),
+  //               meaning: s.string('SynonymDef.meaning'),
+  //             }),
+  //           }),
+  //         ),
+  //         anyOfListWithDiscriminator: s.streaming.array(
+  //           'GlossDiv.anyOfListDiscriminator',
+  //           s.anyOf([
+  //             // No streaming
+  //             s.object('7th Grade Teacher', {
+  //               __discriminator: s.constString('seventh'),
+  //               // Expectation: this will be moved to end of properties list
+  //               birthDate: s.streaming.object('7th.birthDate', {
+  //                 // Expectation: property order won't change, but incremental updates
+  //                 // will occur
+  //                 year: s.string('7th.birthDate.year'),
+  //                 month: s.string('7th.birthDate.month'),
+  //                 day: s.string('7th.birthDate.day'),
+  //                 time: s.object('7th.birthData.time', {
+  //                   hour: s.number('hour'),
+  //                   minute: s.number('minute'),
+  //                 }),
+  //               }),
+  //               firstName: s.string('7th.firstName'),
+  //               lastName: s.string('7th.lastName'),
+  //             }),
+  //             // Will stream
+  //             s.object('8th Grade Teacher', {
+  //               __discriminator: s.constString('eighth'),
+  //               firstName: s.streaming.string('8th.firstName'),
+  //               lastName: s.streaming.string('8th.lastName'),
+  //             }),
+  //           ]),
+  //         ),
+  //       }),
+  //     }),
+  //   }),
   // );
-
-  const responseSchema = s.streaming.array(
-    'root array',
-    s.object('root object', {
-      glossary: s.object('glossary', {
-        title: s.string('glossary.title'),
-        GlossDiv: s.object('GlossDiv', {
-          title: s.string('GlossDiv.title'),
-          GlossList: s.streaming.array(
-            'GlossDiv.GlossList',
-            s.object('', {
-              ID: s.string('GlossList.ID'),
-              SortAs: s.string('GlossList.SortAs'),
-              GlossTerm: s.string('GlossList.GlossTerm'),
-              Acronym: s.string('GlossList.Acronym'),
-              GlossDef: s.object('GlossList.GlossDef', {
-                para: s.string('GlossDef.para'),
-                GlossSeeAlso: s.array('GlossDef.GlossSeeAlso', s.string('')),
-              }),
-              GlossSee: s.string('GlossList.GlossSee'),
-              ExampleSentences: s.streaming.array(
-                'GlossList.ExampleSentences',
-                s.string('ExampleSentence'),
-              ),
-            }),
-          ),
-          SynonymList: s.streaming.array(
-            'GlossDiv.SynonymList',
-            s.object('Synonym', {
-              ID: s.string('Synonym.ID'),
-              GlossTerm: s.string('Synonym.GlossTerm'),
-              Acronym: s.string('Synonym.Acronym'),
-              SynonymDef: s.object('Synonym.SynonymDef', {
-                word: s.string('Synonym.word'),
-                meaning: s.string('SynonymDef.meaning'),
-              }),
-            }),
-          ),
-          anyOfListWithDiscriminator: s.streaming.array(
-            'GlossDiv.anyOfListDiscriminator',
-            s.anyOf([
-              // No streaming
-              s.object('7th Grade Teacher', {
-                __discriminator: s.constString('seventh'),
-                // Expectation: this will be moved to end of properties list
-                birthDate: s.streaming.object('7th.birthDate', {
-                  // Expectation: property order won't change, but incremental updates
-                  // will occur
-                  year: s.string('7th.birthDate.year'),
-                  month: s.string('7th.birthDate.month'),
-                  day: s.string('7th.birthDate.day'),
-                  time: s.object('7th.birthData.time', {
-                    hour: s.number('hour'),
-                    minute: s.number('minute'),
-                  }),
-                }),
-                firstName: s.string('7th.firstName'),
-                lastName: s.string('7th.lastName'),
-              }),
-              // Will stream
-              s.object('8th Grade Teacher', {
-                __discriminator: s.constString('eighth'),
-                firstName: s.streaming.string('8th.firstName'),
-                lastName: s.streaming.string('8th.lastName'),
-              }),
-            ]),
-          ),
-        }),
-      }),
-    }),
-  );
 
   const iterable = new SocketAsyncIterable(client);
 
@@ -96,7 +101,7 @@ import { s } from '../../schema';
     for await (const data of parserIterable) {
       // To see how things are changing in a dynamic way, clear the console before
       // parsing update
-      console.clear();
+      // console.clear();
       console.log('new chunk');
       console.log(JSON.stringify(data, null, 4));
     }

--- a/packages/core/src/streaming-json-parser/test/server.ts
+++ b/packages/core/src/streaming-json-parser/test/server.ts
@@ -1,313 +1,321 @@
 import { createServer } from 'net';
 
-// const TEST_JSON = ['Example glossary', 'another example glossary'];
+const TEST_JSON = {
+  booleanValue: false,
+  value: 'Example glossary',
+  array: ['string 1', 'string 2'],
+  object: {
+    a: 'make it do what it do',
+    b: 'call the Ghost Busters',
+  },
+};
 
-const TEST_JSON = [
-  {
-    glossary: {
-      title: 'example glossary',
-      GlossDiv: {
-        title: 'S',
-        GlossList: [
-          {
-            ID: 'SGML',
-            SortAs: 'SGML',
-            GlossTerm: 'Standard Generalized Markup Language',
-            Acronym: 'SGML',
-            GlossDef: {
-              para: 'A meta-markup language, used to create markup languages such as DocBook.',
-              GlossSeeAlso: ['GML', 'XML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
-              'It provides a framework for specifying document structure and content using tags.',
-              'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
-              'One of SGML’s key strengths is its flexibility in defining complex document structures.',
-              'SGML was standardized by ISO as ISO 8879 in 1986.',
-              'It allows authors to define their own tags, enabling highly customizable document formatting.',
-              'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
-              'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
-              'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
-              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-            ],
-          },
-          {
-            ID: 'XML',
-            SortAs: 'XML',
-            GlossTerm: 'X Markup Language',
-            Acronym: 'XML',
-            GlossDef: {
-              para: 'A markup language, used to create markup languages such as SOAP.',
-              GlossSeeAlso: ['GML', 'XML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
-              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-              'XML is a markup language that allows users to define custom tags to structure data.',
-              'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
-              'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
-              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-              'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
-              'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
-              'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
-              'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
-            ],
-          },
-          {
-            ID: 'HTML',
-            SortAs: 'HTML',
-            GlossTerm: 'Hypertext Markup Language',
-            Acronym: 'HTML',
-            GlossDef: {
-              para: 'A markup language, used to create web pages.',
-              GlossSeeAlso: ['XML', 'XHTML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'HTML stands for HyperText Markup Language.',
-              'It is the standard language used to create and design webpages.',
-              'HTML uses elements called tags to structure content.',
-              'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
-              'HTML documents are saved with a .html or .htm file extension.',
-              'The <html> tag wraps the entire HTML document.',
-              'Web browsers read HTML files to render content visually for users.',
-              'HTML can include text, images, links, videos, and more.',
-              'It works closely with CSS and JavaScript to create interactive and styled webpages.',
-              'HTML5 is the latest version and includes support for multimedia and modern web features.',
-            ],
-          },
-        ],
-        SynonymList: [
-          {
-            ID: 'SGML',
-            GlossTerm: 'Standard Generalized Markup Language',
-            Acronym: 'SGML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'SGML meaning',
-            },
-          },
-          {
-            ID: 'XML',
-            GlossTerm: 'X Markup Language',
-            Acronym: 'XML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'XML meaning',
-            },
-          },
-          {
-            ID: 'HTML',
-            GlossTerm: 'Hypertext Markup Language',
-            Acronym: 'HTML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'HTML meaning',
-            },
-          },
-        ],
-        anyOfListWithDiscriminator: [
-          {
-            __discriminator: 'seventh',
-            firstName: '7th',
-            lastName:
-              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-            birthDate: {
-              year: '2000',
-              month: 'Feb',
-              day: '26',
-              time: {
-                hour: 1,
-                minute: 2,
-              },
-            },
-          },
-          {
-            __discriminator: 'eighth',
-            firstName: '8th',
-            lastName:
-              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-          },
-          {
-            __discriminator: 'seventh',
-            firstName: '7th',
-            lastName:
-              'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
-            birthDate: {
-              year: '2000',
-              month: 'Feb',
-              day: '26',
-              time: {
-                hour: 1,
-                minute: 2,
-              },
-            },
-          },
-          {
-            __discriminator: 'eighth',
-            firstName: '8th',
-            lastName:
-              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-          },
-        ],
-      },
-    },
-  },
-  {
-    glossary: {
-      title: 'another example glossary',
-      GlossDiv: {
-        title: 'S',
-        GlossList: [
-          {
-            ID: 'SGML',
-            SortAs: 'SGML',
-            GlossTerm: 'Standard Generalized Markup Language',
-            Acronym: 'SGML',
-            GlossDef: {
-              para: 'A meta-markup language, used to create markup languages such as DocBook.',
-              GlossSeeAlso: ['GML', 'XML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
-              'It provides a framework for specifying document structure and content using tags.',
-              'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
-              'One of SGML’s key strengths is its flexibility in defining complex document structures.',
-              'SGML was standardized by ISO as ISO 8879 in 1986.',
-              'It allows authors to define their own tags, enabling highly customizable document formatting.',
-              'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
-              'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
-              'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
-              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-            ],
-          },
-          {
-            ID: 'XML',
-            SortAs: 'XML',
-            GlossTerm: 'X Markup Language',
-            Acronym: 'XML',
-            GlossDef: {
-              para: 'A markup language, used to create markup languages such as SOAP.',
-              GlossSeeAlso: ['GML', 'XML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
-              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-              'XML is a markup language that allows users to define custom tags to structure data.',
-              'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
-              'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
-              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-              'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
-              'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
-              'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
-              'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
-            ],
-          },
-          {
-            ID: 'HTML',
-            SortAs: 'HTML',
-            GlossTerm: 'Hypertext Markup Language',
-            Acronym: 'HTML',
-            GlossDef: {
-              para: 'A markup language, used to create web pages.',
-              GlossSeeAlso: ['XML', 'XHTML'],
-            },
-            GlossSee: 'markup',
-            ExampleSentences: [
-              'HTML stands for HyperText Markup Language.',
-              'It is the standard language used to create and design webpages.',
-              'HTML uses elements called tags to structure content.',
-              'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
-              'HTML documents are saved with a .html or .htm file extension.',
-              'The <html> tag wraps the entire HTML document.',
-              'Web browsers read HTML files to render content visually for users.',
-              'HTML can include text, images, links, videos, and more.',
-              'It works closely with CSS and JavaScript to create interactive and styled webpages.',
-              'HTML5 is the latest version and includes support for multimedia and modern web features.',
-            ],
-          },
-        ],
-        SynonymList: [
-          {
-            ID: 'SGML',
-            GlossTerm: 'Standard Generalized Markup Language',
-            Acronym: 'SGML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'SGML meaning',
-            },
-          },
-          {
-            ID: 'XML',
-            GlossTerm: 'X Markup Language',
-            Acronym: 'XML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'XML meaning',
-            },
-          },
-          {
-            ID: 'HTML',
-            GlossTerm: 'Hypertext Markup Language',
-            Acronym: 'HTML',
-            SynonymDef: {
-              word: 'A markup language, used to create web pages.',
-              meaning: 'HTML meaning',
-            },
-          },
-        ],
-        anyOfListWithDiscriminator: [
-          {
-            __discriminator: 'seventh',
-            firstName: '7th',
-            lastName:
-              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-            birthDate: {
-              year: '2000',
-              month: 'Feb',
-              day: '26',
-              time: {
-                hour: 1,
-                minute: 2,
-              },
-            },
-          },
-          {
-            __discriminator: 'eighth',
-            firstName: '8th',
-            lastName:
-              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-          },
-          {
-            __discriminator: 'seventh',
-            firstName: '7th',
-            lastName:
-              'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
-            birthDate: {
-              year: '2000',
-              month: 'Feb',
-              day: '26',
-              time: {
-                hour: 1,
-                minute: 2,
-              },
-            },
-          },
-          {
-            __discriminator: 'eighth',
-            firstName: '8th',
-            lastName:
-              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-          },
-        ],
-      },
-    },
-  },
-];
+// const TEST_JSON = [
+//   {
+//     glossary: {
+//       title: 'example glossary',
+//       GlossDiv: {
+//         title: 'S',
+//         GlossList: [
+//           {
+//             ID: 'SGML',
+//             SortAs: 'SGML',
+//             GlossTerm: 'Standard Generalized Markup Language',
+//             Acronym: 'SGML',
+//             GlossDef: {
+//               para: 'A meta-markup language, used to create markup languages such as DocBook.',
+//               GlossSeeAlso: ['GML', 'XML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
+//               'It provides a framework for specifying document structure and content using tags.',
+//               'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
+//               'One of SGML’s key strengths is its flexibility in defining complex document structures.',
+//               'SGML was standardized by ISO as ISO 8879 in 1986.',
+//               'It allows authors to define their own tags, enabling highly customizable document formatting.',
+//               'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
+//               'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
+//               'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
+//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+//             ],
+//           },
+//           {
+//             ID: 'XML',
+//             SortAs: 'XML',
+//             GlossTerm: 'X Markup Language',
+//             Acronym: 'XML',
+//             GlossDef: {
+//               para: 'A markup language, used to create markup languages such as SOAP.',
+//               GlossSeeAlso: ['GML', 'XML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
+//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+//               'XML is a markup language that allows users to define custom tags to structure data.',
+//               'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
+//               'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
+//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+//               'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
+//               'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
+//               'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
+//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
+//             ],
+//           },
+//           {
+//             ID: 'HTML',
+//             SortAs: 'HTML',
+//             GlossTerm: 'Hypertext Markup Language',
+//             Acronym: 'HTML',
+//             GlossDef: {
+//               para: 'A markup language, used to create web pages.',
+//               GlossSeeAlso: ['XML', 'XHTML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'HTML stands for HyperText Markup Language.',
+//               'It is the standard language used to create and design webpages.',
+//               'HTML uses elements called tags to structure content.',
+//               'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
+//               'HTML documents are saved with a .html or .htm file extension.',
+//               'The <html> tag wraps the entire HTML document.',
+//               'Web browsers read HTML files to render content visually for users.',
+//               'HTML can include text, images, links, videos, and more.',
+//               'It works closely with CSS and JavaScript to create interactive and styled webpages.',
+//               'HTML5 is the latest version and includes support for multimedia and modern web features.',
+//             ],
+//           },
+//         ],
+//         SynonymList: [
+//           {
+//             ID: 'SGML',
+//             GlossTerm: 'Standard Generalized Markup Language',
+//             Acronym: 'SGML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'SGML meaning',
+//             },
+//           },
+//           {
+//             ID: 'XML',
+//             GlossTerm: 'X Markup Language',
+//             Acronym: 'XML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'XML meaning',
+//             },
+//           },
+//           {
+//             ID: 'HTML',
+//             GlossTerm: 'Hypertext Markup Language',
+//             Acronym: 'HTML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'HTML meaning',
+//             },
+//           },
+//         ],
+//         anyOfListWithDiscriminator: [
+//           {
+//             __discriminator: 'seventh',
+//             firstName: '7th',
+//             lastName:
+//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+//             birthDate: {
+//               year: '2000',
+//               month: 'Feb',
+//               day: '26',
+//               time: {
+//                 hour: 1,
+//                 minute: 2,
+//               },
+//             },
+//           },
+//           {
+//             __discriminator: 'eighth',
+//             firstName: '8th',
+//             lastName:
+//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+//           },
+//           {
+//             __discriminator: 'seventh',
+//             firstName: '7th',
+//             lastName:
+//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
+//             birthDate: {
+//               year: '2000',
+//               month: 'Feb',
+//               day: '26',
+//               time: {
+//                 hour: 1,
+//                 minute: 2,
+//               },
+//             },
+//           },
+//           {
+//             __discriminator: 'eighth',
+//             firstName: '8th',
+//             lastName:
+//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+//           },
+//         ],
+//       },
+//     },
+//   },
+//   {
+//     glossary: {
+//       title: 'another example glossary',
+//       GlossDiv: {
+//         title: 'S',
+//         GlossList: [
+//           {
+//             ID: 'SGML',
+//             SortAs: 'SGML',
+//             GlossTerm: 'Standard Generalized Markup Language',
+//             Acronym: 'SGML',
+//             GlossDef: {
+//               para: 'A meta-markup language, used to create markup languages such as DocBook.',
+//               GlossSeeAlso: ['GML', 'XML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
+//               'It provides a framework for specifying document structure and content using tags.',
+//               'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
+//               'One of SGML’s key strengths is its flexibility in defining complex document structures.',
+//               'SGML was standardized by ISO as ISO 8879 in 1986.',
+//               'It allows authors to define their own tags, enabling highly customizable document formatting.',
+//               'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
+//               'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
+//               'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
+//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+//             ],
+//           },
+//           {
+//             ID: 'XML',
+//             SortAs: 'XML',
+//             GlossTerm: 'X Markup Language',
+//             Acronym: 'XML',
+//             GlossDef: {
+//               para: 'A markup language, used to create markup languages such as SOAP.',
+//               GlossSeeAlso: ['GML', 'XML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
+//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+//               'XML is a markup language that allows users to define custom tags to structure data.',
+//               'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
+//               'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
+//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+//               'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
+//               'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
+//               'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
+//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
+//             ],
+//           },
+//           {
+//             ID: 'HTML',
+//             SortAs: 'HTML',
+//             GlossTerm: 'Hypertext Markup Language',
+//             Acronym: 'HTML',
+//             GlossDef: {
+//               para: 'A markup language, used to create web pages.',
+//               GlossSeeAlso: ['XML', 'XHTML'],
+//             },
+//             GlossSee: 'markup',
+//             ExampleSentences: [
+//               'HTML stands for HyperText Markup Language.',
+//               'It is the standard language used to create and design webpages.',
+//               'HTML uses elements called tags to structure content.',
+//               'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
+//               'HTML documents are saved with a .html or .htm file extension.',
+//               'The <html> tag wraps the entire HTML document.',
+//               'Web browsers read HTML files to render content visually for users.',
+//               'HTML can include text, images, links, videos, and more.',
+//               'It works closely with CSS and JavaScript to create interactive and styled webpages.',
+//               'HTML5 is the latest version and includes support for multimedia and modern web features.',
+//             ],
+//           },
+//         ],
+//         SynonymList: [
+//           {
+//             ID: 'SGML',
+//             GlossTerm: 'Standard Generalized Markup Language',
+//             Acronym: 'SGML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'SGML meaning',
+//             },
+//           },
+//           {
+//             ID: 'XML',
+//             GlossTerm: 'X Markup Language',
+//             Acronym: 'XML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'XML meaning',
+//             },
+//           },
+//           {
+//             ID: 'HTML',
+//             GlossTerm: 'Hypertext Markup Language',
+//             Acronym: 'HTML',
+//             SynonymDef: {
+//               word: 'A markup language, used to create web pages.',
+//               meaning: 'HTML meaning',
+//             },
+//           },
+//         ],
+//         anyOfListWithDiscriminator: [
+//           {
+//             __discriminator: 'seventh',
+//             firstName: '7th',
+//             lastName:
+//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+//             birthDate: {
+//               year: '2000',
+//               month: 'Feb',
+//               day: '26',
+//               time: {
+//                 hour: 1,
+//                 minute: 2,
+//               },
+//             },
+//           },
+//           {
+//             __discriminator: 'eighth',
+//             firstName: '8th',
+//             lastName:
+//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+//           },
+//           {
+//             __discriminator: 'seventh',
+//             firstName: '7th',
+//             lastName:
+//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
+//             birthDate: {
+//               year: '2000',
+//               month: 'Feb',
+//               day: '26',
+//               time: {
+//                 hour: 1,
+//                 minute: 2,
+//               },
+//             },
+//           },
+//           {
+//             __discriminator: 'eighth',
+//             firstName: '8th',
+//             lastName:
+//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+//           },
+//         ],
+//       },
+//     },
+//   },
+// ];
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -318,8 +326,10 @@ const server = createServer(async function (socket) {
 
   console.log(`Test string length: ${TEST_STRING.length}`);
 
-  const MAX_SIZE = 30;
-  const MIN_SIZE = 10;
+  // const MAX_SIZE = 30;
+  // const MIN_SIZE = 10;
+  const MAX_SIZE = 3;
+  const MIN_SIZE = 5;
 
   let cursor = 0;
 

--- a/packages/core/src/streaming-json-parser/test/server.ts
+++ b/packages/core/src/streaming-json-parser/test/server.ts
@@ -1,321 +1,313 @@
 import { createServer } from 'net';
 
-const TEST_JSON = {
-  booleanValue: false,
-  value: 'Example glossary',
-  array: ['string 1', 'string 2'],
-  object: {
-    a: 'make it do what it do',
-    b: 'call the Ghost Busters',
-  },
-};
+// const TEST_JSON = ['Example glossary', 'another example glossary'];
 
-// const TEST_JSON = [
-//   {
-//     glossary: {
-//       title: 'example glossary',
-//       GlossDiv: {
-//         title: 'S',
-//         GlossList: [
-//           {
-//             ID: 'SGML',
-//             SortAs: 'SGML',
-//             GlossTerm: 'Standard Generalized Markup Language',
-//             Acronym: 'SGML',
-//             GlossDef: {
-//               para: 'A meta-markup language, used to create markup languages such as DocBook.',
-//               GlossSeeAlso: ['GML', 'XML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
-//               'It provides a framework for specifying document structure and content using tags.',
-//               'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
-//               'One of SGML’s key strengths is its flexibility in defining complex document structures.',
-//               'SGML was standardized by ISO as ISO 8879 in 1986.',
-//               'It allows authors to define their own tags, enabling highly customizable document formatting.',
-//               'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
-//               'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
-//               'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
-//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-//             ],
-//           },
-//           {
-//             ID: 'XML',
-//             SortAs: 'XML',
-//             GlossTerm: 'X Markup Language',
-//             Acronym: 'XML',
-//             GlossDef: {
-//               para: 'A markup language, used to create markup languages such as SOAP.',
-//               GlossSeeAlso: ['GML', 'XML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
-//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-//               'XML is a markup language that allows users to define custom tags to structure data.',
-//               'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
-//               'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
-//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-//               'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
-//               'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
-//               'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
-//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
-//             ],
-//           },
-//           {
-//             ID: 'HTML',
-//             SortAs: 'HTML',
-//             GlossTerm: 'Hypertext Markup Language',
-//             Acronym: 'HTML',
-//             GlossDef: {
-//               para: 'A markup language, used to create web pages.',
-//               GlossSeeAlso: ['XML', 'XHTML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'HTML stands for HyperText Markup Language.',
-//               'It is the standard language used to create and design webpages.',
-//               'HTML uses elements called tags to structure content.',
-//               'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
-//               'HTML documents are saved with a .html or .htm file extension.',
-//               'The <html> tag wraps the entire HTML document.',
-//               'Web browsers read HTML files to render content visually for users.',
-//               'HTML can include text, images, links, videos, and more.',
-//               'It works closely with CSS and JavaScript to create interactive and styled webpages.',
-//               'HTML5 is the latest version and includes support for multimedia and modern web features.',
-//             ],
-//           },
-//         ],
-//         SynonymList: [
-//           {
-//             ID: 'SGML',
-//             GlossTerm: 'Standard Generalized Markup Language',
-//             Acronym: 'SGML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'SGML meaning',
-//             },
-//           },
-//           {
-//             ID: 'XML',
-//             GlossTerm: 'X Markup Language',
-//             Acronym: 'XML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'XML meaning',
-//             },
-//           },
-//           {
-//             ID: 'HTML',
-//             GlossTerm: 'Hypertext Markup Language',
-//             Acronym: 'HTML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'HTML meaning',
-//             },
-//           },
-//         ],
-//         anyOfListWithDiscriminator: [
-//           {
-//             __discriminator: 'seventh',
-//             firstName: '7th',
-//             lastName:
-//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-//             birthDate: {
-//               year: '2000',
-//               month: 'Feb',
-//               day: '26',
-//               time: {
-//                 hour: 1,
-//                 minute: 2,
-//               },
-//             },
-//           },
-//           {
-//             __discriminator: 'eighth',
-//             firstName: '8th',
-//             lastName:
-//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-//           },
-//           {
-//             __discriminator: 'seventh',
-//             firstName: '7th',
-//             lastName:
-//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
-//             birthDate: {
-//               year: '2000',
-//               month: 'Feb',
-//               day: '26',
-//               time: {
-//                 hour: 1,
-//                 minute: 2,
-//               },
-//             },
-//           },
-//           {
-//             __discriminator: 'eighth',
-//             firstName: '8th',
-//             lastName:
-//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-//           },
-//         ],
-//       },
-//     },
-//   },
-//   {
-//     glossary: {
-//       title: 'another example glossary',
-//       GlossDiv: {
-//         title: 'S',
-//         GlossList: [
-//           {
-//             ID: 'SGML',
-//             SortAs: 'SGML',
-//             GlossTerm: 'Standard Generalized Markup Language',
-//             Acronym: 'SGML',
-//             GlossDef: {
-//               para: 'A meta-markup language, used to create markup languages such as DocBook.',
-//               GlossSeeAlso: ['GML', 'XML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
-//               'It provides a framework for specifying document structure and content using tags.',
-//               'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
-//               'One of SGML’s key strengths is its flexibility in defining complex document structures.',
-//               'SGML was standardized by ISO as ISO 8879 in 1986.',
-//               'It allows authors to define their own tags, enabling highly customizable document formatting.',
-//               'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
-//               'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
-//               'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
-//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-//             ],
-//           },
-//           {
-//             ID: 'XML',
-//             SortAs: 'XML',
-//             GlossTerm: 'X Markup Language',
-//             Acronym: 'XML',
-//             GlossDef: {
-//               para: 'A markup language, used to create markup languages such as SOAP.',
-//               GlossSeeAlso: ['GML', 'XML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
-//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-//               'XML is a markup language that allows users to define custom tags to structure data.',
-//               'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
-//               'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
-//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-//               'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
-//               'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
-//               'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
-//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
-//             ],
-//           },
-//           {
-//             ID: 'HTML',
-//             SortAs: 'HTML',
-//             GlossTerm: 'Hypertext Markup Language',
-//             Acronym: 'HTML',
-//             GlossDef: {
-//               para: 'A markup language, used to create web pages.',
-//               GlossSeeAlso: ['XML', 'XHTML'],
-//             },
-//             GlossSee: 'markup',
-//             ExampleSentences: [
-//               'HTML stands for HyperText Markup Language.',
-//               'It is the standard language used to create and design webpages.',
-//               'HTML uses elements called tags to structure content.',
-//               'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
-//               'HTML documents are saved with a .html or .htm file extension.',
-//               'The <html> tag wraps the entire HTML document.',
-//               'Web browsers read HTML files to render content visually for users.',
-//               'HTML can include text, images, links, videos, and more.',
-//               'It works closely with CSS and JavaScript to create interactive and styled webpages.',
-//               'HTML5 is the latest version and includes support for multimedia and modern web features.',
-//             ],
-//           },
-//         ],
-//         SynonymList: [
-//           {
-//             ID: 'SGML',
-//             GlossTerm: 'Standard Generalized Markup Language',
-//             Acronym: 'SGML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'SGML meaning',
-//             },
-//           },
-//           {
-//             ID: 'XML',
-//             GlossTerm: 'X Markup Language',
-//             Acronym: 'XML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'XML meaning',
-//             },
-//           },
-//           {
-//             ID: 'HTML',
-//             GlossTerm: 'Hypertext Markup Language',
-//             Acronym: 'HTML',
-//             SynonymDef: {
-//               word: 'A markup language, used to create web pages.',
-//               meaning: 'HTML meaning',
-//             },
-//           },
-//         ],
-//         anyOfListWithDiscriminator: [
-//           {
-//             __discriminator: 'seventh',
-//             firstName: '7th',
-//             lastName:
-//               'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
-//             birthDate: {
-//               year: '2000',
-//               month: 'Feb',
-//               day: '26',
-//               time: {
-//                 hour: 1,
-//                 minute: 2,
-//               },
-//             },
-//           },
-//           {
-//             __discriminator: 'eighth',
-//             firstName: '8th',
-//             lastName:
-//               'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
-//           },
-//           {
-//             __discriminator: 'seventh',
-//             firstName: '7th',
-//             lastName:
-//               'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
-//             birthDate: {
-//               year: '2000',
-//               month: 'Feb',
-//               day: '26',
-//               time: {
-//                 hour: 1,
-//                 minute: 2,
-//               },
-//             },
-//           },
-//           {
-//             __discriminator: 'eighth',
-//             firstName: '8th',
-//             lastName:
-//               'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
-//           },
-//         ],
-//       },
-//     },
-//   },
-// ];
+const TEST_JSON = [
+  {
+    glossary: {
+      title: 'example glossary',
+      GlossDiv: {
+        title: 'S',
+        GlossList: [
+          {
+            ID: 'SGML',
+            SortAs: 'SGML',
+            GlossTerm: 'Standard Generalized Markup Language',
+            Acronym: 'SGML',
+            GlossDef: {
+              para: 'A meta-markup language, used to create markup languages such as DocBook.',
+              GlossSeeAlso: ['GML', 'XML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
+              'It provides a framework for specifying document structure and content using tags.',
+              'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
+              'One of SGML’s key strengths is its flexibility in defining complex document structures.',
+              'SGML was standardized by ISO as ISO 8879 in 1986.',
+              'It allows authors to define their own tags, enabling highly customizable document formatting.',
+              'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
+              'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
+              'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
+              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+            ],
+          },
+          {
+            ID: 'XML',
+            SortAs: 'XML',
+            GlossTerm: 'X Markup Language',
+            Acronym: 'XML',
+            GlossDef: {
+              para: 'A markup language, used to create markup languages such as SOAP.',
+              GlossSeeAlso: ['GML', 'XML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
+              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+              'XML is a markup language that allows users to define custom tags to structure data.',
+              'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
+              'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
+              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+              'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
+              'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
+              'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
+              'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
+            ],
+          },
+          {
+            ID: 'HTML',
+            SortAs: 'HTML',
+            GlossTerm: 'Hypertext Markup Language',
+            Acronym: 'HTML',
+            GlossDef: {
+              para: 'A markup language, used to create web pages.',
+              GlossSeeAlso: ['XML', 'XHTML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'HTML stands for HyperText Markup Language.',
+              'It is the standard language used to create and design webpages.',
+              'HTML uses elements called tags to structure content.',
+              'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
+              'HTML documents are saved with a .html or .htm file extension.',
+              'The <html> tag wraps the entire HTML document.',
+              'Web browsers read HTML files to render content visually for users.',
+              'HTML can include text, images, links, videos, and more.',
+              'It works closely with CSS and JavaScript to create interactive and styled webpages.',
+              'HTML5 is the latest version and includes support for multimedia and modern web features.',
+            ],
+          },
+        ],
+        SynonymList: [
+          {
+            ID: 'SGML',
+            GlossTerm: 'Standard Generalized Markup Language',
+            Acronym: 'SGML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'SGML meaning',
+            },
+          },
+          {
+            ID: 'XML',
+            GlossTerm: 'X Markup Language',
+            Acronym: 'XML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'XML meaning',
+            },
+          },
+          {
+            ID: 'HTML',
+            GlossTerm: 'Hypertext Markup Language',
+            Acronym: 'HTML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'HTML meaning',
+            },
+          },
+        ],
+        anyOfListWithDiscriminator: [
+          {
+            __discriminator: 'seventh',
+            firstName: '7th',
+            lastName:
+              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+            birthDate: {
+              year: '2000',
+              month: 'Feb',
+              day: '26',
+              time: {
+                hour: 1,
+                minute: 2,
+              },
+            },
+          },
+          {
+            __discriminator: 'eighth',
+            firstName: '8th',
+            lastName:
+              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+          },
+          {
+            __discriminator: 'seventh',
+            firstName: '7th',
+            lastName:
+              'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
+            birthDate: {
+              year: '2000',
+              month: 'Feb',
+              day: '26',
+              time: {
+                hour: 1,
+                minute: 2,
+              },
+            },
+          },
+          {
+            __discriminator: 'eighth',
+            firstName: '8th',
+            lastName:
+              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    glossary: {
+      title: 'another example glossary',
+      GlossDiv: {
+        title: 'S',
+        GlossList: [
+          {
+            ID: 'SGML',
+            SortAs: 'SGML',
+            GlossTerm: 'Standard Generalized Markup Language',
+            Acronym: 'SGML',
+            GlossDef: {
+              para: 'A meta-markup language, used to create markup languages such as DocBook.',
+              GlossSeeAlso: ['GML', 'XML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'SGML stands for Standard Generalized Markup Language and was developed in the 1980s as a standard for defining markup languages.',
+              'It provides a framework for specifying document structure and content using tags.',
+              'SGML is not itself a markup language but a meta-language used to create other markup languages like HTML and XML.',
+              'One of SGML’s key strengths is its flexibility in defining complex document structures.',
+              'SGML was standardized by ISO as ISO 8879 in 1986.',
+              'It allows authors to define their own tags, enabling highly customizable document formatting.',
+              'SGML is used primarily in large-scale publishing, technical documentation, and archival systems.',
+              'Because of its complexity, SGML has largely been replaced by simpler derivatives like XML for web and software applications.',
+              'Documents in SGML must conform to a Document Type Definition (DTD), which describes their allowable structure.',
+              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+            ],
+          },
+          {
+            ID: 'XML',
+            SortAs: 'XML',
+            GlossTerm: 'X Markup Language',
+            Acronym: 'XML',
+            GlossDef: {
+              para: 'A markup language, used to create markup languages such as SOAP.',
+              GlossSeeAlso: ['GML', 'XML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'XML stands for eXtensible Markup Language and was developed by the W3C in the late 1990s.',
+              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+              'XML is a markup language that allows users to define custom tags to structure data.',
+              'It is both human-readable and machine-readable, making it ideal for data exchange between systems.',
+              'Unlike HTML, XML does not have predefined tags; users create their own tags based on the needs of the data.',
+              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+              'A Document Type Definition (DTD) or XML Schema can be used to define the structure and rules of an XML document.',
+              'XML is widely used in web services, configuration files, and data interchange formats like RSS and SOAP.',
+              'Although JSON is often preferred today for its simplicity, XML is still prevalent in enterprise and legacy systems.',
+              'XML helped pave the way for structured data on the internet and continues to influence modern data formats.',
+            ],
+          },
+          {
+            ID: 'HTML',
+            SortAs: 'HTML',
+            GlossTerm: 'Hypertext Markup Language',
+            Acronym: 'HTML',
+            GlossDef: {
+              para: 'A markup language, used to create web pages.',
+              GlossSeeAlso: ['XML', 'XHTML'],
+            },
+            GlossSee: 'markup',
+            ExampleSentences: [
+              'HTML stands for HyperText Markup Language.',
+              'It is the standard language used to create and design webpages.',
+              'HTML uses elements called tags to structure content.',
+              'Tags are usually written in pairs, like <p> for paragraphs and <h1> for headings.',
+              'HTML documents are saved with a .html or .htm file extension.',
+              'The <html> tag wraps the entire HTML document.',
+              'Web browsers read HTML files to render content visually for users.',
+              'HTML can include text, images, links, videos, and more.',
+              'It works closely with CSS and JavaScript to create interactive and styled webpages.',
+              'HTML5 is the latest version and includes support for multimedia and modern web features.',
+            ],
+          },
+        ],
+        SynonymList: [
+          {
+            ID: 'SGML',
+            GlossTerm: 'Standard Generalized Markup Language',
+            Acronym: 'SGML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'SGML meaning',
+            },
+          },
+          {
+            ID: 'XML',
+            GlossTerm: 'X Markup Language',
+            Acronym: 'XML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'XML meaning',
+            },
+          },
+          {
+            ID: 'HTML',
+            GlossTerm: 'Hypertext Markup Language',
+            Acronym: 'HTML',
+            SynonymDef: {
+              word: 'A markup language, used to create web pages.',
+              meaning: 'HTML meaning',
+            },
+          },
+        ],
+        anyOfListWithDiscriminator: [
+          {
+            __discriminator: 'seventh',
+            firstName: '7th',
+            lastName:
+              'It is a simplified subset of SGML, designed to be easier to use and more web-friendly.',
+            birthDate: {
+              year: '2000',
+              month: 'Feb',
+              day: '26',
+              time: {
+                hour: 1,
+                minute: 2,
+              },
+            },
+          },
+          {
+            __discriminator: 'eighth',
+            firstName: '8th',
+            lastName:
+              'XML documents must be well-formed, meaning they follow strict syntax rules such as properly nested tags.',
+          },
+          {
+            __discriminator: 'seventh',
+            firstName: '7th',
+            lastName:
+              'XML helped pave the way for structured data on the internet and continues to influence modern data formats',
+            birthDate: {
+              year: '2000',
+              month: 'Feb',
+              day: '26',
+              time: {
+                hour: 1,
+                minute: 2,
+              },
+            },
+          },
+          {
+            __discriminator: 'eighth',
+            firstName: '8th',
+            lastName:
+              'Although not as widely used today, SGML laid the groundwork for modern web technologies and markup standards.',
+          },
+        ],
+      },
+    },
+  },
+];
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -326,10 +318,8 @@ const server = createServer(async function (socket) {
 
   console.log(`Test string length: ${TEST_STRING.length}`);
 
-  // const MAX_SIZE = 30;
-  // const MIN_SIZE = 10;
-  const MAX_SIZE = 3;
-  const MIN_SIZE = 5;
+  const MAX_SIZE = 30;
+  const MIN_SIZE = 10;
 
   let cursor = 0;
 

--- a/packages/core/src/streaming-json-parser/test/server.ts
+++ b/packages/core/src/streaming-json-parser/test/server.ts
@@ -326,10 +326,8 @@ const server = createServer(async function (socket) {
 
   console.log(`Test string length: ${TEST_STRING.length}`);
 
-  // const MAX_SIZE = 30;
-  // const MIN_SIZE = 10;
-  const MAX_SIZE = 3;
-  const MIN_SIZE = 5;
+  const MAX_SIZE = 30;
+  const MIN_SIZE = 10;
 
   let cursor = 0;
 


### PR DESCRIPTION
This PR:
* removes streaming functions for number, boolean and integer, since an "incomplete" value for them doesn't make sense.
* when the parser detects than a non-streaming object wasn't fully parseable but that all non-streaming properties were present, the object will be returned with "empty" values for streaming properties.

Fixes https://github.com/liveloveapp/hashbrown/issues/88