### PR TITLE
React Configuration Reactivity

### DIFF
--- a/packages/core/src/actions/dev.actions.ts
+++ b/packages/core/src/actions/dev.actions.ts
@@ -1,6 +1,6 @@
+import { Chat } from '../models';
 import { s } from '../schema';
 import { createActionGroup, props } from '../utils/micro-ngrx';
-import { Chat } from '../models';
 
 export default createActionGroup('dev', {
   init: props<{
@@ -21,5 +21,18 @@ export default createActionGroup('dev', {
   }>(),
   sendMessage: props<{
     message: Chat.AnyMessage;
+  }>(),
+  updateOptions: props<{
+    debugName?: string;
+    apiUrl?: string;
+    model?: string;
+    prompt?: string;
+    temperature?: number;
+    maxTokens?: number;
+    tools?: Chat.AnyTool[];
+    responseSchema?: s.HashbrownType;
+    middleware?: Chat.Middleware[];
+    emulateStructuredOutput?: boolean;
+    debounce?: number;
   }>(),
 });

--- a/packages/core/src/public_api.ts
+++ b/packages/core/src/public_api.ts
@@ -1,6 +1,6 @@
-export * as θtypes from './utils/types';
-export * as θcomponents from './utils/expose-component';
+export { fryHashbrown, type Hashbrown } from './hashbrown';
 export * from './models';
 export * from './schema';
-export { VendorClient } from './vendor/vendor-client';
-export { fryHashbrown, Hashbrown } from './hashbrown';
+export * as θcomponents from './utils/expose-component';
+export * as θtypes from './utils/types';
+export { type VendorClient } from './vendor/vendor-client';

--- a/packages/core/src/reducers/config.reducer.ts
+++ b/packages/core/src/reducers/config.reducer.ts
@@ -1,7 +1,7 @@
-import { s } from '../schema';
-import { Chat } from '../models';
-import { createReducer, on } from '../utils/micro-ngrx';
 import { devActions } from '../actions';
+import { Chat } from '../models';
+import { s } from '../schema';
+import { createReducer, on } from '../utils/micro-ngrx';
 
 export interface ConfigState {
   apiUrl: string;
@@ -38,6 +38,12 @@ export const reducer = createReducer(
       middleware: action.payload.middleware,
       emulateStructuredOutput:
         action.payload.emulateStructuredOutput ?? state.emulateStructuredOutput,
+    };
+  }),
+  on(devActions.updateOptions, (state, action) => {
+    return {
+      ...state,
+      ...action.payload,
     };
   }),
 );

--- a/packages/core/src/reducers/tools.reducer.ts
+++ b/packages/core/src/reducers/tools.reducer.ts
@@ -1,5 +1,5 @@
-import { Chat } from '../models';
 import { devActions } from '../actions';
+import { Chat } from '../models';
 import { createReducer, on, select } from '../utils/micro-ngrx';
 
 export type ToolState = {
@@ -15,6 +15,25 @@ const initialState: ToolState = {
 export const reducer = createReducer(
   initialState,
   on(devActions.init, (state, action) => {
+    const tools = action.payload.tools;
+
+    if (!tools) {
+      return state;
+    }
+
+    return {
+      ...state,
+      names: tools.map((tool) => tool.name),
+      entities: tools.reduce(
+        (acc, tool) => {
+          acc[tool.name] = tool;
+          return acc;
+        },
+        {} as Record<string, Chat.Internal.Tool>,
+      ),
+    };
+  }),
+  on(devActions.updateOptions, (state, action) => {
     const tools = action.payload.tools;
 
     if (!tools) {

--- a/packages/react/src/hooks/use-chat.tsx
+++ b/packages/react/src/hooks/use-chat.tsx
@@ -144,29 +144,46 @@ export function useChat<Tools extends Chat.AnyTool>(
   );
 
   useEffect(() => {
+    return () => {
+      if (hashbrown) {
+        hashbrown.teardown();
+        setHashbrown(null);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!config) {
       throw new Error('HashbrownContext not found');
     }
 
-    console.log('frying hashbrown');
+    const instance =
+      hashbrown ??
+      fryHashbrown<Tools>({
+        apiUrl: config.url,
+        middleware: config.middleware,
+        debugName: options.debugName,
+        maxTokens: options.maxTokens,
+        model: options.model,
+        prompt: options.prompt,
+        temperature: options.temperature,
+        tools,
+      });
 
-    const instance = fryHashbrown<Tools>({
-      apiUrl: config.url,
-      middleware: config.middleware,
-      debugName: options.debugName,
-      maxTokens: options.maxTokens,
-      model: options.model,
-      prompt: options.prompt,
-      temperature: options.temperature,
-      tools,
-    });
-
-    setHashbrown(instance);
-
-    return () => {
-      instance.teardown();
-      setHashbrown(null);
-    };
+    if (!hashbrown) {
+      setHashbrown(instance);
+    } else {
+      instance.updateOptions({
+        apiUrl: config.url,
+        middleware: config.middleware,
+        debugName: options.debugName,
+        maxTokens: options.maxTokens,
+        model: options.model,
+        prompt: options.prompt,
+        temperature: options.temperature,
+        tools,
+      });
+    }
   }, [
     config,
     options.debugName,

--- a/packages/react/src/hooks/use-structured-chat.tsx
+++ b/packages/react/src/hooks/use-structured-chat.tsx
@@ -163,28 +163,48 @@ export function useStructuredChat<
   const [schema] = useState<Schema>(options.schema);
 
   useEffect(() => {
+    return () => {
+      if (hashbrown) {
+        hashbrown.teardown();
+        setHashbrown(null);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!config) {
       throw new Error('HashbrownContext not found');
     }
 
-    const instance = fryHashbrown<Schema, Tools, Output>({
-      apiUrl: config.url,
-      middleware: config.middleware,
-      model: options.model,
-      prompt: options.prompt,
-      responseSchema: schema,
-      temperature: options.temperature,
-      maxTokens: options.maxTokens,
-      tools,
-      debugName: options.debugName,
-    });
+    const instance =
+      hashbrown ??
+      fryHashbrown<Schema, Tools, Output>({
+        apiUrl: config.url,
+        middleware: config.middleware,
+        model: options.model,
+        prompt: options.prompt,
+        responseSchema: schema,
+        temperature: options.temperature,
+        maxTokens: options.maxTokens,
+        tools,
+        debugName: options.debugName,
+      });
 
-    setHashbrown(instance);
-
-    return () => {
-      instance.teardown();
-      setHashbrown(null);
-    };
+    if (!hashbrown) {
+      setHashbrown(instance);
+    } else {
+      instance.updateOptions({
+        apiUrl: config.url,
+        middleware: config.middleware,
+        model: options.model,
+        prompt: options.prompt,
+        responseSchema: schema,
+        temperature: options.temperature,
+        maxTokens: options.maxTokens,
+        tools,
+        debugName: options.debugName,
+      });
+    }
   }, [
     config,
     options.model,


### PR DESCRIPTION
In the React version, changes to the hashbrown configuration (or unintentional re-renders of the components running the hooks) will cause hashbrown to lose it's message stage because the hashbrown store will be destroyed and reinitialized.

This closes #90.

This PR adds an `updateOptions` method to the instance returned from `fryHashbrown`.  This allows `useChat` and `useStructuredChat` to check if they have already initialized hashbrown instances and to update the configuration.

This felt less complex than the alternatives I could think of and the update execution takes less than a ms.  If we'd rather this work a different way, comment here and I'll pivot.
