### PR TITLE
Bug(170) forego any of wrappers when not streaming

### DIFF
--- a/packages/core/src/schema/schema-parser-integration.spec.ts
+++ b/packages/core/src/schema/schema-parser-integration.spec.ts
@@ -253,7 +253,7 @@ describe('anyOf', () => {
     const schema = s.object('root', {
       value: s.anyOf([s.number('num'), s.string('str')]),
     });
-    const input = '{"value":{"0":123}}';
+    const input = '{"value":123}';
     const input2 = '{"value":{"1":"hello"}}';
 
     expect(parse(schema, input)).toEqual({ value: 123 });
@@ -264,8 +264,8 @@ describe('anyOf', () => {
     const schema = s.object('root', {
       value: s.anyOf([s.number('num'), s.string('str')]),
     });
-    const chunk1 = '{"value":{"0":';
-    const chunk2 = '123}}';
+    const chunk1 = '{"value":';
+    const chunk2 = '123}';
     const combined = chunk1 + chunk2;
 
     expect(parse(schema, chunk1)).toBe('');
@@ -314,18 +314,18 @@ describe('anyOf', () => {
     const schema = s.streaming.array(
       'streaming array',
       s.anyOf([
+        s.number('array number'),
         s.object('array object', {
           data: s.streaming.string('array object streaming data'),
         }),
-        s.number('array number'),
         s.boolean('array boolean'),
       ]),
     );
 
-    const chunk1 = '[{"0":{"data":"the ';
-    const chunk2 = 'markdown data"}},{"1":17},{"';
-    const chunk3 = '2":false},{"1":12';
-    const chunk4 = '3},{"0":{"data":"more markdown data"}}]';
+    const chunk1 = '[{"1":{"data":"the ';
+    const chunk2 = 'markdown data"}},17,';
+    const chunk3 = 'false,12';
+    const chunk4 = '3,{"1":{"data":"more markdown data"}}]';
 
     expect(parse(schema, chunk1)).toEqual([{ data: 'the' }]);
     expect(parse(schema, chunk1 + chunk2)).toEqual([

--- a/packages/core/src/streaming-json-parser/test/client.ts
+++ b/packages/core/src/streaming-json-parser/test/client.ts
@@ -15,13 +15,14 @@ import { PRIMITIVE_WRAPPER_FIELD_NAME } from '../../schema/base';
   });
 
   // anyOf as a property (instead of in a container)
-  // const responseSchema = s.object('gridArea', {
-  //   element: s.anyOf([
-  //     s.object('Markdown', {
-  //       data: s.streaming.string('The markdown data'),
-  //     }),
-  //   ]),
-  // });
+  const responseSchema = s.object('gridArea', {
+    element: s.anyOf([
+      s.boolean('a boolean'),
+      s.object('Markdown', {
+        data: s.streaming.string('The markdown data'),
+      }),
+    ]),
+  });
 
   // const responseSchema = s.object('UI', {
   //   ui: s.streaming.array(
@@ -37,25 +38,29 @@ import { PRIMITIVE_WRAPPER_FIELD_NAME } from '../../schema/base';
   //   ),
   // });
 
-  const responseSchema = s.number('top-level number');
-
-  // const data = {
-  //   gridArea: 'a string',
-  //   element: {
-  //     [0]: {
-  //       data: 'the markdown data',
-  //     },
-  //   },
-  //   afterAnyOf: 'a string after the anyOf',
-  // };
+  // const responseSchema = s.number('top-level number');
 
   const data = {
-    [PRIMITIVE_WRAPPER_FIELD_NAME]: 7,
+    gridArea: 'a string',
+    element: {
+      [1]: {
+        data: 'the markdown data',
+      },
+    },
+    // element: false,
+    // afterAnyOf: 'a string after the anyOf',
   };
 
-  // console.log(toJsonSchema(responseSchema));
+  // const data = {
+  //   [PRIMITIVE_WRAPPER_FIELD_NAME]: 7,
+  // };
 
-  // console.log(responseSchema.parseJsonSchema(data));
+  console.log(toJsonSchema(responseSchema).properties.element.anyOf);
+
+  // console.log('parsed value:');
+  const result = responseSchema.parseJsonSchema(data);
+  console.log('after parsed value');
+  console.log(result);
   // responseSchema.validateJsonSchema(data);
 
   // console.log(responseSchema.toTypeScript());

--- a/packages/core/src/streaming-json-parser/test/server.ts
+++ b/packages/core/src/streaming-json-parser/test/server.ts
@@ -1,13 +1,14 @@
 import { createServer } from 'net';
 import { PRIMITIVE_WRAPPER_FIELD_NAME } from '../../schema/base';
 
-// const TEST_JSON = {
-//   element: {
-//     0: {
-//       data: 'the markdown data',
-//     },
-//   },
-// };
+const TEST_JSON = {
+  // element: {
+  //   1: {
+  //     data: 'the markdown data',
+  //   },
+  // },
+  element: false,
+};
 
 // const TEST_JSON = {
 //   ui: [
@@ -20,9 +21,9 @@ import { PRIMITIVE_WRAPPER_FIELD_NAME } from '../../schema/base';
 //   ],
 // };
 
-const TEST_JSON = {
-  [PRIMITIVE_WRAPPER_FIELD_NAME]: 7,
-};
+// const TEST_JSON = {
+//   [PRIMITIVE_WRAPPER_FIELD_NAME]: 7,
+// };
 
 // const TEST_JSON = {
 //   booleanValue: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
LLMs seem to struggle with the discriminator wrapper objects we introduced for types in an anyOf.  

Closes #170

## What is the new behavior?
When parsing objects, arrays, anyOfs or streaming strings, we still need the discriminator to know how to handle incomplete objects, so those remain.

For other types (non-streaming strings, types that cannot stream in the first place), discriminator objects are no longer added (or when parsing, removed) from JSONSchema or data.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
