### PR TITLE
feat(react): update useTool ergonomics for v0.2

### DIFF
--- a/packages/react/src/hooks/use-chat.spec.tsx
+++ b/packages/react/src/hooks/use-chat.spec.tsx
@@ -45,9 +45,14 @@ vi.mock('@hashbrownai/core', async () => {
   };
 });
 
-afterEach(() => {
-  shouldRegenerateHandler = false;
+vi.spyOn(console, 'warn').mockImplementation(() => null);
+
+beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.resetAllMocks();
 });
 
 const ProviderWrapper = ({ children }: { children: React.ReactNode }) => (

--- a/packages/react/src/hooks/use-structured-chat.spec.tsx
+++ b/packages/react/src/hooks/use-structured-chat.spec.tsx
@@ -44,30 +44,31 @@ vi.mock('@hashbrownai/core', async () => {
   };
 });
 
-afterEach(() => {
+vi.spyOn(console, 'warn').mockImplementation(() => null);
+
+beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.resetAllMocks();
 });
 
 const ProviderWrapper = ({ children }: { children: React.ReactNode }) => (
   <HashbrownProvider url="localhost">{children}</HashbrownProvider>
 );
 
-let shouldRegenerateHandler = false;
-
 const TestComponent = () => {
-  const searchRestaurantTool = useTool(
-    {
-      name: 'Restaurant Search',
-      description: 'Search for restaurants based on location and cuisine.',
-      schema: s.object('RestaurantSearchParams', {
-        location: s.string('Location'),
-        cuisine: s.string('Cuisine'),
-        radius: s.number('Radius'), // in miles
-      }),
-      handler: async () => vi.fn(),
-    },
-    [shouldRegenerateHandler],
-  );
+  const searchRestaurantTool = useTool({
+    name: 'Restaurant Search',
+    description: 'Search for restaurants based on location and cuisine.',
+    schema: s.object('RestaurantSearchParams', {
+      location: s.string('Location'),
+      cuisine: s.string('Cuisine'),
+      radius: s.number('Radius'), // in miles
+    }),
+    handler: async () => vi.fn(),
+  });
   const { messages } = useStructuredChat({
     model: 'gpt-4o',
     tools: [searchRestaurantTool],
@@ -120,7 +121,6 @@ it('should not regenerate Hashbrown even when a tool has a changed dependency', 
   expect(fryHashbrown).toHaveBeenCalledTimes(1);
   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(1);
 
-  shouldRegenerateHandler = true; // Change the handler to trigger re-render
   rerender(<TestComponent />);
 
   expect(fryHashbrown).toHaveBeenCalledTimes(1);

--- a/samples/smart-home/client-react/src/app/shared/ChatPanel.tsx
+++ b/samples/smart-home/client-react/src/app/shared/ChatPanel.tsx
@@ -1,39 +1,16 @@
-import { Chat, s } from '@hashbrownai/core';
-import { useChat, useTool } from '@hashbrownai/react';
+import { Chat } from '@hashbrownai/core';
+import { useChat } from '@hashbrownai/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSmartHomeStore } from '../store/smart-home.store';
 import { Button } from './button';
 import { Message } from './Message';
 import { ScrollArea } from './scrollarea';
 import { Textarea } from './textarea';
+import { useControlLightTool, useGetLightsTool } from '../tools';
 
 export const ChatPanel = () => {
-  const getLights = useTool(
-    {
-      name: 'getLights',
-      description: 'Get the current lights',
-      handler: () => Promise.resolve(useSmartHomeStore.getState().lights),
-    },
-    [],
-  );
-  const controlLight = useTool(
-    {
-      name: 'controlLight',
-      description:
-        'Control the light. Brightness is a number between 0 and 100.',
-      schema: s.object('Control light input', {
-        lightId: s.string('The id of the light'),
-        brightness: s.number('The brightness of the light, between 0 and 100'),
-      }),
-      handler: (input) => {
-        useSmartHomeStore.getState().updateLight(input.lightId, {
-          brightness: input.brightness,
-        });
-        return Promise.resolve(true);
-      },
-    },
-    [],
-  );
+  const getLights = useGetLightsTool();
+  const controlLight = useControlLightTool();
+
   const {
     messages,
     sendMessage,

--- a/samples/smart-home/client-react/src/app/shared/RichChatPanel.tsx
+++ b/samples/smart-home/client-react/src/app/shared/RichChatPanel.tsx
@@ -1,7 +1,6 @@
 import { Chat, s } from '@hashbrownai/core';
-import { exposeComponent, useTool, useUiChat } from '@hashbrownai/react';
+import { exposeComponent, useUiChat } from '@hashbrownai/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSmartHomeStore } from '../store/smart-home.store';
 import { LightChatComponent } from '../views/components/LightChatComponent';
 import { Button } from './button';
 import { CardComponent } from './CardComponent';
@@ -9,38 +8,9 @@ import { MarkdownComponent } from './MarkdownComponent';
 import { RichMessage } from './RichMessage';
 import { ScrollArea } from './scrollarea';
 import { Textarea } from './textarea';
+import { useControlLightTool, useGetLightsTool } from '../tools';
 
 export const RichChatPanel = () => {
-  const getLights = useTool(
-    {
-      name: 'getLights',
-      description: 'Get the current lights',
-      handler: () => Promise.resolve(useSmartHomeStore.getState().lights),
-    },
-    [],
-  );
-  const controlLight = useTool(
-    {
-      name: 'controlLight',
-      description:
-        'Control the light. Brightness is a number between 0 and 100.',
-      schema: s.object('Control light input', {
-        lightId: s.string('The id of the light'),
-        brightness: s.number('The brightness of the light, between 0 and 100'),
-      }),
-      handler: (input) => {
-        const { lightId, brightness } = input;
-
-        useSmartHomeStore.getState().updateLight(lightId, {
-          brightness,
-        });
-
-        return Promise.resolve(true);
-      },
-    },
-    [],
-  );
-
   const {
     messages,
     sendMessage,
@@ -53,7 +23,7 @@ export const RichChatPanel = () => {
     model: 'gpt-4o',
     system:
       'You are a smart home assistant. You can control the lights in the house. You should not stringify (aka escape) function arguments',
-    tools: [getLights, controlLight],
+    tools: [useGetLightsTool(), useControlLightTool()],
     components: [
       exposeComponent(LightChatComponent, {
         name: 'LightChatComponent',

--- a/samples/smart-home/client-react/src/app/tools/index.ts
+++ b/samples/smart-home/client-react/src/app/tools/index.ts
@@ -1,0 +1,2 @@
+export { useControlLightTool } from './use-control-light-tool';
+export { useGetLightsTool } from './use-get-lights-tool';

--- a/samples/smart-home/client-react/src/app/tools/use-control-light-tool.tsx
+++ b/samples/smart-home/client-react/src/app/tools/use-control-light-tool.tsx
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { s } from '@hashbrownai/core';
+import { useTool } from '@hashbrownai/react';
+import { useSmartHomeStore } from '../store/smart-home.store';
+
+export const useControlLightTool = () => {
+  const controlLightHandler = useCallback(
+    (input: { lightId: string; brightness: number }) => {
+      useSmartHomeStore.getState().updateLight(input.lightId, {
+        brightness: input.brightness,
+      });
+      return Promise.resolve(true);
+    },
+    [],
+  );
+  const controlLight = useTool({
+    name: 'controlLight',
+    description: 'Control the light. Brightness is a number between 0 and 100.',
+    schema: s.object('Control light input', {
+      lightId: s.string('The id of the light'),
+      brightness: s.number('The brightness of the light, between 0 and 100'),
+    }),
+    handler: controlLightHandler,
+  });
+
+  return controlLight;
+};

--- a/samples/smart-home/client-react/src/app/tools/use-get-lights-tool.tsx
+++ b/samples/smart-home/client-react/src/app/tools/use-get-lights-tool.tsx
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useTool } from '@hashbrownai/react';
+import { useSmartHomeStore } from '../store/smart-home.store';
+
+export const useGetLightsTool = () => {
+  const lightsHandler = useCallback(() => {
+    return Promise.resolve(useSmartHomeStore.getState().lights);
+  }, []);
+  const getLights = useTool({
+    name: 'getLights',
+    description: 'Get the current lights',
+    handler: lightsHandler,
+  });
+
+  return getLights;
+};

--- a/www/src/examples/react/ui-chat/src/app/App.tsx
+++ b/www/src/examples/react/ui-chat/src/app/App.tsx
@@ -16,12 +16,24 @@ export default function App(): ReactElement {
   const setApiKey = useConfigStore((state) => state.setApiKey);
   const [showApiKeyDialog, setShowApiKeyDialog] = useState(false);
 
+  const getLightsHandler = useCallback(() => {
+    return Promise.resolve(useSmartHomeStore.getState().lights);
+  }, []);
   const getLights = useTool({
     name: 'getLights',
     description: 'Get the current lights',
-    handler: () => Promise.resolve(useSmartHomeStore.getState().lights),
+    handler: getLightsHandler,
   });
 
+  const controlLightHandler = useCallback(
+    (input: { lightId: string; brightness: number }) => {
+      useSmartHomeStore.getState().updateLight(input.lightId, {
+        brightness: input.brightness,
+      });
+      return Promise.resolve(true);
+    },
+    [],
+  );
   const controlLight = useTool({
     name: 'controlLight',
     description: 'Control the light. Brightness is a number between 0 and 100.',
@@ -29,16 +41,7 @@ export default function App(): ReactElement {
       lightId: s.string('The id of the light'),
       brightness: s.number('The brightness of the light, between 0 and 100'),
     }),
-    handler: (input: object) => {
-      const { lightId, brightness } = input as {
-        lightId: string;
-        brightness: number;
-      };
-      useSmartHomeStore.getState().updateLight(lightId, {
-        brightness,
-      });
-      return Promise.resolve(true);
-    },
+    handler: controlLightHandler,
   });
 
   const { messages, sendMessage, isSending, isReceiving, isRunningToolCalls } =


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, `useTool` tries to help users manage the fact that Hashbrown tools need to be stable references to functions, or else the LLM won't have access to the new reference. However, this got murky quickly.

Closes #

## What is the new behavior?

`useTool` no longer accepts a `deps` array and will in no way try to manage your handler reference for you; developers are responsible for creating stable references (`useCallback`).

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

## Other information

This API shift should be considered a developer preview, and may change again as we build more understanding of what it's like to build with Hashbrown in React.