### PR TITLE
feat(openai,writer,google,azure): onChatCompletion callback & usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,7 @@
         "ng-packagr": "20.0.0",
         "nx": "21.2.0-beta.1",
         "nx-ignore": "^19.8.0",
-        "openai": "^4.93.0",
+        "openai": "^5.11.0",
         "portfinder": "^1.0.37",
         "postcss": "^8.4.5",
         "postcss-url": "~10.1.3",
@@ -18935,17 +18935,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
       "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
@@ -21227,19 +21216,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -29304,20 +29280,6 @@
         "node": ">= 14.17"
       }
     },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -30831,16 +30793,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -41739,20 +41691,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.11.0.tgz",
+      "integrity": "sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
       "bin": {
         "openai": "bin/cli"
       },
@@ -41768,30 +41711,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.113",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.113.tgz",
-      "integrity": "sha512-TmSTE9vyebJ9vSEiU+P+0Sp4F5tMgjiEOZaQUW6wA3ODvi6uBgkHQ+EsIu0pbiKvf9QHEvyRCiaz03rV0b+IaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
@@ -53484,16 +53403,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/web-vitals": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "ng-packagr": "20.0.0",
     "nx": "21.2.0-beta.1",
     "nx-ignore": "^19.8.0",
-    "openai": "^4.93.0",
+    "openai": "^5.11.0",
     "portfinder": "^1.0.37",
     "postcss": "^8.4.5",
     "postcss-url": "~10.1.3",

--- a/packages/azure/src/stream/text.fn.ts
+++ b/packages/azure/src/stream/text.fn.ts
@@ -109,6 +109,9 @@ export async function* text(
             },
           }
         : undefined,
+      stream_options: {
+        include_usage: true,
+      },
     };
 
     const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =

--- a/packages/azure/src/stream/text.fn.ts
+++ b/packages/azure/src/stream/text.fn.ts
@@ -116,7 +116,7 @@ export async function* text(
         ? await transformRequestOptions(baseOptions)
         : baseOptions;
 
-    const stream = client.beta.chat.completions.stream(resolvedOptions);
+    const stream = client.chat.completions.stream(resolvedOptions);
 
     for await (const chunk of stream) {
       const chunkMessage: Chat.Api.CompletionChunk = {

--- a/packages/core/src/public_api.ts
+++ b/packages/core/src/public_api.ts
@@ -12,3 +12,4 @@ export * as ɵcomponents from './utils/expose-component';
 export * as ɵtypes from './utils/types';
 export type { KnownModelIds } from './utils';
 export { deepEqual as ɵdeepEqual } from './utils/deep-equal';
+export { updateMessagesWithDelta as ɵupdateMessagesWithDelta } from './utils/update-message';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
-export * from './expose-component';
-export * from './types';
-export * from './llm';
 export * from './deep-equal';
+export * from './expose-component';
+export * from './llm';
+export * from './types';
+export { updateMessagesWithDelta } from './update-message';

--- a/packages/core/src/utils/update-message.ts
+++ b/packages/core/src/utils/update-message.ts
@@ -1,0 +1,68 @@
+import { Chat } from '../models';
+import { DeepPartial } from '../utils';
+
+/**
+ * Merges existing and new tool calls.
+ *
+ * @param existingCalls - The existing tool calls.
+ * @param newCalls - The new tool calls to merge.
+ * @returns The merged array of tool calls.
+ */
+function mergeToolCalls(
+  existingCalls: Chat.Api.ToolCall[] = [],
+  newCalls: DeepPartial<Chat.Api.ToolCall>[] = [],
+): Chat.Api.ToolCall[] {
+  const merged = [...existingCalls];
+  newCalls.forEach((newCall) => {
+    const index = merged.findIndex((call) => call.index === newCall.index);
+    if (index !== -1) {
+      const existing = merged[index];
+      merged[index] = {
+        ...existing,
+        function: {
+          ...existing.function,
+          arguments:
+            existing.function.arguments + (newCall.function?.arguments ?? ''),
+        },
+      };
+    } else {
+      merged.push(newCall as Chat.Api.ToolCall);
+    }
+  });
+  return merged;
+}
+
+/**
+ * Updates the messages array with an incoming assistant delta.
+ *
+ * @param messages - The current messages array.
+ * @param delta - The incoming message delta.
+ * @returns The updated messages array.
+ */
+export function updateMessagesWithDelta(
+  message: Chat.Api.AssistantMessage | null,
+  delta: Chat.Api.CompletionChunk,
+): Chat.Api.AssistantMessage | null {
+  if (message && message.role === 'assistant' && delta.choices.length) {
+    const updatedToolCalls = mergeToolCalls(
+      message.toolCalls,
+      delta.choices[0].delta.toolCalls ?? [],
+    );
+    const updatedMessage: Chat.Api.AssistantMessage = {
+      ...message,
+      content: (message.content ?? '') + (delta.choices[0].delta.content ?? ''),
+      toolCalls: updatedToolCalls,
+    };
+    return updatedMessage;
+  } else if (
+    delta.choices.length &&
+    delta.choices[0]?.delta?.role === 'assistant'
+  ) {
+    return {
+      role: 'assistant',
+      content: delta.choices[0].delta.content ?? '',
+      toolCalls: mergeToolCalls([], delta.choices[0].delta.toolCalls ?? []),
+    };
+  }
+  return message;
+}

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -16,7 +16,7 @@
     "@hashbrownai/core": "0.2.3"
   },
   "peerDependencies": {
-    "openai": "^4.93.0"
+    "openai": "^5.11.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -98,9 +98,10 @@ export async function* text(
         ? await transformRequestOptions(baseOptions)
         : baseOptions;
 
-    const stream = openai.beta.chat.completions.stream(resolvedOptions);
+    const stream = openai.chat.completions.stream(resolvedOptions);
 
     for await (const chunk of stream) {
+      console.log('chunk', chunk);
       const chunkMessage: Chat.Api.CompletionChunk = {
         choices: chunk.choices.map(
           (choice): Chat.Api.CompletionChunkChoice => ({

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -123,7 +123,6 @@ export async function* text(
     let usage: OpenAI.Completions.CompletionUsage | undefined;
 
     for await (const chunk of stream) {
-      console.log('chunk', chunk);
       const chunkMessage: Chat.Api.CompletionChunk = {
         choices: chunk.choices.map(
           (choice): Chat.Api.CompletionChunkChoice => ({

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -91,6 +91,9 @@ export async function* text(
             },
           }
         : undefined,
+      stream_options: {
+        include_usage: true,
+      },
     };
 
     const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =

--- a/samples/server/src/main.ts
+++ b/samples/server/src/main.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Chat, KnownModelIds } from '@hashbrownai/core';
-import { HashbrownAzure } from '@hashbrownai/azure';
-import { HashbrownOpenAI } from '@hashbrownai/openai';
 import { HashbrownGoogle } from '@hashbrownai/google';
+import { HashbrownOpenAI } from '@hashbrownai/openai';
 import { HashbrownWriter } from '@hashbrownai/writer';
 import cors from 'cors';
 import 'dotenv/config';
 import express from 'express';
+import OpenAI from 'openai';
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -80,6 +80,14 @@ app.listen(port, host, () => {
   console.log(`[ ready ] http://${host}:${port}`);
 });
 
+const onCompletion = async (
+  messages: OpenAI.ChatCompletionMessageParam[],
+  completionMessage: Chat.Api.AssistantMessage | null,
+  usage: OpenAI.Completions.CompletionUsage | undefined,
+) => {
+  console.log('onCompletion', messages, completionMessage, usage);
+};
+
 app.post('/chat', async (req, res, next) => {
   const request = req.body as Chat.Api.CompletionCreateParams;
 
@@ -95,6 +103,7 @@ app.post('/chat', async (req, res, next) => {
     stream = HashbrownOpenAI.stream.text({
       apiKey: OPENAI_API_KEY,
       request,
+      onChatCompletion: onCompletion,
     });
   } else if (KNOWN_WRITER_MODEL_NAMES.includes(modelName as KnownModelIds)) {
     stream = HashbrownWriter.stream.text({

--- a/samples/server/src/main.ts
+++ b/samples/server/src/main.ts
@@ -6,7 +6,16 @@ import { HashbrownWriter } from '@hashbrownai/writer';
 import cors from 'cors';
 import 'dotenv/config';
 import express from 'express';
-import OpenAI from 'openai';
+
+// import OpenAI from 'openai';
+//
+// const onCompletion = async (
+//   messages: OpenAI.ChatCompletionMessageParam[],
+//   completionMessage: Chat.Api.AssistantMessage | null,
+//   usage: OpenAI.Completions.CompletionUsage | undefined,
+// ) => {
+//   console.log('onCompletion', messages, completionMessage, usage);
+// };
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -79,14 +88,6 @@ app.use(cors());
 app.listen(port, host, () => {
   console.log(`[ ready ] http://${host}:${port}`);
 });
-
-const onCompletion = async (
-  messages: OpenAI.ChatCompletionMessageParam[],
-  completionMessage: Chat.Api.AssistantMessage | null,
-  usage: OpenAI.Completions.CompletionUsage | undefined,
-) => {
-  console.log('onCompletion', messages, completionMessage, usage);
-};
 
 app.post('/chat', async (req, res, next) => {
   const request = req.body as Chat.Api.CompletionCreateParams;

--- a/samples/server/src/main.ts
+++ b/samples/server/src/main.ts
@@ -104,7 +104,6 @@ app.post('/chat', async (req, res, next) => {
     stream = HashbrownOpenAI.stream.text({
       apiKey: OPENAI_API_KEY,
       request,
-      onChatCompletion: onCompletion,
     });
   } else if (KNOWN_WRITER_MODEL_NAMES.includes(modelName as KnownModelIds)) {
     stream = HashbrownWriter.stream.text({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

@jakeharris and I added a backend callback to the vendor packages allowing a developer to specify a callback function for completion.  This is useful for a few reasons.

1. It allows product developers to consistently access the contents of chats from the backend.
2. It enables metrics reporting to observability platforms for cost and volume.
3. It sets the stage for token usage metrics to be sent to the front end.  

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. You cannot access chats or completions from the backend.
2. You cannot get token usage metrics from the vendor packages.

Closes #

## What is the new behavior?

1. You can specify a callback function `onChatCompletion` that will be called when completions.. completes.
2. You can specify `includeUsage` to tell the vendor package whether or not to include metrics data in that callback. (defaults `true`)

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
