### PR TITLE
fix(core): prompt non-ui template expressions

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,3 @@
 {
-  "mcpServers": {
-    "nx-mcp": {
-      "url": "http://localhost:9972/sse"
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Placeholders that originated outside `<ui>` blocks could survive compilation as raw `__HBX_*` tokens whenever injected UI content shortened the original block range, leading to leaked placeholder markers in prompts.

Closes #371 

## What is the new behavior?

Only placeholders that were authored outside `<ui>` blocks are replaced post-injection; tokens inside UI blocks are skipped, non-serializable values fall back to `String(value)`, and new regression tests cover the mixed UI/non-UI scenarios to assert the fix.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

- Tests: `npx nx run core:test`
