### PR TITLE
fix(gemini): fix error when developer does not provide any tools

### DIFF
--- a/packages/google/src/stream/text.fn.ts
+++ b/packages/google/src/stream/text.fn.ts
@@ -117,14 +117,18 @@ export async function* text(
       systemInstruction: {
         parts: [{ text: system }],
       },
-      tools: [
+      responseMimeType: responseFormat ? 'application/json' : 'text/plain',
+      responseSchema: responseSchema,
+    };
+
+    // Only include tools and toolConfig when there are actual tools
+    if (geminiTools.length > 0) {
+      config.tools = [
         {
           functionDeclarations: geminiTools,
         },
-      ],
-      responseMimeType: responseFormat ? 'application/json' : 'text/plain',
-      responseSchema: responseSchema,
-      toolConfig: {
+      ];
+      config.toolConfig = {
         functionCallingConfig: {
           mode:
             toolChoice === 'required'
@@ -133,8 +137,8 @@ export async function* text(
                 ? FunctionCallingConfigMode.NONE
                 : FunctionCallingConfigMode.AUTO,
         },
-      },
-    };
+      };
+    }
 
     const params: GenerateContentParameters = {
       model: model as string,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a developr does not provide a tools array, internally hashbrown adds some configurations that causes gemini to error.

Closes #399

## What is the new behavior?

We will only add these default tools configurations if the users provides any tools to use

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<img width="1017" height="400" alt="CleanShot 2025-11-02 at 10 30 05" src="https://github.com/user-attachments/assets/df9e5081-5625-4ef1-98d0-4165bcb91668" />
