### PR TITLE
Add explicit export settings so that the 'import' entrypoint will res…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,5 +38,17 @@
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/liveloveapp"
+  },
+  "module": "./index.esm.js",
+  "main": "./index.cjs.js",
+  "types": "./index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.esm.js",
+      "require": "./index.cjs.js",
+      "default": "./index.cjs.js"
+    }
   }
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -22,7 +22,6 @@
         "tsConfig": "packages/core/tsconfig.lib.json",
         "outputPath": "dist/packages/core",
         "format": ["esm", "cjs"],
-        "generateExportsField": true,
         "outputFileName": "index",
         "outputFileExtensionForEsm": ".mjs",
         "outputFileExtensionForCjs": ".cjs",


### PR DESCRIPTION
Fixes https://github.com/liveloveapp/hashbrown/issues/419 by overriding the rollup generated exports with explicit ones that resolve 'import' entry points to 'esm' (instead of the auto-generated 'cjs').

We think the combination of having rollup generate export settings combined with packaging builds out of a shared, top-level dist directory caused rollup's export detection heuristics to go awry.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I checked out the reporter-provided repo and modified it to install hashbrownai/core from my local checkout.  Running `npx nx build app` raised the reported error about the `url` package.

Closes #419 

## What is the new behavior?

With the fix, and after an npm install in the reporter's repo, the error no longer happens.

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```

This PR may consistitute a breaking change for some installations, but the new behavior should be the "correct" one.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
