### PR TITLE
feat(google): add Vertex AI authentication support

### DIFF
--- a/packages/google/src/integration.spec.ts
+++ b/packages/google/src/integration.spec.ts
@@ -6,6 +6,8 @@ import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
 import { HashbrownGoogle } from './index';
 
 const GOOGLE_API_KEY = process.env['GOOGLE_API_KEY'] ?? '';
+const VERTEX_AI_PROJECT = process.env['GOOGLE_CLOUD_PROJECT'] ?? '';
+const VERTEX_AI_LOCATION = process.env['GOOGLE_CLOUD_LOCATION'] ?? '';
 
 jest.setTimeout(60_000);
 
@@ -27,6 +29,46 @@ test('Google Text Streaming', async () => {
 
      DO NOT respond with any other text.
     `,
+      messages: [
+        {
+          role: 'user',
+          content: 'Please respond with the correct text.',
+        },
+      ],
+    });
+
+    await waitUntilHashbrownIsSettled(hashbrown);
+
+    const assistantMessage = hashbrown
+      .messages()
+      .find((message) => message.role === 'assistant');
+
+    expect(assistantMessage?.content).toBe('Hello, world!');
+  } finally {
+    server.close();
+  }
+});
+
+xtest('Vertex AI Text Streaming', async () => {
+  const server = await createServer((request) =>
+    HashbrownGoogle.stream.text({
+      vertexai: true,
+      project: VERTEX_AI_PROJECT,
+      location: VERTEX_AI_LOCATION,
+      request,
+    }),
+  );
+  try {
+    const hashbrown = fryHashbrown({
+      debounce: 0,
+      apiUrl: server.url,
+      model: 'gemini-2.5-flash',
+      system: `
+       I am writing an integration test against Google Vertex AI. Respond
+       exactly with the text "Hello, world!"
+
+       DO NOT respond with any other text.
+      `,
       messages: [
         {
           role: 'user',

--- a/packages/google/src/integration.spec.ts
+++ b/packages/google/src/integration.spec.ts
@@ -49,7 +49,7 @@ test('Google Text Streaming', async () => {
   }
 });
 
-xtest('Vertex AI Text Streaming', async () => {
+test.skip('Vertex AI Text Streaming', async () => {
   const server = await createServer((request) =>
     HashbrownGoogle.stream.text({
       vertexai: true,

--- a/packages/google/src/stream/text.fn.ts
+++ b/packages/google/src/stream/text.fn.ts
@@ -16,8 +16,21 @@ import {
   updateAssistantMessage,
 } from '@hashbrownai/core';
 
-type BaseGoogleTextStreamOptions = {
+type ApiKeyAuthOptions = {
   apiKey: string;
+  vertexai?: undefined;
+  project?: undefined;
+  location?: undefined;
+};
+
+type VertexAIAuthOptions = {
+  vertexai: true;
+  project: string;
+  location: string;
+  apiKey?: undefined;
+};
+
+type BaseGoogleTextStreamOptions = (ApiKeyAuthOptions | VertexAIAuthOptions) & {
   request: Chat.Api.CompletionCreateParams;
   transformRequestOptions?: (
     options: GenerateContentParameters,
@@ -47,16 +60,19 @@ export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
 export async function* text(
   options: GoogleTextStreamOptions,
 ): AsyncIterable<Uint8Array> {
-  const { apiKey, request, transformRequestOptions, loadThread, saveThread } =
-    options;
+  const { request, transformRequestOptions, loadThread, saveThread } = options;
   const { model, tools, responseFormat, toolChoice, system } = request;
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
   let effectiveThreadId = threadId;
 
-  const ai = new GoogleGenAI({
-    apiKey,
-  });
+  const ai: GoogleGenAI = options.vertexai
+    ? new GoogleGenAI({
+        vertexai: true,
+        project: options.project,
+        location: options.location,
+      })
+    : new GoogleGenAI({ apiKey: options.apiKey });
 
   const shouldLoadThread = Boolean(request.threadId);
   const shouldHydrateThreadOnTheClient = Boolean(

--- a/www/analog/src/app/pages/docs/angular/platform/google.md
+++ b/www/analog/src/app/pages/docs/angular/platform/google.md
@@ -12,6 +12,30 @@ First, install the Google adapter package:
 npm install @hashbrownai/google
 ```
 
+## Authentication
+
+The adapter supports two mutually exclusive authentication modes.
+
+**API Key (Gemini Developer API):**
+
+```ts
+HashbrownGoogle.stream.text({
+  apiKey: process.env.GOOGLE_API_KEY!,
+  request: req.body,
+});
+```
+
+**Vertex AI (project + location via ADC):**
+
+```ts
+HashbrownGoogle.stream.text({
+  vertexai: true,
+  project: ‘your-gcp-project’,
+  location: ‘us-central1’,
+  request: req.body,
+});
+```
+
 ## Streaming Text Responses
 
 Hashbrown’s Google Gemini adapter lets you **stream chat completions** from Google Gemini models, handling function calls, response schemas, and request transforms.
@@ -24,11 +48,14 @@ Streams a Gemini chat completion as a series of encoded frames. Handles content,
 
 **Options:**
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your Google Gemini API Key.                                                    |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Gemini request before it is sent. |
+| Name                      | Type                                    | Description                                                                                    |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | Gemini Developer API key. Mutually exclusive with `vertexai`.                                  |
+| `vertexai`                | `true`                                  | Enable Vertex AI auth. Mutually exclusive with `apiKey`.                                       |
+| `project`                 | `string`                                | GCP project ID. Required when `vertexai: true`.                                                |
+| `location`                | `string`                                | GCP region (e.g. `us-central1`). Required when `vertexai: true`.                              |
+| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.                         |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Gemini request before it is sent.                 |
 
 **Supported Features:**
 

--- a/www/analog/src/app/pages/docs/angular/platform/google.md
+++ b/www/analog/src/app/pages/docs/angular/platform/google.md
@@ -30,8 +30,8 @@ HashbrownGoogle.stream.text({
 ```ts
 HashbrownGoogle.stream.text({
   vertexai: true,
-  project: ‘your-gcp-project’,
-  location: ‘us-central1’,
+  project: 'your-gcp-project',
+  location: 'us-central1',
   request: req.body,
 });
 ```

--- a/www/analog/src/app/pages/docs/react/platform/google.md
+++ b/www/analog/src/app/pages/docs/react/platform/google.md
@@ -13,6 +13,30 @@ First, install the Google adapter package:
 npm install @hashbrownai/google
 ```
 
+## Authentication
+
+The adapter supports two mutually exclusive authentication modes.
+
+**API Key (Gemini Developer API):**
+
+```ts
+HashbrownGoogle.stream.text({
+  apiKey: process.env.GOOGLE_API_KEY!,
+  request: req.body,
+});
+```
+
+**Vertex AI (project + location via ADC):**
+
+```ts
+HashbrownGoogle.stream.text({
+  vertexai: true,
+  project: ‘your-gcp-project’,
+  location: ‘us-central1’,
+  request: req.body,
+});
+```
+
 ## Streaming Text Responses
 
 Hashbrown’s Google Gemini adapter lets you **stream chat completions** from Google Gemini models, handling function calls, response schemas, and request transforms.
@@ -25,11 +49,14 @@ Streams a Gemini chat completion as a series of encoded frames. Handles content,
 
 **Options:**
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your Google Gemini API Key.                                                    |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Gemini request before it is sent. |
+| Name                      | Type                                    | Description                                                                                    |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | Gemini Developer API key. Mutually exclusive with `vertexai`.                                  |
+| `vertexai`                | `true`                                  | Enable Vertex AI auth. Mutually exclusive with `apiKey`.                                       |
+| `project`                 | `string`                                | GCP project ID. Required when `vertexai: true`.                                                |
+| `location`                | `string`                                | GCP region (e.g. `us-central1`). Required when `vertexai: true`.                              |
+| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.                         |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Gemini request before it is sent.                 |
 
 **Supported Features:**
 

--- a/www/analog/src/app/pages/docs/react/platform/google.md
+++ b/www/analog/src/app/pages/docs/react/platform/google.md
@@ -31,8 +31,8 @@ HashbrownGoogle.stream.text({
 ```ts
 HashbrownGoogle.stream.text({
   vertexai: true,
-  project: ‘your-gcp-project’,
-  location: ‘us-central1’,
+  project: 'your-gcp-project',
+  location: 'us-central1',
   request: req.body,
 });
 ```


### PR DESCRIPTION
Support Vertex AI (project + location + ADC) alongside the existing Gemini API key, enabling use in GCP-hosted environments.

Closes #469
