### PR TITLE
[codex] chore: remediate React Router audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,7 @@
         "prettier": "^3.9.4",
         "react-day-picker": "^8.10.2",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "6.29.0",
+        "react-router-dom": "6.30.4",
         "serverless": "^4.38.1",
         "serverless-esbuild": "^1.57.2",
         "serverless-offline": "^14.7.4",
@@ -21402,9 +21402,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
-      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -54772,13 +54772,13 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
-      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.22.0"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -54788,14 +54788,14 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
-      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.22.0",
-        "react-router": "6.29.0"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "prettier": "^3.9.4",
     "react-day-picker": "^8.10.2",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "6.29.0",
+    "react-router-dom": "6.30.4",
     "serverless": "^4.38.1",
     "serverless-esbuild": "^1.57.2",
     "serverless-offline": "^14.7.4",


### PR DESCRIPTION
## Summary

- Updates `react-router-dom` from `6.29.0` to `6.30.4`.
- Updates the corresponding `react-router` and `@remix-run/router` lockfile entries.
- Removes the React Router audit advisory group without changing the broader Angular/Nx toolchain.

## Audit impact

Before this branch, `npm audit` reported 71 vulnerabilities: 7 low, 34 moderate, 30 high.

After this branch, `npm audit` reports 68 vulnerabilities: 7 low, 34 moderate, 27 high.

The remaining direct advisory groups are in the Angular/Nx/Analog/SWC/esbuild/ng-packagr/Verdaccio toolchain paths. I left those out because npm's fix paths require major upgrades or the known-bad Analog `2.6.x` path from the dependency update PR.

## Verification

- `npm ci`
- `npm audit --json`
- `NX_DAEMON=false npx nx affected -t build,test,lint --uncommitted`
- `git diff --check`

## Notes

The Nx verification exits 0 but still prints the existing warning set: lint warnings, API Extractor warnings, jsdom CSS parse noise, bundle/chunk-size warnings, and build-tool deprecation warnings.