### PR TITLE
[codex] chore: update Analog to 2.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@analogjs/content": "^2.0.3",
-        "@analogjs/router": "^2.0.3",
+        "@analogjs/content": "^2.6.2",
+        "@analogjs/router": "^2.6.2",
         "@angular-architects/ngrx-toolkit": "^20.7.0",
         "@angular/animations": "^20.3.25",
         "@angular/cdk": "^20.2.14",
@@ -59,9 +59,9 @@
       },
       "devDependencies": {
         "-": "^0.0.1",
-        "@analogjs/platform": "^2.0.3",
-        "@analogjs/vite-plugin-angular": "^2.0.3",
-        "@analogjs/vitest-angular": "^2.0.3",
+        "@analogjs/platform": "^2.6.2",
+        "@analogjs/vite-plugin-angular": "^2.6.2",
+        "@analogjs/vitest-angular": "^2.6.2",
         "@angular-devkit/build-angular": "^20.3.31",
         "@angular-devkit/core": "^20.3.31",
         "@angular-devkit/schematics": "^20.3.31",
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@analogjs/content": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@analogjs/content/-/content-2.0.3.tgz",
-      "integrity": "sha512-9Dx9oPI4WSrZpVSlPruMGlwp/Qn8wcFRUB4D72gCNJSvPN7oztYjJqqWD2G8AHek3FNSV+VvxoEyTlryjmaIWA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@analogjs/content/-/content-2.6.2.tgz",
+      "integrity": "sha512-w/J14olma/FvuOofPRZDv0Zf8el0vSBC3rcOyPhGY28lANUtsG7jVkzo/pLSZZ15Mh8BmyNl7A04aWCtV32FaA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -255,11 +255,11 @@
         "url": "https://github.com/sponsors/brandonroberts"
       },
       "peerDependencies": {
-        "@angular/common": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@angular/core": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@angular/platform-browser": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@angular/router": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@nx/devkit": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/router": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@nx/devkit": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0 || ^22",
         "front-matter": "^4.0.2",
         "marked": "^15.0.7",
         "marked-gfm-heading-id": "^4.1.1",
@@ -287,32 +287,32 @@
       }
     },
     "node_modules/@analogjs/platform": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@analogjs/platform/-/platform-2.0.3.tgz",
-      "integrity": "sha512-BKzgKLdWOnvlJbkfkmtcIVU1tQJXHV18c4r/bTJ+MxfnYhBmWNujODw0NAFjL3lOhYtrVN4v6G3+DdhiPmQeug==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@analogjs/platform/-/platform-2.6.2.tgz",
+      "integrity": "sha512-oMRrSN4D7yvb+cY94tqznijuos3KD9UTabbRb5UqZsvU3QRw61oJB9Yi77xoBb7vsqYmrjdkyLeGrmt7s+gdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@analogjs/vite-plugin-angular": "^2.0.3",
-        "@analogjs/vite-plugin-nitro": "^2.0.3",
-        "nitropack": "^2.11.0",
-        "vitefu": "^1.0.0"
+        "@analogjs/vite-plugin-angular": "^2.6.2",
+        "@analogjs/vite-plugin-nitro": "^2.6.2",
+        "nitropack": "^2.13.1",
+        "vitefu": "^1.1.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/brandonroberts"
       },
       "peerDependencies": {
-        "@nx/angular": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
-        "@nx/devkit": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
-        "@nx/vite": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
-        "marked": "^15.0.7",
-        "marked-gfm-heading-id": "^4.1.1",
-        "marked-highlight": "^2.2.1",
-        "marked-mangle": "^1.1.10",
-        "marked-shiki": "^1.1.0",
-        "shiki": "^1.6.1",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@nx/angular": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0 || ^22",
+        "@nx/devkit": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0 || ^22",
+        "@nx/vite": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0 || ^22",
+        "marked": "^15.0.12",
+        "marked-gfm-heading-id": "^4.1.3",
+        "marked-highlight": "^2.2.3",
+        "marked-mangle": "^1.1.12",
+        "marked-shiki": "^1.2.1",
+        "shiki": "^1.29.2",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@nx/angular": {
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@analogjs/router": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@analogjs/router/-/router-2.0.3.tgz",
-      "integrity": "sha512-u4QyHSNlMJu2VkCOV/70h2Lq0qJko2b28zxBJ0UpY4vstXoBWk3I0KmIm3+LnjpSHCKpRz2xdM/P71oIpNBcJw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@analogjs/router/-/router-2.6.2.tgz",
+      "integrity": "sha512-y7EY7BDpty7j2lgJc14yxkRDTBatsmqvFb+3fDwz6Z5esH6medkIjXSoXMtYtUELL6eWSz7q54ZL2p9+z0343Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -351,18 +351,22 @@
         "url": "https://github.com/sponsors/brandonroberts"
       },
       "peerDependencies": {
-        "@analogjs/content": "^2.0.3",
-        "@angular/core": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@angular/router": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
+        "@analogjs/content": "^2.6.2",
+        "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/router": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0"
       }
     },
     "node_modules/@analogjs/vite-plugin-angular": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-2.0.3.tgz",
-      "integrity": "sha512-aaaPhuFpDmq86+KkcOA5QKuY+ZGGFBvs4KSBT7Yt1uzoxVX6nwfI1SzExF9dfgTP/UZP8arDrtxVTls0fXVtqw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-2.6.2.tgz",
+      "integrity": "sha512-XbrdII0OpQcOfiyJ8N+FSlhF+Y+oEpLFkN35aJBh2QhhOrtHWX4XcqulcZwLJRU67eawfh/Bu6jJ3sSGLVEc4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "oxc-parser": "^0.121.0",
+        "tinyglobby": "^0.2.14",
         "ts-morph": "^21.0.0"
       },
       "funding": {
@@ -370,14 +374,18 @@
         "url": "https://github.com/sponsors/brandonroberts"
       },
       "peerDependencies": {
-        "@angular-devkit/build-angular": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0",
-        "@angular/build": "^18.0.0 || ^19.0.0 || ^20.0.0"
+        "@angular-devkit/build-angular": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/build": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@angular-devkit/build-angular": {
           "optional": true
         },
         "@angular/build": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }
@@ -834,9 +842,9 @@
       }
     },
     "node_modules/@analogjs/vitest-angular": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@analogjs/vitest-angular/-/vitest-angular-2.0.3.tgz",
-      "integrity": "sha512-lDyFl7BOC1Z+hG8r/QhDvceqxZoZle6HHTMgnLNB4StYmrPZD3CkbQvZehNlXoGus3o+ROY8pwIRheJtotUgAg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@analogjs/vitest-angular/-/vitest-angular-2.6.2.tgz",
+      "integrity": "sha512-aLyvyqv2bpgNXDhWwR5M974RVuF2TFfFfFIn2OuwRO7hf+w60v/GaJxvbFob8f7VJgztvoVGgDhWpu2Qon/dmg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -845,8 +853,15 @@
       },
       "peerDependencies": {
         "@analogjs/vite-plugin-angular": "*",
-        "@angular-devkit/architect": ">=0.1500.0 < 0.2100.0",
-        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+        "@angular-devkit/architect": ">=0.1700.0 < 0.2300.0 || >=0.2200.0 < 0.2300.0",
+        "@angular-devkit/schematics": ">=17.0.0",
+        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+        "zone.js": ">=0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "zone.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-architects/ngrx-toolkit": {
@@ -19175,7 +19190,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19193,7 +19207,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19211,7 +19224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19229,7 +19241,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19247,7 +19258,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19265,7 +19275,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19283,7 +19292,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19301,7 +19309,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19319,7 +19326,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19337,7 +19343,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19355,7 +19360,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19373,7 +19377,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19391,7 +19394,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19409,7 +19411,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19427,7 +19428,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19445,7 +19445,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19460,7 +19459,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.1.1"
       },
@@ -19475,7 +19473,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -19501,7 +19498,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19519,7 +19515,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19537,7 +19532,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -19548,8 +19542,6 @@
       "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -52115,6 +52107,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -52420,8 +52426,6 @@
       "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.121.0"
       },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     ]
   },
   "dependencies": {
-    "@analogjs/content": "^2.0.3",
-    "@analogjs/router": "^2.0.3",
+    "@analogjs/content": "^2.6.2",
+    "@analogjs/router": "^2.6.2",
     "@angular-architects/ngrx-toolkit": "^20.7.0",
     "@angular/animations": "^20.3.25",
     "@angular/cdk": "^20.2.14",
@@ -81,9 +81,9 @@
   },
   "devDependencies": {
     "-": "^0.0.1",
-    "@analogjs/platform": "^2.0.3",
-    "@analogjs/vite-plugin-angular": "^2.0.3",
-    "@analogjs/vitest-angular": "^2.0.3",
+    "@analogjs/platform": "^2.6.2",
+    "@analogjs/vite-plugin-angular": "^2.6.2",
+    "@analogjs/vitest-angular": "^2.6.2",
     "@angular-devkit/build-angular": "^20.3.31",
     "@angular-devkit/core": "^20.3.31",
     "@angular-devkit/schematics": "^20.3.31",

--- a/www/analog/tsconfig.json
+++ b/www/analog/tsconfig.json
@@ -23,6 +23,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "module": "ES2022",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Summary
- Updates the Analog packages from 2.0.3 to 2.6.2.
- Adds bundler module resolution for the Analog docs app so TypeScript resolves the package export subpaths used by @analogjs/router/server and @analogjs/router/tokens.

## Validation
- npm audit --json (68 total: 7 low, 34 moderate, 27 high)
- NX_DAEMON=false npx nx build www
- NX_DAEMON=false npx nx affected -t build,test,lint --uncommitted
- git diff --check

## Notes
- PR #473 has already been merged into main. This branch is based on that updated main.