### PR TITLE
[codex] test: update unavailable Gemini pro model

### DIFF
--- a/packages/google/src/integration.spec.ts
+++ b/packages/google/src/integration.spec.ts
@@ -333,7 +333,7 @@ test('Google with tool calling and structured output (gemini-3-flash-preview)', 
   }
 });
 
-test('Google with tool calling and structured output (gemini-3-pro-preview)', async () => {
+test('Google with tool calling and structured output (gemini-3.1-pro-preview)', async () => {
   const expectedResponse = 'Measure twice, cut once';
   let toolCallArgs: any;
   const server = await createServer((request) =>
@@ -347,7 +347,7 @@ test('Google with tool calling and structured output (gemini-3-pro-preview)', as
     const hashbrown = fryHashbrown({
       debounce: 0,
       apiUrl: server.url,
-      model: 'gemini-3-pro-preview',
+      model: 'gemini-3.1-pro-preview',
       system: `
      I am writing an integration test against Google. Call
      the "test" tool with the argument "Hello, world!"


### PR DESCRIPTION
## Summary
- Updates the Google integration test from `gemini-3-pro-preview` to `gemini-3.1-pro-preview`.
- Keeps the test coverage focused on a Gemini pro model with tool calling and structured output.

## Root cause
The root `.env` with `GOOGLE_API_KEY` is present in the primary checkout at `/Users/blove/repos/hashbrown/.env`, but this Codex worktree does not have that untracked file. After explicitly loading that file, Google e2e reached the API and failed because `gemini-3-pro-preview` now returns a 404 unavailable-model response. A minimal generation check confirmed `gemini-3.1-pro-preview` is available with the same key.

## Validation
- `NX_DAEMON=false npx nx run-many -t build,test,lint --projects google --parallel=1`
- `NODE_OPTIONS='-r dotenv/config' DOTENV_CONFIG_PATH=/Users/blove/repos/hashbrown/.env NX_DAEMON=false npx nx e2e google`
- `git diff --check`