### PR TITLE
[codex] feat: add Ollama client options

### DIFF
--- a/docs/superpowers/plans/2026-07-06-ollama-client-options.md
+++ b/docs/superpowers/plans/2026-07-06-ollama-client-options.md
@@ -1,0 +1,162 @@
+# Ollama Client Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit Ollama local client configuration via `host` and `client` while preserving default local and Turbo behavior.
+
+**Architecture:** `HashbrownOllama.stream.text()` will resolve an Ollama client before sending the chat request. Client selection precedence is `client` > `turbo` > `host` > default client. Request mutation remains isolated to `transformRequestOptions`.
+
+**Tech Stack:** TypeScript, Nx, Jest, Ollama JS SDK, Analog docs markdown.
+
+---
+
+### Task 1: Add Failing Client-Selection Tests
+
+**Files:**
+- Create: `packages/ollama/src/stream/text.fn.spec.ts`
+- Modify if needed: `packages/ollama/jest.config.ts`
+
+- [x] **Step 1: Inspect test target discovery**
+
+Run: `npx jest --config packages/ollama/jest.config.ts --listTests`
+
+Expected: identify whether non-integration unit specs are currently discovered by `nx test ollama`.
+
+- [x] **Step 2: Write failing mocked tests**
+
+Create unit tests that mock the `ollama` module and verify:
+
+```ts
+test('uses the default Ollama client when no client options are provided', async () => {
+  // arrange a mocked default client whose chat method records calls
+  // act by consuming HashbrownOllama.stream.text(...)
+  // assert defaultClient.chat was called
+});
+
+test('creates an Ollama client with the configured host', async () => {
+  // arrange mocked Ollama constructor
+  // act with host: 'http://ollama:11434'
+  // assert new Ollama({ host: 'http://ollama:11434' })
+});
+
+test('uses an explicit Ollama client when provided', async () => {
+  // arrange explicit fake client with chat
+  // act with client
+  // assert explicit client chat was called and constructor was not used
+});
+
+test('creates an Ollama Turbo client when turbo is provided', async () => {
+  // act with turbo: { apiKey: 'test-key' }
+  // assert new Ollama({ host: 'https://ollama.com', headers: { Authorization: 'Bearer test-key' } })
+});
+```
+
+- [x] **Step 3: Run tests and verify RED**
+
+Run: `npx nx test ollama`
+
+Expected: tests fail because `host` and `client` are not implemented.
+
+### Task 2: Implement Client Selection
+
+**Files:**
+- Modify: `packages/ollama/src/stream/text.fn.ts`
+
+- [x] **Step 1: Add public options**
+
+Add `client?: Ollama` and `host?: string` to `BaseOllamaTextStreamOptions`.
+
+- [x] **Step 2: Extract client resolution helper**
+
+Add:
+
+```ts
+function getOllamaClient(options: OpenAITextStreamOptions): Ollama {
+  if (options.client) return options.client;
+  if (options.turbo) return new Ollama({ host: 'https://ollama.com', headers: { Authorization: `Bearer ${options.turbo.apiKey}` } });
+  if (options.host) return new Ollama({ host: options.host });
+  return OllamaClient;
+}
+```
+
+- [x] **Step 3: Use helper in `text()`**
+
+Replace inline `turbo ? new Ollama(...) : OllamaClient` selection with `getOllamaClient(options)`.
+
+- [x] **Step 4: Run tests and verify GREEN**
+
+Run: `npx nx test ollama`
+
+Expected: unit tests pass.
+
+### Task 3: Update Integration Tests and Docs
+
+**Files:**
+- Modify: `packages/ollama/src/integration.spec.ts`
+- Modify: `www/analog/src/app/pages/docs/react/platform/ollama.md`
+- Modify: `www/analog/src/app/pages/docs/angular/platform/ollama.md`
+
+- [x] **Step 1: Update e2e tests**
+
+Replace the current pattern:
+
+```ts
+transformRequestOptions: (opts) => ({
+  ...opts,
+  ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
+}),
+```
+
+with top-level:
+
+```ts
+host: OLLAMA_HOST,
+```
+
+Keep existing `transformRequestOptions` only where it mutates real chat request options.
+
+- [x] **Step 2: Update docs**
+
+Document:
+
+- `host?: string` for local/container Ollama.
+- `client?: Ollama` for advanced SDK configuration.
+- `turbo.apiKey` for Turbo.
+- `transformRequestOptions` only changes chat request options.
+- Default local behavior uses the default Ollama client; it does not claim to honor `OLLAMA_HOST`.
+
+### Task 4: Verify and Publish
+
+**Files:**
+- All changed files.
+
+- [x] **Step 1: Run package checks**
+
+Run:
+
+```sh
+npx nx build ollama
+npx nx test ollama
+npx nx lint ollama
+npx nx build-api-report ollama
+```
+
+- [x] **Step 2: Run docs checks**
+
+Run:
+
+```sh
+npx nx build www
+```
+
+- [x] **Step 3: Run formatting guard**
+
+Run: `git diff --check`
+
+- [ ] **Step 4: Commit and open PR**
+
+Commit implementation and docs. Push branch and open a PR for issue #471.
+
+- [ ] **Step 5: Merge on green**
+
+Monitor GitHub checks. If green, mark ready and squash-merge.

--- a/docs/superpowers/specs/2026-07-06-ollama-client-options-design.md
+++ b/docs/superpowers/specs/2026-07-06-ollama-client-options-design.md
@@ -1,0 +1,152 @@
+# Ollama Client Options Design
+
+## Context
+
+Issue #471 reports that `OLLAMA_HOST` is not respected when Hashbrown's Ollama adapter runs in a different container from the Ollama server. The current adapter uses the default exported `OllamaClient` for local calls, so Hashbrown has no chance to pass a host into `new Ollama({ host })`. Existing integration tests try to pass `host` through `transformRequestOptions`, but `host` is client configuration, not a chat request option.
+
+Provider comparison:
+
+- OpenAI and Anthropic expose `baseURL` for endpoint-like configuration.
+- Azure exposes `endpoint`.
+- Google exposes explicit auth mode fields.
+- Bedrock exposes `client?: BedrockRuntimeClient` plus common constructor fields.
+
+Ollama is closest to Bedrock because local/container deployments may need either a simple host URL or a fully configured SDK client.
+
+## Goals
+
+- Fix #471 with an explicit public `host` option for the common Docker/container case.
+- Keep the API surface small.
+- Add a `client` escape hatch for advanced Ollama SDK configuration.
+- Preserve existing default local behavior when no client options are provided.
+- Preserve existing Turbo behavior.
+- Clarify that `transformRequestOptions` only mutates the chat request.
+
+## Non-Goals
+
+- Do not add more implicit environment-variable behavior.
+- Do not expose every Ollama SDK constructor option directly through Hashbrown.
+- Do not change Hashbrown's chat request shape or streaming frame behavior.
+
+## API Design
+
+Extend `HashbrownOllama.stream.text(options)` with two local client options:
+
+```ts
+type BaseOllamaTextStreamOptions = {
+  request: Chat.Api.CompletionCreateParams;
+  client?: Ollama;
+  host?: string;
+  turbo?: { apiKey: string };
+  transformRequestOptions?: (
+    options: ChatRequest & { stream: true },
+  ) =>
+    | (ChatRequest & { stream: true })
+    | Promise<ChatRequest & { stream: true }>;
+};
+```
+
+Document precedence:
+
+1. `client`
+2. `turbo`
+3. `host`
+4. default Ollama client
+
+The API intentionally exposes only `host` as a convenience field. Advanced configuration such as custom headers, fetch, or proxy should use `client`.
+
+## Implementation Sketch
+
+```ts
+function getOllamaClient(options: OllamaTextStreamOptions): Ollama {
+  if (options.client) {
+    return options.client;
+  }
+
+  if (options.turbo) {
+    return new Ollama({
+      host: 'https://ollama.com',
+      headers: {
+        Authorization: `Bearer ${options.turbo.apiKey}`,
+      },
+    });
+  }
+
+  if (options.host) {
+    return new Ollama({
+      host: options.host,
+    });
+  }
+
+  return OllamaClient;
+}
+```
+
+`text()` should call `getOllamaClient(options)` and then call `client.chat(resolvedOptions)` as it does today.
+
+## Developer Documentation
+
+Update React and Angular Ollama platform docs.
+
+Simple containerized local Ollama:
+
+```ts
+HashbrownOllama.stream.text({
+  host: 'http://ollama:11434',
+  request: req.body,
+});
+```
+
+Advanced client configuration:
+
+```ts
+import { Ollama } from 'ollama';
+
+const client = new Ollama({
+  host: 'http://ollama:11434',
+  headers: {
+    'x-service': 'hashbrown',
+  },
+});
+
+HashbrownOllama.stream.text({
+  client,
+  request: req.body,
+});
+```
+
+Turbo:
+
+```ts
+HashbrownOllama.stream.text({
+  turbo: {
+    apiKey: process.env.OLLAMA_API_KEY!,
+  },
+  request: req.body,
+});
+```
+
+Docs should remove claims that the default local path honors `OLLAMA_HOST`. Instead, state that callers should pass `host` or a preconfigured `client`.
+
+## Testing
+
+Add focused unit coverage with the `ollama` module mocked:
+
+- Default local path uses the default exported Ollama client.
+- `host` creates `new Ollama({ host })`.
+- `client` uses the supplied client directly.
+- `turbo` creates `new Ollama({ host: 'https://ollama.com', headers: { Authorization: ... } })`.
+- `transformRequestOptions` continues to mutate only the chat request options.
+
+Update integration tests to pass `host: OLLAMA_HOST` when `OLLAMA_HOST` is set, instead of adding `host` to `transformRequestOptions`.
+
+Verification commands:
+
+```sh
+npx nx build ollama
+npx nx test ollama
+npx nx lint ollama
+npx nx build-api-report ollama
+```
+
+Run `npx nx e2e ollama` when a reachable Ollama or Turbo configuration is available.

--- a/packages/ollama/jest.config.ts
+++ b/packages/ollama/jest.config.ts
@@ -7,5 +7,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/ollama',
-  testPathIgnorePatterns: ['(?!.*integration).*\\.ts$'],
+  testPathIgnorePatterns: ['.*integration\\.spec\\.ts$'],
 };

--- a/packages/ollama/src/integration.spec.ts
+++ b/packages/ollama/src/integration.spec.ts
@@ -17,12 +17,8 @@ test('Ollama Text Streaming', async () => {
       turbo: OLLAMA_TURBO_API_KEY
         ? { apiKey: OLLAMA_TURBO_API_KEY }
         : undefined,
+      host: OLLAMA_HOST,
       request,
-      transformRequestOptions: (opts) => ({
-        ...opts,
-        // Allow overriding host for local daemon when provided
-        ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
-      }),
     }),
   );
   try {
@@ -68,11 +64,8 @@ test('Ollama Tool Calling', async () => {
       turbo: OLLAMA_TURBO_API_KEY
         ? { apiKey: OLLAMA_TURBO_API_KEY }
         : undefined,
+      host: OLLAMA_HOST,
       request,
-      transformRequestOptions: (opts) => ({
-        ...opts,
-        ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
-      }),
     }),
   );
 
@@ -149,11 +142,8 @@ test('Ollama with structured output', async () => {
       turbo: OLLAMA_TURBO_API_KEY
         ? { apiKey: OLLAMA_TURBO_API_KEY }
         : undefined,
+      host: OLLAMA_HOST,
       request,
-      transformRequestOptions: (opts) => ({
-        ...opts,
-        ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
-      }),
     }),
   );
 
@@ -201,11 +191,8 @@ test('Ollama with tool calling and structured output', async () => {
       turbo: OLLAMA_TURBO_API_KEY
         ? { apiKey: OLLAMA_TURBO_API_KEY }
         : undefined,
+      host: OLLAMA_HOST,
       request,
-      transformRequestOptions: (opts) => ({
-        ...opts,
-        ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
-      }),
     }),
   );
 
@@ -277,11 +264,8 @@ test('Ollama supports thread IDs across turns', async () => {
       turbo: OLLAMA_TURBO_API_KEY
         ? { apiKey: OLLAMA_TURBO_API_KEY }
         : undefined,
+      host: OLLAMA_HOST,
       request: incomingRequest,
-      transformRequestOptions: (opts) => ({
-        ...opts,
-        ...(OLLAMA_HOST ? { host: OLLAMA_HOST } : {}),
-      }),
       loadThread: async (threadId: string) =>
         threadMessages.get(threadId) ?? [],
       saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {

--- a/packages/ollama/src/stream/text.fn.spec.ts
+++ b/packages/ollama/src/stream/text.fn.spec.ts
@@ -1,0 +1,185 @@
+import OllamaClient, { Ollama } from 'ollama';
+import { Chat } from '@hashbrownai/core';
+import { text } from './text.fn';
+
+jest.mock('ollama', () => {
+  const defaultClient = {
+    chat: jest.fn(),
+  };
+
+  return {
+    __esModule: true,
+    default: defaultClient,
+    Ollama: jest.fn(),
+  };
+});
+
+const MockedOllama = jest.mocked(Ollama);
+const mockedDefaultClient = jest.mocked(OllamaClient);
+
+test('uses the default Ollama client when no client options are provided', async () => {
+  resetOllamaMocks();
+  const defaultChat = jest.fn().mockResolvedValue(createOllamaStream());
+  mockedDefaultClient.chat = defaultChat;
+  const request = createRequest();
+
+  await consumeStream(
+    text({
+      request,
+    }),
+  );
+
+  expect(defaultChat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: request.model,
+      stream: true,
+    }),
+  );
+  expect(MockedOllama).not.toHaveBeenCalled();
+});
+
+test('creates an Ollama client with the configured host', async () => {
+  resetOllamaMocks();
+  const chat = jest.fn().mockResolvedValue(createOllamaStream());
+  MockedOllama.mockImplementationOnce(() => ({ chat }) as unknown as Ollama);
+  const request = createRequest();
+
+  await consumeStream(
+    text({
+      host: 'http://ollama:11434',
+      request,
+    }),
+  );
+
+  expect(MockedOllama).toHaveBeenCalledWith({
+    host: 'http://ollama:11434',
+  });
+  expect(chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: request.model,
+      stream: true,
+    }),
+  );
+});
+
+test('uses an explicit Ollama client when provided', async () => {
+  resetOllamaMocks();
+  const chat = jest.fn().mockResolvedValue(createOllamaStream());
+  const client = { chat } as unknown as Ollama;
+  const request = createRequest();
+
+  await consumeStream(
+    text({
+      client,
+      host: 'http://ollama:11434',
+      turbo: { apiKey: 'test-api-key' },
+      request,
+    }),
+  );
+
+  expect(chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: request.model,
+      stream: true,
+    }),
+  );
+  expect(MockedOllama).not.toHaveBeenCalled();
+});
+
+test('creates an Ollama Turbo client before the configured host when turbo is provided', async () => {
+  resetOllamaMocks();
+  const chat = jest.fn().mockResolvedValue(createOllamaStream());
+  MockedOllama.mockImplementationOnce(() => ({ chat }) as unknown as Ollama);
+  const request = createRequest();
+
+  await consumeStream(
+    text({
+      host: 'http://ollama:11434',
+      turbo: { apiKey: 'test-api-key' },
+      request,
+    }),
+  );
+
+  expect(MockedOllama).toHaveBeenCalledWith({
+    host: 'https://ollama.com',
+    headers: {
+      Authorization: 'Bearer test-api-key',
+    },
+  });
+  expect(chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: request.model,
+      stream: true,
+    }),
+  );
+});
+
+test('passes transformed request options to the selected client', async () => {
+  resetOllamaMocks();
+  const chat = jest.fn().mockResolvedValue(createOllamaStream());
+  mockedDefaultClient.chat = chat;
+
+  await consumeStream(
+    text({
+      request: createRequest(),
+      transformRequestOptions: (options) => ({
+        ...options,
+        options: {
+          temperature: 0,
+        },
+      }),
+    }),
+  );
+
+  expect(chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      options: {
+        temperature: 0,
+      },
+    }),
+  );
+});
+
+async function consumeStream(stream: AsyncIterable<Uint8Array>): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+    // Consume the stream so client selection and chat execution happen.
+  }
+}
+
+function resetOllamaMocks(): void {
+  MockedOllama.mockReset();
+  mockedDefaultClient.chat = jest.fn().mockResolvedValue(createOllamaStream());
+}
+
+function createRequest(): Chat.Api.CompletionCreateParams {
+  return {
+    operation: 'generate',
+    model: 'llama3.2',
+    system: 'Respond tersely.',
+    messages: [
+      {
+        role: 'user',
+        content: 'Hello',
+      },
+    ],
+  };
+}
+
+async function* createOllamaStream() {
+  yield {
+    done: false,
+    message: {
+      role: 'assistant',
+      content: 'Hello',
+    },
+  };
+
+  yield {
+    done: true,
+    message: {
+      role: 'assistant',
+      content: '',
+    },
+  };
+}

--- a/packages/ollama/src/stream/text.fn.ts
+++ b/packages/ollama/src/stream/text.fn.ts
@@ -9,13 +9,26 @@ import OllamaClient, { ChatRequest, Message, Ollama, ToolCall } from 'ollama';
 import { FunctionParameters } from 'openai/resources/shared';
 
 type BaseOllamaTextStreamOptions = {
+  /**
+   * Preconfigured Ollama SDK client for advanced transport settings.
+   * Takes precedence over `turbo` and `host`.
+   */
+  client?: Ollama;
+  /**
+   * Ollama host URL used to create an SDK client when `client` and `turbo`
+   * are omitted.
+   */
+  host?: string;
+  /**
+   * Ollama Turbo credentials. Takes precedence over `host` when `client` is
+   * omitted.
+   */
   turbo?: { apiKey: string };
   request: Chat.Api.CompletionCreateParams;
   transformRequestOptions?: (
     options: ChatRequest & { stream: true },
   ) =>
-    | (ChatRequest & { stream: true })
-    | Promise<ChatRequest & { stream: true }>;
+    (ChatRequest & { stream: true }) | Promise<ChatRequest & { stream: true }>;
 };
 
 type ThreadPersistenceOptions = {
@@ -41,8 +54,7 @@ export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
 export async function* text(
   options: OpenAITextStreamOptions,
 ): AsyncIterable<Uint8Array> {
-  const { turbo, request, transformRequestOptions, loadThread, saveThread } =
-    options;
+  const { request, transformRequestOptions, loadThread, saveThread } = options;
   const { model, tools, responseFormat, system } = request;
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
@@ -121,17 +133,15 @@ export async function* text(
               content: message.content ?? '',
               tool_calls:
                 message.toolCalls && message.toolCalls.length > 0
-                  ? message.toolCalls.map(
-                      (toolCall): ToolCall => ({
-                        ...toolCall,
-                        function: {
-                          ...toolCall.function,
-                          arguments: normalizeToolArguments(
-                            toolCall.function.arguments,
-                          ),
-                        },
-                      }),
-                    )
+                  ? message.toolCalls.map((toolCall): ToolCall => ({
+                      ...toolCall,
+                      function: {
+                        ...toolCall.function,
+                        arguments: normalizeToolArguments(
+                          toolCall.function.arguments,
+                        ),
+                      },
+                    }))
                   : undefined,
             };
           }
@@ -165,14 +175,7 @@ export async function* text(
         ? await transformRequestOptions(baseOptions)
         : baseOptions;
 
-    const client = turbo
-      ? new Ollama({
-          host: 'https://ollama.com',
-          headers: {
-            Authorization: `Bearer ${turbo.apiKey}`,
-          },
-        })
-      : OllamaClient;
+    const client = getClient(options);
 
     const stream = await client.chat(resolvedOptions);
 
@@ -251,6 +254,29 @@ export async function* text(
       return;
     }
   }
+}
+
+function getClient(options: OpenAITextStreamOptions): Ollama {
+  if (options.client) {
+    return options.client;
+  }
+
+  if (options.turbo) {
+    return new Ollama({
+      host: 'https://ollama.com',
+      headers: {
+        Authorization: `Bearer ${options.turbo.apiKey}`,
+      },
+    });
+  }
+
+  if (options.host) {
+    return new Ollama({
+      host: options.host,
+    });
+  }
+
+  return OllamaClient;
 }
 
 function normalizeError(error: unknown): { message: string; stack?: string } {

--- a/www/analog/src/app/pages/docs/angular/platform/ollama.md
+++ b/www/analog/src/app/pages/docs/angular/platform/ollama.md
@@ -26,7 +26,9 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 
 | Name                       | Type                              | Description                                                                                        |
 | -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key. Defaults to local Ollama via `OLLAMA_HOST`. |
+| `host`                     | `string`                          | _(Optional)_ Ollama host URL, such as `http://localhost:11434` or a container host.                |
+| `client`                   | `Ollama`                          | _(Optional)_ Preconfigured Ollama SDK client for advanced transport settings.                      |
+| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key.                                             |
 | `request`                  | `Chat.Api.CompletionCreateParams` | The chat request: model, messages, tools, system, `responseFormat`, etc.                           |
 | `transformRequestOptions`  | `function`                        | _(Optional)_ Async function to transform Ollama request options before sending (e.g., for `think` parameter). |
 
@@ -37,7 +39,7 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 - **Response Format:** Optionally specify a JSON schema in `responseFormat` (forwarded to Ollama `format`)
 - **System Prompt:** Included as the first message if provided
 - **Streaming:** Each chunk is encoded into a resilient streaming format
-- **Local or Turbo:** Connects to local Ollama by default; set `turbo.apiKey` to use Ollama Turbo
+- **Local, Hosted, or Turbo:** Connects to the default Ollama client, a configured `host`, an explicit `client`, or Ollama Turbo
 
 ---
 
@@ -48,8 +50,10 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 - **Response Format:** Pass a JSON schema in `responseFormat`; forwarded to Ollama as `format` for structured output.
 - **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
 - **Client Selection:**
-  - Default: local Ollama via the `ollama` Node client (honors `OLLAMA_HOST`)
-  - Turbo: set `turbo.apiKey` to route via Turbo
+  - `client`: use a preconfigured Ollama SDK client
+  - `turbo.apiKey`: route requests through Ollama Turbo
+  - `host`: create an Ollama SDK client for the configured host URL
+  - Default: use the default `ollama` Node client
 - **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
 
 ---
@@ -69,6 +73,8 @@ app.use(express.json());
 
 app.post('/chat', async (req, res) => {
   const stream = HashbrownOllama.stream.text({
+    // Optional: connect to a remote or containerized Ollama server
+    // host: 'http://ollama:11434',
     // Optional: use Ollama Turbo
     // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
     request: req.body, // must be Chat.Api.CompletionCreateParams
@@ -194,7 +200,7 @@ export default app;
 
 ### Transform Request Options
 
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to Ollama. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
+The `transformRequestOptions` parameter allows you to intercept and modify the chat request before it's sent to Ollama. Use `host` or `client` for transport settings such as the Ollama server URL.
 
 <hb-backend-code-example>
 

--- a/www/analog/src/app/pages/docs/react/platform/ollama.md
+++ b/www/analog/src/app/pages/docs/react/platform/ollama.md
@@ -26,7 +26,9 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 
 | Name                       | Type                              | Description                                                                                        |
 | -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key. Defaults to local Ollama via `OLLAMA_HOST`. |
+| `host`                     | `string`                          | _(Optional)_ Ollama host URL, such as `http://localhost:11434` or a container host.                |
+| `client`                   | `Ollama`                          | _(Optional)_ Preconfigured Ollama SDK client for advanced transport settings.                      |
+| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key.                                             |
 | `request`                  | `Chat.Api.CompletionCreateParams` | The chat request: model, messages, tools, system, `responseFormat`, etc.                           |
 | `transformRequestOptions`  | `function`                        | _(Optional)_ Async function to transform Ollama request options before sending (e.g., for `think` parameter). |
 
@@ -37,7 +39,7 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 - **Response Format:** Optionally specify a JSON schema in `responseFormat` (forwarded to Ollama `format`)
 - **System Prompt:** Included as the first message if provided
 - **Streaming:** Each chunk is encoded into a resilient streaming format
-- **Local or Turbo:** Connects to local Ollama by default; set `turbo.apiKey` to use Ollama Turbo
+- **Local, Hosted, or Turbo:** Connects to the default Ollama client, a configured `host`, an explicit `client`, or Ollama Turbo
 
 ---
 
@@ -48,8 +50,10 @@ Streams an Ollama chat completion as a series of encoded frames. Handles content
 - **Response Format:** Pass a JSON schema in `responseFormat`; forwarded to Ollama as `format` for structured output.
 - **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
 - **Client Selection:**
-  - Default: local Ollama via the `ollama` Node client (honors `OLLAMA_HOST`)
-  - Turbo: set `turbo.apiKey` to route via Turbo
+  - `client`: use a preconfigured Ollama SDK client
+  - `turbo.apiKey`: route requests through Ollama Turbo
+  - `host`: create an Ollama SDK client for the configured host URL
+  - Default: use the default `ollama` Node client
 - **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
 
 ---
@@ -69,6 +73,8 @@ app.use(express.json());
 
 app.post('/chat', async (req, res) => {
   const stream = HashbrownOllama.stream.text({
+    // Optional: connect to a remote or containerized Ollama server
+    // host: 'http://ollama:11434',
     // Optional: use Ollama Turbo
     // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
     request: req.body, // must be Chat.Api.CompletionCreateParams
@@ -194,7 +200,7 @@ export default app;
 
 ### Transform Request Options
 
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to Ollama. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
+The `transformRequestOptions` parameter allows you to intercept and modify the chat request before it's sent to Ollama. Use `host` or `client` for transport settings such as the Ollama server URL.
 
 <hb-backend-code-example>
 


### PR DESCRIPTION
## Summary
- add explicit `host` and `client` options for the Ollama stream transport
- preserve client resolution precedence: `client` > `turbo` > `host` > default Ollama client
- update Ollama e2e call sites and React/Angular docs to stop treating host as a chat request option

Closes #471.

## Validation
- `npx nx build ollama`
- `npx nx test ollama`
- `npx nx lint ollama` (0 errors; existing `no-explicit-any` warnings remain in `text.fn.ts`)
- `npx nx build-api-report ollama` (exits 0; existing missing-release-tag warnings remain)
- `npx nx build www` (exits 0; existing docs/API/bundle warnings remain)
- `git diff --check`

## Local e2e note
`NODE_OPTIONS="-r dotenv/config" DOTENV_CONFIG_PATH=/Users/blove/repos/hashbrown/.env npx nx e2e ollama` could not complete locally because the configured local Ollama server only has `qwen2.5:14b`, while the suite is hardcoded to `gpt-oss:120b`.
