### PR TITLE
feat: support documented message history

### DIFF
--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHashbrown } from '../providers/provide-hashbrown.fn';
+import { chatResource } from './chat-resource.fn';
+
+test('chatResource initializes with the provided message history', () => {
+  const messages = [
+    {
+      role: 'user' as const,
+      content: 'Summarize the previous order.',
+    },
+  ];
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  const chat = TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      system: 'You are a helpful assistant.',
+      messages,
+    }),
+  );
+
+  expect(chat.value()).toEqual(messages);
+});
+
+test('chatResource allows replacing message history', () => {
+  const initialMessages = [
+    {
+      role: 'user' as const,
+      content: 'Summarize the previous order.',
+    },
+  ];
+  const nextMessages = [
+    {
+      role: 'user' as const,
+      content: 'Keep only this follow-up.',
+    },
+  ];
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  const chat = TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      system: 'You are a helpful assistant.',
+      messages: initialMessages,
+    }),
+  );
+
+  chat.setMessages(nextMessages);
+
+  expect(chat.value()).toEqual(nextMessages);
+});

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -28,8 +28,9 @@ import { bindToolToInjector } from '../utils/create-tool.fn';
  * @param sendMessage - Send a new user message to the chat.
  * @param reload - Remove the last assistant response and re-send the previous user message. Returns true if a reload was performed.
  */
-export interface ChatResourceRef<Tools extends Chat.AnyTool>
-  extends Resource<Chat.Message<string, Tools>[]> {
+export interface ChatResourceRef<Tools extends Chat.AnyTool> extends Resource<
+  Chat.Message<string, Tools>[]
+> {
   /** Indicates whether the chat is currently receiving tokens. */
   isReceiving: Signal<boolean>;
   /** Indicates whether the chat is currently sending a user message. */
@@ -58,6 +59,13 @@ export interface ChatResourceRef<Tools extends Chat.AnyTool>
    * @param message - The user message to send.
    */
   sendMessage: (message: Chat.UserMessage) => void;
+
+  /**
+   * Replace the current chat message history.
+   *
+   * @param messages - The new array of chat messages.
+   */
+  setMessages: (messages: Chat.Message<string, Tools>[]) => void;
 
   /**
    * Stops any currently-streaming message.
@@ -119,8 +127,7 @@ export interface ChatResourceOptions<Tools extends Chat.AnyTool> {
    * @typeParam Tools - The set of tool definitions available to the chat.
    */
   messages?:
-    | Chat.Message<string, Tools>[]
-    | Signal<Chat.Message<string, Tools>[]>;
+    Chat.Message<string, Tools>[] | Signal<Chat.Message<string, Tools>[]>;
 
   /**
    * The debounce time for the chat.
@@ -184,6 +191,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
         runInInjectionContext(injector, () => m(requestInit));
     }),
     system: readSignalLike(options.system),
+    messages: options.messages ? [...readSignalLike(options.messages)] : [],
     model: readSignalLike(options.model),
     tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
     emulateStructuredOutput: config.emulateStructuredOutput,
@@ -297,6 +305,10 @@ export function chatResource<Tools extends Chat.AnyTool>(
     hashbrown.sendMessage(message);
   }
 
+  function setMessages(messages: Chat.Message<string, Tools>[]) {
+    hashbrown.setMessages(messages);
+  }
+
   function stop(clearStreamingMessage = false) {
     hashbrown.stop(clearStreamingMessage);
   }
@@ -317,6 +329,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
     threadSaveError,
     reload,
     sendMessage,
+    setMessages,
     stop,
     value,
     error,

--- a/packages/react/src/hooks/use-chat.spec.tsx
+++ b/packages/react/src/hooks/use-chat.spec.tsx
@@ -1,129 +1,29 @@
-// /* eslint-disable @typescript-eslint/no-explicit-any */
-// import { render, screen } from '@testing-library/react';
-// import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { HashbrownProvider } from '../hashbrown-provider';
+import { useChat } from './use-chat';
 
-// import { HashbrownProvider } from '../hashbrown-provider';
-// import { useTool } from './use-tool';
-// import { useChat } from './use-chat';
+test('useChat initializes with the provided message history', () => {
+  const messages = [
+    {
+      role: 'user' as const,
+      content: 'Summarize the previous order.',
+    },
+  ];
 
-test('uncomment the tests and delete me', () => {
-  expect(true).toBe(true);
+  const { result } = renderHook(
+    () =>
+      useChat({
+        model: 'gpt-4.1',
+        system: 'You are a helpful assistant.',
+        messages,
+      }),
+    { wrapper: ProviderWrapper },
+  );
+
+  expect(result.current.messages).toEqual(messages);
 });
 
-// vi.mock('@hashbrownai/core', async () => {
-//   const originalModule = (await vi.importActual(
-//     '@hashbrownai/core',
-//   )) as typeof import('@hashbrownai/core');
-
-//   const updateOptions = vi.fn();
-//   const fryHashbrown = vi.fn(
-//     (options: {
-//       messages: Chat.Message<string, Chat.AnyTool>[];
-//       system: string;
-//     }) => {
-//       return {
-//         messages: options.messages,
-//         error: undefined,
-//         teardown: vi.fn(),
-//         setMessages: vi.fn(),
-//         sendMessage: vi.fn(),
-//         stop: vi.fn(),
-//         resendMessages: vi.fn(),
-//         updateOptions,
-//         observeIsReceiving: vi.fn(),
-//         observeMessages: vi.fn(),
-//         observeIsSending: vi.fn(),
-//         observeIsRunningToolCalls: vi.fn(),
-//         observeError: vi.fn(),
-//         observeExhaustedRetries: vi.fn(),
-//         observeIsLoading: vi.fn(),
-//       } as Hashbrown<unknown, Chat.AnyTool>;
-//     },
-//   );
-
-//   (fryHashbrown as any).updateOptions = updateOptions;
-
-//   return {
-//     ...originalModule,
-//     fryHashbrown,
-//   };
-// });
-
-// afterEach(() => {
-//   shouldRegenerateHandler = false;
-//   vi.clearAllMocks();
-// });
-
-// const ProviderWrapper = ({ children }: { children: React.ReactNode }) => (
-//   <HashbrownProvider url="localhost">{children}</HashbrownProvider>
-// );
-
-// let shouldRegenerateHandler = false;
-
-// const TestComponent = () => {
-//   const searchRestaurantTool = useTool({
-//     name: 'Restaurant Search',
-//     description: 'Search for restaurants based on location and cuisine.',
-//     schema: s.object('RestaurantSearchParams', {
-//       location: s.string('Location'),
-//       cuisine: s.string('Cuisine'),
-//       radius: s.number('Radius'), // in miles
-//     }),
-//     handler: async () => vi.fn(),
-//     deps: [shouldRegenerateHandler],
-//   });
-//   const { messages } = useChat({
-//     model: 'gpt-4o',
-//     tools: [searchRestaurantTool],
-//     system: 'You are a helpful assistant.',
-//     messages: [
-//       {
-//         role: 'user',
-//         content: 'Can you help me find a restaurant?',
-//       },
-//     ],
-//   });
-
-//   return (
-//     <div>
-//       {messages.map((msg, index) => (
-//         <div key={index}>{JSON.stringify(msg.content)}</div>
-//       ))}
-//     </div>
-//   );
-// };
-
-// it('should initialize with default values', () => {
-//   render(<TestComponent />, { wrapper: ProviderWrapper });
-
-//   expect(
-//     screen.getByText('"Can you help me find a restaurant?"'),
-//   ).toBeInTheDocument();
-// });
-
-// it('should not regenerate Hashbrown on a typical render', () => {
-//   const { rerender } = render(<TestComponent />, {
-//     wrapper: ProviderWrapper,
-//   });
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(1);
-
-//   rerender(<TestComponent />);
-
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(2);
-// });
-
-// it('should not regenerate Hashbrown even when a tool has a changed dependency', () => {
-//   const { rerender } = render(<TestComponent />, {
-//     wrapper: ProviderWrapper,
-//   });
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(1);
-
-//   shouldRegenerateHandler = true; // Change the handler to trigger re-render
-//   rerender(<TestComponent />);
-
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(2);
-// });
+function ProviderWrapper({ children }: { children: ReactNode }) {
+  return <HashbrownProvider url="/chat">{children}</HashbrownProvider>;
+}

--- a/packages/react/src/hooks/use-chat.tsx
+++ b/packages/react/src/hooks/use-chat.tsx
@@ -236,6 +236,7 @@ export function useChat<Tools extends Chat.AnyTool>(
       debugName: options.debugName,
       model: options.model,
       system: options.system,
+      messages: [...(options.messages ?? [])],
       tools,
       debounce: options.debounceTime,
       retries: options.retries,

--- a/packages/react/src/hooks/use-structured-chat.spec.tsx
+++ b/packages/react/src/hooks/use-structured-chat.spec.tsx
@@ -1,130 +1,33 @@
-// /* eslint-disable @typescript-eslint/no-explicit-any */
-// import { type Chat, fryHashbrown, type Hashbrown, s } from '@hashbrownai/core';
-// import { render, screen } from '@testing-library/react';
-// import { HashbrownProvider } from '../hashbrown-provider';
-// import { useStructuredChat } from './use-structured-chat';
-// import { useTool } from './use-tool';
+import { renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { s } from '@hashbrownai/core';
+import { HashbrownProvider } from '../hashbrown-provider';
+import { useStructuredChat } from './use-structured-chat';
 
-test('uncomment the tests and delete me', () => {
-  expect(true).toBe(true);
+test('useStructuredChat initializes with the provided message history', () => {
+  const messages = [
+    {
+      role: 'user' as const,
+      content: 'What is the current portfolio risk?',
+    },
+  ];
+
+  const { result } = renderHook(
+    () =>
+      useStructuredChat({
+        model: 'gpt-4.1',
+        system: 'You are a portfolio analyst.',
+        schema: s.object('risk summary', {
+          risk: s.string('Risk level'),
+        }),
+        messages,
+      }),
+    { wrapper: ProviderWrapper },
+  );
+
+  expect(result.current.messages).toEqual(messages);
 });
 
-// vi.mock('@hashbrownai/core', async () => {
-//   const originalModule = (await vi.importActual(
-//     '@hashbrownai/core',
-//   )) as typeof import('@hashbrownai/core');
-
-//   const updateOptions = vi.fn();
-//   const fryHashbrown = vi.fn(
-//     (options: {
-//       messages: Chat.Message<string, Chat.AnyTool>[];
-//       system: string;
-//     }) => {
-//       return {
-//         messages: options.messages,
-//         error: undefined,
-//         teardown: vi.fn(),
-//         setMessages: vi.fn(),
-//         sendMessage: vi.fn(),
-//         stop: vi.fn(),
-//         resendMessages: vi.fn(),
-//         updateOptions,
-//         observeIsReceiving: vi.fn(),
-//         observeMessages: vi.fn(),
-//         observeIsSending: vi.fn(),
-//         observeIsRunningToolCalls: vi.fn(),
-//         observeError: vi.fn(),
-//         observeExhaustedRetries: vi.fn(),
-//         observeIsLoading: vi.fn(),
-//       } as Hashbrown<unknown, Chat.AnyTool>;
-//     },
-//   );
-
-//   (fryHashbrown as any).updateOptions = updateOptions;
-
-//   return {
-//     ...originalModule,
-//     fryHashbrown,
-//   };
-// });
-
-// afterEach(() => {
-//   vi.clearAllMocks();
-// });
-
-// const ProviderWrapper = ({ children }: { children: React.ReactNode }) => (
-//   <HashbrownProvider url="localhost">{children}</HashbrownProvider>
-// );
-
-// let shouldRegenerateHandler = false;
-
-// const TestComponent = () => {
-//   const searchRestaurantTool = useTool({
-//     name: 'Restaurant Search',
-//     description: 'Search for restaurants based on location and cuisine.',
-//     schema: s.object('RestaurantSearchParams', {
-//       location: s.string('Location'),
-//       cuisine: s.string('Cuisine'),
-//       radius: s.number('Radius'), // in miles
-//     }),
-//     handler: async () => vi.fn(),
-//     deps: [shouldRegenerateHandler],
-//   });
-//   const { messages } = useStructuredChat({
-//     model: 'gpt-4o',
-//     tools: [searchRestaurantTool],
-//     system: 'You are a helpful assistant.',
-//     messages: [
-//       {
-//         role: 'user',
-//         content: 'Can you help me find a restaurant?',
-//       },
-//     ],
-//     schema: s.object('TestSchema', {
-//       name: s.string('Name'),
-//     }),
-//   });
-
-//   return (
-//     <div>
-//       {messages.map((msg, index) => (
-//         <div key={index}>{JSON.stringify(msg.content)}</div>
-//       ))}
-//     </div>
-//   );
-// };
-
-// it('should initialize with default values', () => {
-//   render(<TestComponent />, { wrapper: ProviderWrapper });
-
-//   expect(
-//     screen.getByText('"Can you help me find a restaurant?"'),
-//   ).toBeInTheDocument();
-// });
-
-// it('should not regenerate Hashbrown on a typical render', () => {
-//   const { rerender } = render(<TestComponent />, {
-//     wrapper: ProviderWrapper,
-//   });
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(1);
-
-//   rerender(<TestComponent />);
-
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(2);
-// });
-
-// it('should not regenerate Hashbrown even when a tool has a changed dependency', () => {
-//   const { rerender } = render(<TestComponent />, {
-//     wrapper: ProviderWrapper,
-//   });
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(1);
-
-//   shouldRegenerateHandler = true; // Change the handler to trigger re-render
-//   rerender(<TestComponent />);
-
-//   expect(fryHashbrown).toHaveBeenCalledTimes(1);
-//   expect((fryHashbrown as any).updateOptions).toHaveBeenCalledTimes(2);
-// });
+function ProviderWrapper({ children }: { children: ReactNode }) {
+  return <HashbrownProvider url="/chat">{children}</HashbrownProvider>;
+}

--- a/packages/react/src/hooks/use-structured-chat.tsx
+++ b/packages/react/src/hooks/use-structured-chat.tsx
@@ -247,6 +247,7 @@ export function useStructuredChat<
       model: options.model,
       system: options.system,
       responseSchema: schema,
+      messages: [...(options.messages ?? [])],
       tools,
       debugName: options.debugName,
       debounce: options.debounceTime,

--- a/www/analog/src/app/components/DocsMenu.ts
+++ b/www/analog/src/app/components/DocsMenu.ts
@@ -158,10 +158,18 @@ import { Squircle } from './Squircle';
         </li>
         <li>
           <a
+            [routerLink]="[docsUrl(), 'concept', 'message-history']"
+            routerLinkActive="active"
+            wwwSquircle="8"
+            >3. Message History</a
+          >
+        </li>
+        <li>
+          <a
             [routerLink]="[docsUrl(), 'concept', 'schema']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >3. Skillet Schema</a
+            >4. Skillet Schema</a
           >
         </li>
         <li>
@@ -169,7 +177,7 @@ import { Squircle } from './Squircle';
             [routerLink]="[docsUrl(), 'concept', 'streaming']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >4. Streaming</a
+            >5. Streaming</a
           >
         </li>
         <li>
@@ -177,7 +185,7 @@ import { Squircle } from './Squircle';
             [routerLink]="[docsUrl(), 'concept', 'functions']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >5. Tool Calling</a
+            >6. Tool Calling</a
           >
         </li>
         <li>
@@ -185,7 +193,7 @@ import { Squircle } from './Squircle';
             [routerLink]="[docsUrl(), 'concept', 'structured-output']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >6. Structured Output</a
+            >7. Structured Output</a
           >
         </li>
         <li>
@@ -193,7 +201,7 @@ import { Squircle } from './Squircle';
             [routerLink]="[docsUrl(), 'concept', 'components']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >7. Generative UI</a
+            >8. Generative UI</a
           >
         </li>
         <li>
@@ -201,7 +209,7 @@ import { Squircle } from './Squircle';
             [routerLink]="[docsUrl(), 'concept', 'runtime']"
             routerLinkActive="active"
             wwwSquircle="8"
-            >8. JavaScript Runtime</a
+            >9. JavaScript Runtime</a
           >
         </li>
       </ol>

--- a/www/analog/src/app/pages/docs/angular/concept/message-history.md
+++ b/www/analog/src/app/pages/docs/angular/concept/message-history.md
@@ -1,0 +1,177 @@
+---
+title: 'Message History: Hashbrown Angular Docs'
+meta:
+  - name: description
+    content: 'Persist, restore, and mutate Hashbrown chat message history in Angular.'
+---
+# Message History
+
+<p class="subtitle">Persist, restore, and prune the messages your chat sends to the model.</p>
+
+Hashbrown keeps chat state in a `messages` array. Each turn appends user, assistant, tool, and error messages to that array, and each request sends the current history so the model has conversational context.
+
+Use message history when you want to:
+
+1. Restore a chat after a page refresh
+2. Persist conversations to local storage or your backend
+3. Remove or summarize older turns before the next request
+4. Let users delete or retry part of a conversation
+
+---
+
+## Initialize with Stored Messages
+
+Pass `messages` when you create the resource. Hashbrown uses this array as the initial chat history.
+
+<hb-code-example header="support-chat.component.ts">
+
+```ts
+import { Component, effect } from '@angular/core';
+import { type Chat } from '@hashbrownai/core';
+import { chatResource } from '@hashbrownai/angular';
+
+const STORAGE_KEY = "support-chat-messages";
+
+function loadMessages(): Chat.Message<string, Chat.AnyTool>[] {
+  if (typeof window === "undefined") return [];
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return [];
+  }
+}
+
+@Component({
+  selector: 'app-support-chat',
+  standalone: true,
+  template: `
+    @for (message of chat.value(); track $index) {
+      <p>{{ message.content }}</p>
+    }
+  `,
+})
+export class SupportChatComponent {
+  chat = chatResource({
+    model: 'gpt-4.1',
+    system: 'You are a helpful support assistant.',
+    messages: loadMessages(),
+  });
+
+  constructor() {
+    effect(() => {
+      if (typeof window === "undefined") return;
+
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(this.chat.value()),
+      );
+    });
+  }
+}
+```
+
+</hb-code-example>
+
+Keep the stored value as plain JSON. Do not store functions, component references, `Promise` values, or provider-specific request objects in message history.
+
+---
+
+## Replace History with `setMessages`
+
+Use `setMessages` when your app needs to replace the current history. Always pass a new array instead of mutating `chat.value()` in place.
+
+<hb-code-example header="support-chat.component.ts">
+
+```ts
+keepRecentMessages() {
+  this.chat.setMessages(this.chat.value().slice(-8));
+}
+
+clearHistory() {
+  this.chat.setMessages([]);
+}
+
+removeLastAssistantMessage() {
+  const messages = this.chat.value();
+  const index = messages.findLastIndex(
+    (message) => message.role === 'assistant',
+  );
+
+  if (index === -1) return;
+
+  this.chat.setMessages(messages.filter((_, i) => i !== index));
+}
+```
+
+</hb-code-example>
+
+This is useful for "clear chat", "delete message", "retry from here", and "trim old turns" controls.
+
+---
+
+## Summarize Older Turns
+
+For long chats, keep recent messages verbatim and replace older turns with a summary. This preserves context while reducing payload size.
+
+<hb-code-example header="support-chat.component.ts">
+
+```ts
+async compactHistory() {
+  const messages = this.chat.value();
+  const recentMessages = messages.slice(-8);
+  const olderMessages = messages.slice(0, -8);
+
+  if (olderMessages.length === 0) return;
+
+  const summary = await summarizeMessages(olderMessages);
+
+  this.chat.setMessages([
+    {
+      role: 'user',
+      content: `Previous conversation summary:\n${summary}`,
+    },
+    ...recentMessages,
+  ]);
+}
+```
+
+</hb-code-example>
+
+Put durable application rules in `system`. Use summarized messages for conversational facts, user preferences, and prior decisions.
+
+---
+
+## Client History vs. Threads
+
+Client-managed history sends the message array with each request. It is simple and works well for local storage, short conversations, and user-controlled editing.
+
+Use [Threads](/docs/angular/recipes/threads) when you want the server to own persistence, rehydrate by `threadId`, and send only new message deltas after a conversation is established.
+
+---
+
+## Next Steps
+
+<hb-next-steps>
+  <hb-next-step link="recipes/threads">
+    <div>
+      <hb-code />
+    </div>
+    <div>
+      <h4>Threads</h4>
+      <p>Persist chats on the server and send only message deltas.</p>
+    </div>
+  </hb-next-step>
+  <hb-next-step link="concept/system-instructions">
+    <div>
+      <hb-functions />
+    </div>
+    <div>
+      <h4>System Instructions</h4>
+      <p>Keep durable behavior and constraints outside message history.</p>
+    </div>
+  </hb-next-step>
+</hb-next-steps>

--- a/www/analog/src/app/pages/docs/angular/guide/prompt-engineering.md
+++ b/www/analog/src/app/pages/docs/angular/guide/prompt-engineering.md
@@ -34,25 +34,24 @@ ngOnInit() {
 
 Hashbrown manages message history for you. Pass an initial message array to the `messages` option when initializing, or use the `setMessages` method to update it.
 
-```typescript
-import { HashbrownChatService, ChatMessage } from '@hashbrownai/angular';
+For persistence, pruning, and history mutation examples, see [Message History](/docs/angular/concept/message-history).
 
-const initialMessages: ChatMessage[] = [
-  { role: 'user', content: 'What is the capital of France?' }
+```ts
+import { chatResource } from '@hashbrownai/angular';
+
+const initialMessages = [
+  { role: 'user' as const, content: 'What is the capital of France?' },
 ];
 
-constructor(private chat: HashbrownChatService) {}
+const chat = chatResource({
+  model: 'gpt-4.1',
+  system: 'You are a geography expert.',
+  messages: initialMessages,
+});
 
-ngOnInit() {
-  this.chat.initialize({
-    model: 'gpt-4',
-    system: 'You are a geography expert.',
-    messages: initialMessages,
-  });
-}
-
-// To update messages later:
-// this.chat.setMessages(newMessages);
+chat.setMessages([
+  { role: 'user', content: 'What is the capital of Belgium?' },
+]);
 ```
 
 **Best Practices:**

--- a/www/analog/src/app/pages/docs/react/concept/message-history.md
+++ b/www/analog/src/app/pages/docs/react/concept/message-history.md
@@ -1,0 +1,167 @@
+---
+title: 'Message History: Hashbrown React Docs'
+meta:
+  - name: description
+    content: 'Persist, restore, and mutate Hashbrown chat message history in React.'
+---
+# Message History
+
+<p class="subtitle">Persist, restore, and prune the messages your chat sends to the model.</p>
+
+Hashbrown keeps chat state in a `messages` array. Each turn appends user, assistant, tool, and error messages to that array, and each request sends the current history so the model has conversational context.
+
+Use message history when you want to:
+
+1. Restore a chat after a page refresh
+2. Persist conversations to local storage or your backend
+3. Remove or summarize older turns before the next request
+4. Let users delete or retry part of a conversation
+
+---
+
+## Initialize with Stored Messages
+
+Pass `messages` when you create the hook. Hashbrown uses this array as the initial chat history.
+
+<hb-code-example header="support-chat.tsx">
+
+```tsx
+import { useEffect } from 'react';
+import { type Chat } from '@hashbrownai/core';
+import { useChat } from '@hashbrownai/react';
+
+const STORAGE_KEY = "support-chat-messages";
+
+function loadMessages(): Chat.Message<string, Chat.AnyTool>[] {
+  if (typeof window === "undefined") return [];
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    return JSON.parse(stored);
+  } catch {
+    return [];
+  }
+}
+
+export function SupportChat() {
+  const chat = useChat({
+    model: 'gpt-4.1',
+    system: 'You are a helpful support assistant.',
+    messages: loadMessages(),
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(chat.messages));
+  }, [chat.messages]);
+
+  return (
+    <div>
+      {chat.messages.map((message, index) => (
+        <p key={index}>{message.content}</p>
+      ))}
+    </div>
+  );
+}
+```
+
+</hb-code-example>
+
+Keep the stored value as plain JSON. Do not store functions, component references, `Promise` values, or provider-specific request objects in message history.
+
+---
+
+## Replace History with `setMessages`
+
+Use `setMessages` when your app needs to replace the current history. Always pass a new array instead of mutating `chat.messages` in place.
+
+<hb-code-example header="prune-history.tsx">
+
+```tsx
+function keepRecentMessages() {
+  chat.setMessages(chat.messages.slice(-8));
+}
+
+function clearHistory() {
+  chat.setMessages([]);
+}
+
+function removeLastAssistantMessage() {
+  const index = chat.messages.findLastIndex(
+    (message) => message.role === 'assistant',
+  );
+
+  if (index === -1) return;
+
+  chat.setMessages(chat.messages.filter((_, i) => i !== index));
+}
+```
+
+</hb-code-example>
+
+This is useful for "clear chat", "delete message", "retry from here", and "trim old turns" controls.
+
+---
+
+## Summarize Older Turns
+
+For long chats, keep recent messages verbatim and replace older turns with a summary. This preserves context while reducing payload size.
+
+<hb-code-example header="summarize-history.tsx">
+
+```tsx
+async function compactHistory() {
+  const recentMessages = chat.messages.slice(-8);
+  const olderMessages = chat.messages.slice(0, -8);
+
+  if (olderMessages.length === 0) return;
+
+  const summary = await summarizeMessages(olderMessages);
+
+  chat.setMessages([
+    {
+      role: 'user',
+      content: `Previous conversation summary:\n${summary}`,
+    },
+    ...recentMessages,
+  ]);
+}
+```
+
+</hb-code-example>
+
+Put durable application rules in `system`. Use summarized messages for conversational facts, user preferences, and prior decisions.
+
+---
+
+## Client History vs. Threads
+
+Client-managed history sends the message array with each request. It is simple and works well for local storage, short conversations, and user-controlled editing.
+
+Use [Threads](/docs/react/recipes/threads) when you want the server to own persistence, rehydrate by `threadId`, and send only new message deltas after a conversation is established.
+
+---
+
+## Next Steps
+
+<hb-next-steps>
+  <hb-next-step link="recipes/threads">
+    <div>
+      <hb-code />
+    </div>
+    <div>
+      <h4>Threads</h4>
+      <p>Persist chats on the server and send only message deltas.</p>
+    </div>
+  </hb-next-step>
+  <hb-next-step link="concept/system-instructions">
+    <div>
+      <hb-functions />
+    </div>
+    <div>
+      <h4>System Instructions</h4>
+      <p>Keep durable behavior and constraints outside message history.</p>
+    </div>
+  </hb-next-step>
+</hb-next-steps>

--- a/www/analog/src/app/pages/docs/react/guide/prompt-engineering.md
+++ b/www/analog/src/app/pages/docs/react/guide/prompt-engineering.md
@@ -30,6 +30,8 @@ const { messages, sendMessage } = useChat({
 
 Hashbrown manages message history for you. Pass an initial message array to the `messages` option, or use the `setMessages` method to update it.
 
+For persistence, pruning, and history mutation examples, see [Message History](/docs/react/concept/message-history).
+
 ```tsx
 import { useChat } from '@hashbrownai/react';
 


### PR DESCRIPTION
## Summary
- Add React and Angular Message History docs for persistence, pruning, and `setMessages` workflows.
- Wire initial `messages` through React chat hooks and Angular `chatResource`.
- Expose `chatResource.setMessages()` and add regression coverage for initialization/replacement.

## Validation
- `npx vitest run --config packages/react/vite.config.ts`
- `npx nx test angular`
- `npx nx build react`
- `npx nx build angular`
- `npx nx lint angular`
- `npx nx build-api-report react`
- `npx nx build-api-report angular`
- `npx nx build www`
- `npx nx test www`
- `git diff --check`

Closes #329