### PR TITLE
Add aimock provider e2e foundation

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint, test, and build affected projects
-        run: npx nx affected -t lint,test,build --parallel=3
+      - name: Lint, test, build, and e2e affected projects
+        run: npx nx affected -t lint,test,build,e2e --parallel=3

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,10 @@ export default [
         'error',
         {
           enforceBuildableLibDependency: true,
-          allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?js$'],
+          allow: [
+            '^.*/eslint(\\.base)?\\.config\\.[cm]?js$',
+            '^@hashbrownai/testing/aimock$',
+          ],
           depConstraints: [
             {
               sourceTag: '*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
         "@babel/core": "^7.29.7",
         "@babel/preset-react": "^7.29.7",
+        "@copilotkit/aimock": "^1.35.1",
         "@eslint/js": "^9.39.4",
         "@faker-js/faker": "^9.9.0",
         "@microsoft/api-extractor": "^7.58.9",
@@ -5669,6 +5670,32 @@
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@copilotkit/aimock": {
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/aimock/-/aimock-1.35.1.tgz",
+      "integrity": "sha512-d+bJFOGjydly9ayh6kK3bhj6m8xskz5Z/G/kSAvcK1WJ2OwRgMjnSG+9nv7INyBmx+5P1DIBg85+ua1Hd5tlNw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "aimock": "dist/aimock-cli.js",
+        "llmock": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.15.0"
+      },
+      "peerDependencies": {
+        "jest": ">=29",
+        "vitest": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
     "@babel/core": "^7.29.7",
     "@babel/preset-react": "^7.29.7",
+    "@copilotkit/aimock": "^1.35.1",
     "@eslint/js": "^9.39.4",
     "@faker-js/faker": "^9.9.0",
     "@microsoft/api-extractor": "^7.58.9",

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -1,392 +1,187 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownAnthropic } from './index';
 
-const ANTHROPIC_API_KEY = process.env['ANTHROPIC_API_KEY'] ?? '';
-const ANTHROPIC_MODEL =
-  (process.env[
-    'ANTHROPIC_MODEL'
-  ] as Chat.Api.CompletionCreateParams['model']) ?? 'claude-haiku-4-5-20251001';
+const ANTHROPIC_MODEL = 'claude-haiku-4-5-20251001';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
 
-test('Anthropic Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownAnthropic.stream.text({
-      apiKey: ANTHROPIC_API_KEY,
-      request,
-    }),
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: ANTHROPIC_MODEL,
-      system: `
-     I am writing an integration test against Anthropic. Respond
-     exactly with the text "Hello, world!"
+}
 
-     DO NOT respond with any other text.
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
 
-     # Examples
-     User: "Please respond with the correct text"
-     Assistant: "Hello, world!"
-
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
-});
-
-test('Anthropic Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownAnthropic.stream.text({
-      apiKey: ANTHROPIC_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: ANTHROPIC_MODEL,
-      system: `
-     I am writing an integration test against Anthropic. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
-          },
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Anthropic with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownAnthropic.stream.text({
-      apiKey: ANTHROPIC_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: ANTHROPIC_MODEL,
-      emulateStructuredOutput: true,
-      system: `
-     I am writing an integration test against Anthropic. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-}, 10000);
-
-test('Anthropic with tool calling and structured output', async () => {
-  const expectedResponse =
-    "Every time things are going good, having a laugh, gotta remember God's a hater.";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownAnthropic.stream.text({
-      apiKey: ANTHROPIC_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: ANTHROPIC_MODEL,
-      emulateStructuredOutput: true,
-      system: `
-     I am writing an integration test against Anthropic. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
-          },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-}, 20000);
-
-test('Anthropic supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownAnthropic.stream.text({
-      apiKey: ANTHROPIC_API_KEY,
-      request: incomingRequest,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'anthropic-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-    });
-
-    return iterator;
-  });
-
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: ANTHROPIC_MODEL,
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'anthropic-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
-});
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    if (process.env['DEBUG_HASHBROWN_ANTHROPIC'] === '1') {
-      console.log('[anthropic:request]', JSON.stringify(req.body));
-    }
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
+function baseRequest(
+  userMessage: string,
+): Chat.Api.CompletionCreateParams {
   return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
+    operation: 'generate',
+    model: ANTHROPIC_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
   };
 }
 
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Anthropic text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: baseRequest('say hi briefly'),
+      }),
   });
 
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
+});
 
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Anthropic streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: baseRequest('stream deterministic text'),
+      }),
   });
 
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
+  );
+});
 
-  if (errorMessage) console.error(errorMessage);
-}
+test('Anthropic tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: {
+          ...baseRequest('call the lookup tool'),
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Lookup deterministic fixture data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          ],
+          toolChoice: 'required',
+        },
+      }),
+  });
+
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  );
+
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some(
+      (toolCall) => toolCall.function?.name === 'lookup',
+    ),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
+
+test('Anthropic structured output fixture emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: baseRequest('return structured output'),
+      }),
+  });
+
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
+});
+
+test('Anthropic provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: baseRequest('return provider error'),
+      }),
+  });
+
+  expect(frames).toEqual([
+    { type: 'generation-start' },
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.stringContaining('Deterministic provider error'),
+    }),
+  ]);
+});
+
+test('Anthropic thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        request: {
+          ...baseRequest('say hi briefly'),
+          threadId: 'anthropic-thread',
+        },
+        loadThread: async () => [
+          {
+            role: 'user',
+            content: 'previous message',
+          },
+        ],
+        saveThread: async (thread) => {
+          savedThreads.push(thread);
+          return 'anthropic-thread';
+        },
+      }),
+  });
+
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
+});

--- a/packages/azure/src/integration.spec.ts
+++ b/packages/azure/src/integration.spec.ts
@@ -1,15 +1,43 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownAzure } from './index';
-import { AzureCompletionCreateParams } from './stream/text.fn';
+import type { AzureCompletionCreateParams } from './stream/text.fn';
 
-const AZURE_API_KEY = process.env['AZURE_API_KEY'] ?? '';
-const AZURE_ENDPOINT = process.env['AZURE_ENDPOINT'] ?? '';
+const AZURE_MODEL = 'gpt-4o@2025-01-01-preview';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
+
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
+  );
+}
+
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
+
+function baseRequest(userMessage: string): AzureCompletionCreateParams {
+  return {
+    operation: 'generate',
+    model: AZURE_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
+  };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
 
 test('Azure JSON response format mode requests JSON object output', async () => {
   let capturedResponseFormat: unknown;
@@ -19,10 +47,8 @@ test('Azure JSON response format mode requests JSON object output', async () => 
       apiKey: 'test-api-key',
       endpoint: 'https://example.openai.azure.com/',
       request: {
-        operation: 'generate',
-        model: 'gpt-4o@2025-01-01-preview',
+        ...baseRequest('Hello'),
         system: 'Respond with JSON.',
-        messages: [{ role: 'user', content: 'Hello' }],
         responseFormatMode: 'json',
       },
       transformRequestOptions: (options) => {
@@ -35,384 +61,164 @@ test('Azure JSON response format mode requests JSON object output', async () => 
   expect(capturedResponseFormat).toEqual({ type: 'json_object' });
 });
 
-test('Azure OpenAI Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownAzure.stream.text({
-      apiKey: AZURE_API_KEY,
-      endpoint: AZURE_ENDPOINT,
-      request: request as AzureCompletionCreateParams,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gpt-4o@2025-01-01-preview',
-      system: `
-     I am writing an integration test against Azure OpenAI. Respond
-     exactly with the text "Hello, world!"
+test('Azure OpenAI text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: baseRequest('say hi briefly'),
+      }),
+  });
 
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
 });
 
-test('Azure OpenAI Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownAzure.stream.text({
-      apiKey: AZURE_API_KEY,
-      endpoint: AZURE_ENDPOINT,
-      request: request as AzureCompletionCreateParams,
-    }),
+test('Azure OpenAI streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: baseRequest('stream deterministic text'),
+      }),
+  });
+
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gpt-4o@2025-01-01-preview',
-      system: `
-     I am writing an integration test against Azure OpenAI. Call
-     the "test" tool with the argument "Hello, world!"
+});
 
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
+test('Azure OpenAI tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: {
+          ...baseRequest('call the lookup tool'),
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Lookup deterministic fixture data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          ],
+          toolChoice: 'required',
         },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
+      }),
+  });
 
-            return {
-              text: expectedResponse,
-            };
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  );
+
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
+
+test('Azure OpenAI structured output emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: {
+          ...baseRequest('return structured output'),
+          responseFormat: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+              ok: { type: 'boolean' },
+            },
+            required: ['text', 'ok'],
           },
         },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Azure OpenAI with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownAzure.stream.text({
-      apiKey: AZURE_API_KEY,
-      endpoint: AZURE_ENDPOINT,
-      request: request as AzureCompletionCreateParams,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gpt-4o@2025-01-01-preview',
-      system: `
-     I am writing an integration test against Azure OpenAI. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
       }),
-    });
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
 });
 
-test('Azure OpenAI with tool calling and structured output', async () => {
-  const expectedResponse =
-    "Every time things are going good, having a laugh, gotta remember God's a hater.";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownAzure.stream.text({
-      apiKey: AZURE_API_KEY,
-      endpoint: AZURE_ENDPOINT,
-      request: request as AzureCompletionCreateParams,
+test('Azure OpenAI provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: baseRequest('return provider error'),
+      }),
+  });
+
+  expect(frames).toEqual([
+    { type: 'generation-start' },
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.stringContaining('Deterministic provider error'),
     }),
-  );
+  ]);
+});
 
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gpt-4o@2025-01-01-preview',
-      system: `
-     I am writing an integration test against Azure OpenAI. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
+test('Azure OpenAI thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownAzure.stream.text({
+        apiKey: 'test-not-used',
+        endpoint: aimock.url,
+        request: {
+          ...baseRequest('say hi briefly'),
+          threadId: 'azure-thread',
         },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+        loadThread: async () => [
+          {
+            role: 'user',
+            content: 'previous message',
           },
+        ],
+        saveThread: async (thread) => {
+          savedThreads.push(thread);
+          return 'azure-thread';
         },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
       }),
-    });
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
 });
-
-test('Azure OpenAI supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownAzure.stream.text({
-      apiKey: AZURE_API_KEY,
-      endpoint: AZURE_ENDPOINT,
-      request: incomingRequest as AzureCompletionCreateParams,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'azure-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-    });
-
-    return iterator;
-  });
-
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gpt-4o@2025-01-01-preview',
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'azure-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
-});
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
-  return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
-  };
-}
-
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-  }
-}
-
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-}

--- a/packages/bedrock/src/integration.spec.ts
+++ b/packages/bedrock/src/integration.spec.ts
@@ -1,395 +1,194 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { type AimockHandle, runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownBedrock } from './index';
 
-const BEDROCK_MODEL_ID =
-  process.env['BEDROCK_MODEL_ID'] ??
-  'anthropic.claude-3-5-sonnet-20240620-v1:0';
-const BEDROCK_REGION =
-  process.env['BEDROCK_REGION'] ?? process.env['AWS_REGION'] ?? 'us-east-1';
+const BEDROCK_MODEL_ID = 'anthropic.claude-3-5-sonnet-20240620-v1:0';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
 
-const shouldSkip =
-  !!process.env['CI'] &&
-  !process.env['AWS_ACCESS_KEY_ID'] &&
-  !process.env['AWS_PROFILE'];
-const maybeTest = shouldSkip ? test.skip : test;
+function createBedrockClient(aimock: AimockHandle): BedrockRuntimeClient {
+  return new BedrockRuntimeClient({
+    region: 'us-east-1',
+    endpoint: aimock.url,
+    credentials: {
+      accessKeyId: 'test-not-used',
+      secretAccessKey: 'test-not-used',
+    },
+    requestHandler: new NodeHttpHandler(),
+  });
+}
 
-if (shouldSkip) {
-  console.warn(
-    'Skipping Bedrock integration tests: AWS credentials not configured for CI',
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
   );
 }
 
-maybeTest('Amazon Bedrock Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownBedrock.stream.text({
-      region: BEDROCK_REGION,
-      request: request as Chat.Api.CompletionCreateParams,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: BEDROCK_MODEL_ID,
-      system: `
-     I am writing an integration test against Amazon Bedrock. Respond
-     exactly with the text "Hello, world!"
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
 
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
-});
-
-maybeTest('Amazon Bedrock Tool Calling', async () => {
-  const expectedResponse =
-    'Recall the wind chime voice you heard when you were young.';
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownBedrock.stream.text({
-      region: BEDROCK_REGION,
-      request: request as Chat.Api.CompletionCreateParams,
-    }),
-  );
-
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: BEDROCK_MODEL_ID,
-      system: `
-     I am writing an integration test against Amazon Bedrock. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-            return { text: expectedResponse };
-          },
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-maybeTest('Amazon Bedrock with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownBedrock.stream.text({
-      region: BEDROCK_REGION,
-      request: request as Chat.Api.CompletionCreateParams,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: BEDROCK_MODEL_ID,
-      emulateStructuredOutput: true,
-      system: `
-     I am writing an integration test against Amazon Bedrock. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-maybeTest(
-  'Amazon Bedrock with tool calling and structured output',
-  async () => {
-    const expectedResponse =
-      'I bend down and listen to the moss humming near the roots.';
-    let toolCallArgs: any;
-    const server = await createServer((request) =>
-      HashbrownBedrock.stream.text({
-        region: BEDROCK_REGION,
-        request: request as Chat.Api.CompletionCreateParams,
-      }),
-    );
-
-    try {
-      const hashbrown = fryHashbrown({
-        debounce: 0,
-        apiUrl: server.url,
-        model: BEDROCK_MODEL_ID,
-        emulateStructuredOutput: true,
-        system: `
-     I am writing an integration test against Amazon Bedrock. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-    `,
-        messages: [
-          {
-            role: 'user',
-            content: 'Please call the test tool and respond with the text.',
-          },
-        ],
-        tools: [
-          {
-            name: 'test',
-            description: 'Test tool',
-            schema: s.object('args', {
-              text: s.string(''),
-            }),
-            handler: async (args: {
-              text: string;
-            }): Promise<{ text: string }> => {
-              toolCallArgs = args;
-              return { text: expectedResponse };
-            },
-          },
-        ],
-        responseSchema: s.object('response', {
-          text: s.string(''),
-        }),
-      });
-
-      await waitUntilHashbrownIsSettled(hashbrown);
-
-      const assistantMessage = hashbrown
-        .messages()
-        .reverse()
-        .find((message) => message.role === 'assistant');
-
-      expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-      expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-    } finally {
-      server.close();
-    }
-  },
-);
-
-maybeTest('Amazon Bedrock supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownBedrock.stream.text({
-      region: BEDROCK_REGION,
-      request: incomingRequest as Chat.Api.CompletionCreateParams,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'bedrock-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-    });
-
-    return iterator;
-  });
-
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: BEDROCK_MODEL_ID,
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'bedrock-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
-});
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
+function baseRequest(
+  userMessage: string,
+): Chat.Api.CompletionCreateParams {
   return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
+    operation: 'generate',
+    model: BEDROCK_MODEL_ID,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
   };
 }
 
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Amazon Bedrock text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: baseRequest('say hi briefly'),
+      }),
   });
 
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
+});
 
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Amazon Bedrock streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: baseRequest('stream deterministic text'),
+      }),
   });
 
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
+  );
+});
 
-  if (errorMessage) console.error(errorMessage);
-}
+test('Amazon Bedrock tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: {
+          ...baseRequest('call the lookup tool'),
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Lookup deterministic fixture data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          ],
+          toolChoice: 'required',
+        },
+      }),
+  });
+
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  );
+
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some(
+      (toolCall) => toolCall.function?.name === 'lookup',
+    ),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
+
+test('Amazon Bedrock structured output fixture emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: baseRequest('return structured output'),
+      }),
+  });
+
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
+});
+
+test('Amazon Bedrock provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: baseRequest('return provider error'),
+      }),
+  });
+
+  expect(frames).toEqual([
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.any(String),
+    }),
+  ]);
+});
+
+test('Amazon Bedrock thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownBedrock.stream.text({
+        client: createBedrockClient(aimock),
+        request: {
+          ...baseRequest('say hi briefly'),
+          threadId: 'bedrock-thread',
+        },
+        loadThread: async () => [
+          {
+            role: 'user',
+            content: 'previous message',
+          },
+        ],
+        saveThread: async (thread) => {
+          savedThreads.push(thread);
+          return 'bedrock-thread';
+        },
+      }),
+  });
+
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
+});

--- a/packages/google/src/integration.spec.ts
+++ b/packages/google/src/integration.spec.ts
@@ -1,15 +1,64 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import {
+  type AimockHandle,
+  runProviderTextWithAimock,
+} from '@hashbrownai/testing/aimock';
 import { HashbrownGoogle } from './index';
 
-const GOOGLE_API_KEY = process.env['GOOGLE_API_KEY'] ?? '';
-const VERTEX_AI_PROJECT = process.env['GOOGLE_CLOUD_PROJECT'] ?? '';
-const VERTEX_AI_LOCATION = process.env['GOOGLE_CLOUD_LOCATION'] ?? '';
+const GOOGLE_MODEL = 'gemini-2.5-flash';
+const GOOGLE_BASE_URL_ENV = 'HASHBROWN_GOOGLE_API_BASE_URL';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
+
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
+  );
+}
+
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
+
+function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
+  return {
+    operation: 'generate',
+    model: GOOGLE_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
+  };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
+async function* googleTextWithAimock(
+  aimock: AimockHandle,
+  createStream: () => AsyncIterable<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  const previousBaseUrl = process.env[GOOGLE_BASE_URL_ENV];
+  process.env[GOOGLE_BASE_URL_ENV] = aimock.url;
+
+  try {
+    yield* createStream();
+  } finally {
+    if (previousBaseUrl === undefined) {
+      delete process.env[GOOGLE_BASE_URL_ENV];
+    } else {
+      process.env[GOOGLE_BASE_URL_ENV] = previousBaseUrl;
+    }
+  }
+}
 
 test('Google JSON response format mode requests JSON without a schema', async () => {
   let capturedConfig: unknown;
@@ -18,10 +67,8 @@ test('Google JSON response format mode requests JSON without a schema', async ()
     HashbrownGoogle.stream.text({
       apiKey: 'test-api-key',
       request: {
-        operation: 'generate',
-        model: 'gemini-2.5-flash',
+        ...baseRequest('Hello'),
         system: 'Respond with JSON.',
-        messages: [{ role: 'user', content: 'Hello' }],
         responseFormatMode: 'json',
       },
       transformRequestOptions: (options) => {
@@ -39,558 +86,169 @@ test('Google JSON response format mode requests JSON without a schema', async ()
   );
 });
 
-test('Google Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      system: `
-     I am writing an integration test against Google. Respond
-     exactly with the text "Hello, world!"
+test('Google text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('say hi briefly'),
+        }),
+      ),
+  });
 
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
 });
 
-test.skip('Vertex AI Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      vertexai: true,
-      project: VERTEX_AI_PROJECT,
-      location: VERTEX_AI_LOCATION,
-      request,
-    }),
+test('Google streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('stream deterministic text'),
+        }),
+      ),
+  });
+
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      system: `
-       I am writing an integration test against Google Vertex AI. Respond
-       exactly with the text "Hello, world!"
-
-       DO NOT respond with any other text.
-      `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
 });
 
-test('Google Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      system: `
-     I am writing an integration test against Google. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-
-     # Example
-     User: Please call the test tool and respond with the text.
-     [tool_call] "test"
-      {
-        "text": "It's not the heat, it's the dust"
-      }
-     Assistant: It's not the heat, it's the dust
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+test('Google tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('call the lookup tool'),
+            tools: [
+              {
+                name: 'lookup',
+                description: 'Lookup deterministic fixture data.',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    query: { type: 'string' },
+                  },
+                  required: ['query'],
+                },
+              },
+            ],
+            toolChoice: 'required',
           },
-        },
-      ],
-    });
+        }),
+      ),
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Google with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      system: `
-     I am writing an integration test against Google. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Google with tool calling and structured output', async () => {
-  const expectedResponse =
-    "Every time things are going good, having a laugh, gotta remember God's a hater";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
-    }),
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
   );
 
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      emulateStructuredOutput: true,
-      system: `
-     I am writing an integration test against Google. Call
-     the "test" tool with the argument "Hello, world!"
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
 
-     Respond with JSON that matches {"text": string} using the tool's response.
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+test('Google structured output emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('return structured output'),
+            responseFormat: {
+              type: 'object',
+              properties: {
+                text: { type: 'string' },
+                ok: { type: 'boolean' },
+              },
+              required: ['text', 'ok'],
+            },
           },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
+        }),
+      ),
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
 });
 
-test('Google with tool calling and structured output (gemini-3-flash-preview)', async () => {
-  const expectedResponse = 'The proof is in the pudding';
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
+test('Google provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('return provider error'),
+        }),
+      ),
+  });
+
+  expect(frames).toEqual([
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.stringContaining('Deterministic provider error'),
     }),
-  );
+  ]);
+});
 
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-3-flash-preview',
-      system: `
-     I am writing an integration test against Google. Call
-     the "test" tool with the argument "Hello, world!"
-
-     Respond with JSON that matches {"text": string} using the tool's response.
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+test('Google thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      googleTextWithAimock(aimock, () =>
+        HashbrownGoogle.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('say hi briefly'),
+            threadId: 'google-thread',
           },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Google with tool calling and structured output (gemini-3.1-pro-preview)', async () => {
-  const expectedResponse = 'Measure twice, cut once';
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request,
-    }),
-  );
-
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-3.1-pro-preview',
-      system: `
-     I am writing an integration test against Google. Call
-     the "test" tool with the argument "Hello, world!"
-
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+          loadThread: async () => [
+            {
+              role: 'user',
+              content: 'previous message',
+            },
+          ],
+          saveThread: async (thread) => {
+            savedThreads.push(thread);
+            return 'google-thread';
           },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
+        }),
+      ),
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
 });
-
-test('Google supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownGoogle.stream.text({
-      apiKey: GOOGLE_API_KEY,
-      request: incomingRequest,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'google-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-    });
-
-    return iterator;
-  });
-
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'gemini-2.5-flash',
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'google-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
-});
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
-  return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
-  };
-}
-
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-  }
-}
-
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-}

--- a/packages/google/src/stream/text.fn.ts
+++ b/packages/google/src/stream/text.fn.ts
@@ -72,6 +72,7 @@ export async function* text(
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
   let effectiveThreadId = threadId;
+  const baseUrl = process.env['HASHBROWN_GOOGLE_API_BASE_URL'];
 
   const ai: GoogleGenAI = options.vertexai
     ? new GoogleGenAI({
@@ -79,7 +80,10 @@ export async function* text(
         project: options.project,
         location: options.location,
       })
-    : new GoogleGenAI({ apiKey: options.apiKey });
+    : new GoogleGenAI({
+        apiKey: options.apiKey,
+        ...(baseUrl ? { httpOptions: { baseUrl } } : {}),
+      });
 
   const shouldLoadThread = Boolean(request.threadId);
   const shouldHydrateThreadOnTheClient = Boolean(

--- a/packages/ollama/src/integration.spec.ts
+++ b/packages/ollama/src/integration.spec.ts
@@ -1,459 +1,186 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownOllama } from './index';
 
 const OLLAMA_MODEL = 'gpt-oss:120b';
-const OLLAMA_TURBO_API_KEY = process.env['OLLAMA_API_KEY'];
-const OLLAMA_HOST = process.env['OLLAMA_HOST'];
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
 
-test('Ollama Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownOllama.stream.text({
-      turbo: OLLAMA_TURBO_API_KEY
-        ? { apiKey: OLLAMA_TURBO_API_KEY }
-        : undefined,
-      host: OLLAMA_HOST,
-      request,
-    }),
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OLLAMA_MODEL,
-      system: `
-     I am writing an integration test against Ollama. Respond
-     exactly with the text "Hello, world!"
+}
 
-     Example output:
-     Hello, world!
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
 
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
-}, 20_000);
-
-test('Ollama Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-
-  const server = await createServer((request) =>
-    HashbrownOllama.stream.text({
-      turbo: OLLAMA_TURBO_API_KEY
-        ? { apiKey: OLLAMA_TURBO_API_KEY }
-        : undefined,
-      host: OLLAMA_HOST,
-      request,
-    }),
-  );
-
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OLLAMA_MODEL,
-      system: `
-     I am writing an integration test against Ollama. Call
-     the "test" tool with the argument "Hello, world!"
-
-     Example tool call args:
-     { "text": "Hello, world!" }
-
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-
-     Example:
-
-     <user>Please call the test tool and respond with the text.</user>
-     <assistant>
-       <tool-call name="test" id="123">
-         { "text": "Hello, world!" }
-       </tool-call>
-       <assistant>
-         Hello, world!
-       </assistant>
-     </assistant>
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return { text: expectedResponse };
-          },
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Ollama with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownOllama.stream.text({
-      turbo: OLLAMA_TURBO_API_KEY
-        ? { apiKey: OLLAMA_TURBO_API_KEY }
-        : undefined,
-      host: OLLAMA_HOST,
-      request,
-    }),
-  );
-
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OLLAMA_MODEL,
-      system: `
-     I am writing an integration test against Ollama. Respond
-     exactly with the text "Hello, world!" in JSON format.
-
-     Example output JSON:
-     { "text": "Hello, world!" }
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Ollama with tool calling and structured output', async () => {
-  const expectedResponse = 'Hello, world!';
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownOllama.stream.text({
-      turbo: OLLAMA_TURBO_API_KEY
-        ? { apiKey: OLLAMA_TURBO_API_KEY }
-        : undefined,
-      host: OLLAMA_HOST,
-      request,
-    }),
-  );
-
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OLLAMA_MODEL,
-      system: `
-        You must call the "test" tool with the argument "Hello, world!".
-        After the tool returns, respond only with its text in JSON { "text": "<value>" }.
-
-        Example tool call args:
-        { "text": "Hello, world!" }
-
-        Example final reply JSON:
-        { "text": "Hello, world!" }
-      `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
-          },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-}, 20_000);
-
-test('Ollama supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(cloneCompletionRequest(incomingRequest));
-
-    return HashbrownOllama.stream.text({
-      turbo: OLLAMA_TURBO_API_KEY
-        ? { apiKey: OLLAMA_TURBO_API_KEY }
-        : undefined,
-      host: OLLAMA_HOST,
-      request: incomingRequest,
-      loadThread: async (threadId: string) =>
-        threadMessages.get(threadId) ?? [],
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'ollama-thread';
-        threadMessages.set(id, thread.map(cloneMessage));
-        return id;
-      },
-    });
-  });
-
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OLLAMA_MODEL,
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-
-     Examples:
-     - User: "Store this value: 42" -> Assistant: "Stored"
-     - User: "Recall value" -> Assistant: "42"
-     - User: "Hi" -> Assistant: "Unexpected input"
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'ollama-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(requests).toHaveLength(1);
-    expect(requests[0].messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
-}, 20_000);
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
+function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
   return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
+    operation: 'generate',
+    model: OLLAMA_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
   };
 }
 
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Ollama text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: baseRequest('say hi briefly'),
+      }),
   });
 
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
+});
 
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
+test('Ollama streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: baseRequest('stream deterministic text'),
+      }),
   });
 
-  const errorMessage = hashbrown.error();
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
+  );
+});
 
-  if (errorMessage) console.error(errorMessage);
-}
+test('Ollama tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: {
+          ...baseRequest('call the lookup tool'),
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Lookup deterministic fixture data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          ],
+          toolChoice: 'required',
+        },
+      }),
+  });
 
-function cloneCompletionRequest(
-  request: Chat.Api.CompletionCreateParams,
-): Chat.Api.CompletionCreateParams {
-  return {
-    ...request,
-    messages: request.messages.map(cloneMessage),
-  };
-}
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  );
 
-function cloneMessage(message: Chat.Api.Message): Chat.Api.Message {
-  switch (message.role) {
-    case 'assistant':
-      return {
-        role: 'assistant',
-        content: message.content,
-        toolCalls: message.toolCalls?.map((toolCall) => ({
-          ...toolCall,
-          function: { ...toolCall.function },
-        })),
-      };
-    case 'tool':
-      return {
-        role: 'tool',
-        content: message.content,
-        toolCallId: message.toolCallId,
-        toolName: message.toolName,
-      };
-    default:
-      return { ...message };
-  }
-}
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
+  ).toBe(true);
+  expect(
+    JSON.stringify(
+      toolCallDeltas.map((toolCall) => toolCall.function?.arguments ?? ''),
+    ),
+  ).toContain('hashbrown');
+});
+
+test('Ollama structured output fixture emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: {
+          ...baseRequest('return structured output'),
+          responseFormat: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+              ok: { type: 'boolean' },
+            },
+            required: ['text', 'ok'],
+          },
+        },
+      }),
+  });
+
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
+});
+
+test('Ollama provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: baseRequest('return provider error'),
+      }),
+  });
+
+  expect(frames).toEqual([
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.any(String),
+    }),
+  ]);
+});
+
+test('Ollama thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        request: {
+          ...baseRequest('say hi briefly'),
+          threadId: 'ollama-thread',
+        },
+        loadThread: async () => [
+          {
+            role: 'user',
+            content: 'previous message',
+          },
+        ],
+        saveThread: async (thread) => {
+          savedThreads.push(thread);
+          return 'ollama-thread';
+        },
+      }),
+  });
+
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
+});

--- a/packages/openai/src/integration.spec.ts
+++ b/packages/openai/src/integration.spec.ts
@@ -1,15 +1,42 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownOpenAI } from './index';
 
-const OPENAI_API_KEY = process.env['OPENAI_API_KEY'] ?? '';
-const OPENAI_MODEL = (process.env['OPENAI_MODEL'] ??
-  'gpt-4.1-mini') as Chat.Api.CompletionCreateParams['model'];
+const OPENAI_MODEL = 'gpt-4.1-mini';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
+
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
+  );
+}
+
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
+
+function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
+  return {
+    operation: 'generate',
+    model: OPENAI_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
+  };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
 
 test('OpenAI JSON response format mode requests JSON object output', async () => {
   let capturedResponseFormat: unknown;
@@ -18,10 +45,8 @@ test('OpenAI JSON response format mode requests JSON object output', async () =>
     HashbrownOpenAI.stream.text({
       apiKey: 'test-api-key',
       request: {
-        operation: 'generate',
-        model: OPENAI_MODEL,
+        ...baseRequest('Hello'),
         system: 'Respond with JSON.',
-        messages: [{ role: 'user', content: 'Hello' }],
         responseFormatMode: 'json',
       },
       transformRequestOptions: (options) => {
@@ -34,389 +59,164 @@ test('OpenAI JSON response format mode requests JSON object output', async () =>
   expect(capturedResponseFormat).toEqual({ type: 'json_object' });
 });
 
-test('OpenAI Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OPENAI_MODEL,
-      system: `
-     I am writing an integration test against OpenAI. Respond
-     exactly with the text "Hello, world!"
+test('OpenAI text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: baseRequest('say hi briefly'),
+      }),
+  });
 
-     DO NOT respond with any other text.
-
-     # Examples
-     User: "Please respond with the correct text"
-     Assistant: "Hello, world!"
-
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
 });
 
-test('OpenAI Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request,
-    }),
+test('OpenAI streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: baseRequest('stream deterministic text'),
+      }),
+  });
+
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OPENAI_MODEL,
-      system: `
-     I am writing an integration test against OpenAI. Call
-     the "test" tool with the argument "Hello, world!"
+});
 
-     DO NOT respond with any other text.
-
-     The tool will respond with text. You must respond with the
-     exact text from the tool call.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
+test('OpenAI tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: {
+          ...baseRequest('call the lookup tool'),
+          tools: [
+            {
+              name: 'lookup',
+              description: 'Lookup deterministic fixture data.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          ],
+          toolChoice: 'required',
         },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
+      }),
+  });
 
-            return {
-              text: expectedResponse,
-            };
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  );
+
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
+
+test('OpenAI structured output emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: {
+          ...baseRequest('return structured output'),
+          responseFormat: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+              ok: { type: 'boolean' },
+            },
+            required: ['text', 'ok'],
           },
         },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('OpenAI with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OPENAI_MODEL,
-      system: `
-     I am writing an integration test against OpenAI. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
       }),
-    });
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
 });
 
-test('OpenAI with tool calling and structured output', async () => {
-  const expectedResponse = 'Hello, world!';
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request,
+test('OpenAI provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: baseRequest('return provider error'),
+      }),
+  });
+
+  expect(frames).toEqual([
+    { type: 'generation-start' },
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.stringContaining('Deterministic provider error'),
     }),
-  );
+  ]);
+});
 
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OPENAI_MODEL,
-      system: `
-        You must call the "test" tool with the argument "Hello, world!".
-        After the tool returns, respond only with its text in JSON { "text": "<value>" }.
-      `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
+test('OpenAI thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        request: {
+          ...baseRequest('say hi briefly'),
+          threadId: 'openai-thread',
         },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+        loadThread: async () => [
+          {
+            role: 'user',
+            content: 'previous message',
           },
+        ],
+        saveThread: async (thread) => {
+          savedThreads.push(thread);
+          return 'openai-thread';
         },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
       }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-}, 20_000);
-
-test('OpenAI supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request: incomingRequest,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'server-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-      transformRequestOptions: (options) => {
-        return options;
-      },
-    });
-
-    return iterator;
   });
 
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: OPENAI_MODEL,
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'openai-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(requests).toHaveLength(1);
-    expect(requests[0].messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
 });
-
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
-  });
-
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
-  return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
-  };
-}
-
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-  }
-}
-
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown.error();
-
-  if (errorMessage) console.error(errorMessage);
-}

--- a/packages/writer/src/integration.spec.ts
+++ b/packages/writer/src/integration.spec.ts
@@ -1,13 +1,68 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import {} from 'dotenv';
-import * as express from 'express';
-import * as cors from 'cors';
-import { Chat, fryHashbrown, Hashbrown, s } from '@hashbrownai/core';
+import { resolve } from 'node:path';
+import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
+import {
+  type AimockHandle,
+  runProviderTextWithAimock,
+  startWriterCompatServer,
+} from '@hashbrownai/testing/aimock';
 import { HashbrownWriter } from './index';
 
-const WRITER_API_KEY = process.env['WRITER_API_KEY'] ?? '';
+const WRITER_MODEL = 'palmyra-x5';
+const WRITER_BASE_URL_ENV = 'WRITER_BASE_URL';
 
-jest.setTimeout(60_000);
+function fixturePath(name: string): string {
+  return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
+}
+
+function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
+  return frames.filter(
+    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
+  );
+}
+
+function streamedContent(frames: Frame[]): string {
+  return generationChunks(frames)
+    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
+    .join('');
+}
+
+function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
+  return {
+    operation: 'generate',
+    model: WRITER_MODEL,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: userMessage }],
+  };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
+async function* writerTextWithAimock(
+  aimock: AimockHandle,
+  createStream: () => AsyncIterable<Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  const compat = await startWriterCompatServer(aimock);
+  const previousBaseUrl = process.env[WRITER_BASE_URL_ENV];
+  process.env[WRITER_BASE_URL_ENV] = compat.baseUrl;
+
+  try {
+    yield* createStream();
+  } finally {
+    if (previousBaseUrl === undefined) {
+      delete process.env[WRITER_BASE_URL_ENV];
+    } else {
+      process.env[WRITER_BASE_URL_ENV] = previousBaseUrl;
+    }
+
+    await compat.stop();
+  }
+}
 
 test('Writer JSON response format mode does not request a provider schema', async () => {
   let capturedResponseFormat: unknown;
@@ -16,10 +71,8 @@ test('Writer JSON response format mode does not request a provider schema', asyn
     HashbrownWriter.stream.text({
       apiKey: 'test-api-key',
       request: {
-        operation: 'generate',
-        model: 'palmyra-x5',
+        ...baseRequest('Hello'),
         system: 'Respond with JSON.',
-        messages: [{ role: 'user', content: 'Hello' }],
         responseFormatMode: 'json',
       },
       transformRequestOptions: (options) => {
@@ -32,404 +85,169 @@ test('Writer JSON response format mode does not request a provider schema', asyn
   expect(capturedResponseFormat).toBeUndefined();
 });
 
-test('Writer Text Streaming', async () => {
-  const server = await createServer((request) =>
-    HashbrownWriter.stream.text({
-      apiKey: WRITER_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'palmyra-x5',
-      system: `
-     I am writing an integration test against Writer. Respond
-     exactly with the text "Hello, world!"
+test('Writer text streaming emits Hashbrown generation frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('say hi briefly'),
+        }),
+      ),
+  });
 
-     DO NOT respond with any other text.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe('Hello, world!');
-  } finally {
-    server.close();
-  }
+  expect(frames[0].type).toBe('generation-start');
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  expect(streamedContent(frames)).toBe('Hello from aimock.');
 });
 
-test('Writer Tool Calling', async () => {
-  const expectedResponse =
-    "I don't sleep, I hover outside myself, watching my body survive";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownWriter.stream.text({
-      apiKey: WRITER_API_KEY,
-      request,
-    }),
+test('Writer streaming preserves chunked content across multiple frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('stream deterministic text'),
+        }),
+      ),
+  });
+
+  expect(generationChunks(frames).length).toBeGreaterThan(1);
+  expect(streamedContent(frames)).toContain(
+    'Streaming fixture response with enough text',
   );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'palmyra-x5',
-      system: `
-     I am writing an integration test against Writer. Call
-     the "test" tool with the argument "Hello, world!"
+});
 
-      DO NOT respond with any other text.
-
-      The tool will respond with JSON containing a "text" field. You must
-      respond with the exact text from the tool call.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+test('Writer tool calling emits tool call deltas', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('call the lookup tool'),
+            tools: [
+              {
+                name: 'lookup',
+                description: 'Lookup deterministic fixture data.',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    query: { type: 'string' },
+                  },
+                  required: ['query'],
+                },
+              },
+            ],
+            toolChoice: 'required',
           },
-        },
-      ],
-    });
+        }),
+      ),
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toBe(expectedResponse);
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Writer with structured output', async () => {
-  const server = await createServer((request) =>
-    HashbrownWriter.stream.text({
-      apiKey: WRITER_API_KEY,
-      request,
-    }),
-  );
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'palmyra-x5',
-      emulateStructuredOutput: true,
-      system: `
-     I am writing an integration test against Writer. Respond
-     exactly with the text "Hello, world!" in JSON format.
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please respond with the correct text.',
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
-
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
-});
-
-test('Writer with tool calling and structured output', async () => {
-  const expectedResponse =
-    "Every time things are going good, having a laugh, gotta remember God's a hater.";
-  let toolCallArgs: any;
-  const server = await createServer((request) =>
-    HashbrownWriter.stream.text({
-      apiKey: WRITER_API_KEY,
-      request,
-    }),
+  const toolCallDeltas = generationChunks(frames).flatMap(
+    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
   );
 
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'palmyra-x5',
-      emulateStructuredOutput: true,
-      system: `
-      I am writing an integration test against Writer. Call
-      the "test" tool with the following arguments:
-      {
-        "text": "Hello, world!"
-      }
+  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
+  expect(
+    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
+  ).toBe(true);
+  expect(
+    toolCallDeltas
+      .map((toolCall) => toolCall.function?.arguments ?? '')
+      .join(''),
+  ).toContain('"query":"hashbrown"');
+});
 
-      The tool will respond with JSON containing a "text" field. You must
-      respond with the exact text from the tool call.
-
-      Example:
-      <user>Please call the test tool and respond with the text.</user>
-      <assistant>
-        <tool-call name="test" id="123">
-          {
-            "text": "Hello, world!"
-          }
-        </tool-call>
-        <tool-call-result name="test" id="123">
-          {
-            "text": "Some other text!"
-          }
-        </tool-call-result>
-        <assistant>
-          { "text": "Some other text!" }
-        </assistant>
-      </assistant>
-
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Please call the test tool and respond with the text.',
-        },
-      ],
-      tools: [
-        {
-          name: 'test',
-          description: 'Test tool',
-          schema: s.object('args', {
-            text: s.string(''),
-          }),
-          handler: async (args: {
-            text: string;
-          }): Promise<{ text: string }> => {
-            toolCallArgs = args;
-
-            return {
-              text: expectedResponse,
-            };
+test('Writer structured output emits JSON text content', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('return structured output'),
+            responseFormat: {
+              type: 'object',
+              properties: {
+                text: { type: 'string' },
+                ok: { type: 'boolean' },
+              },
+              required: ['text', 'ok'],
+            },
           },
-        },
-      ],
-      responseSchema: s.object('response', {
-        text: s.string(''),
-      }),
-    });
+        }),
+      ),
+  });
 
-    await waitUntilHashbrownIsSettled(hashbrown);
-
-    const assistantMessage = hashbrown
-      .messages()
-      .reverse()
-      .find((message) => message.role === 'assistant');
-
-    expect(assistantMessage?.content).toEqual({ text: expectedResponse });
-    expect(toolCallArgs).toEqual({ text: 'Hello, world!' });
-  } finally {
-    server.close();
-  }
+  expect(JSON.parse(streamedContent(frames))).toEqual({
+    text: 'Hello from structured aimock.',
+    ok: true,
+  });
 });
 
-test('Writer supports thread IDs across turns', async () => {
-  const requests: Chat.Api.CompletionCreateParams[] = [];
-  const threadMessages = new Map<string, Chat.Api.Message[]>();
-  const server = await createServer((incomingRequest) => {
-    requests.push(incomingRequest);
-
-    const iterator = HashbrownWriter.stream.text({
-      apiKey: WRITER_API_KEY,
-      request: incomingRequest,
-      loadThread: async (threadId: string) => {
-        return threadMessages.get(threadId) ?? [];
-      },
-      saveThread: async (thread: Chat.Api.Message[], threadId?: string) => {
-        const id = threadId ?? incomingRequest.threadId ?? 'writer-thread';
-        threadMessages.set(id, thread);
-        return id;
-      },
-    });
-
-    return iterator;
+test('Writer provider errors emit generation-error frames', async () => {
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('error.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: baseRequest('return provider error'),
+        }),
+      ),
   });
 
-  let teardown: (() => void) | undefined;
-  try {
-    const hashbrown = fryHashbrown({
-      debounce: 0,
-      apiUrl: server.url,
-      model: 'palmyra-x5',
-      system: `
-     You are participating in a deterministic integration test.
-
-     Rules:
-     1. When the user sends a message that starts with "Store this value:", respond with "Stored".
-     2. When the user later sends a message that is exactly "Recall value", respond with the value that appeared after "Store this value:" in the most recent earlier user message. Respond with the value alone.
-     3. For any other message, respond with "Unexpected input".
-    `,
-      messages: [
-        {
-          role: 'user',
-          content: 'Store this value: 12345',
-        },
-      ],
-      threadId: 'writer-thread',
-    });
-
-    teardown = hashbrown.sizzle();
-
-    await waitForNextIdle(hashbrown);
-
-    const firstAssistant = hashbrown
-      .messages()
-      .find((message) => message.role === 'assistant');
-
-    expect(firstAssistant?.content).toBe('Stored');
-
-    hashbrown.sendMessage({
-      role: 'user',
-      content: 'Recall value',
-    });
-
-    await waitForNextIdle(hashbrown);
-
-    expect(requests).toHaveLength(2);
-    const [initialRequest, followupRequest] = requests;
-
-    expect(initialRequest.threadId).toBeDefined();
-    expect(followupRequest.threadId).toBe(initialRequest.threadId);
-    expect(initialRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Store this value: 12345',
-      },
-    ]);
-    expect(followupRequest.messages).toEqual([
-      {
-        role: 'user',
-        content: 'Recall value',
-      },
-    ]);
-    const savedThread =
-      threadMessages.get(initialRequest.threadId as string) ?? [];
-    const savedContents = savedThread.map((m) => m.content);
-    expect(savedContents).toContain('Store this value: 12345');
-    expect(savedContents.some((c) => c === 'Stored')).toBeTruthy();
-    expect(hashbrown.threadId()).toBe(initialRequest.threadId);
-  } finally {
-    teardown?.();
-    server.close();
-  }
+  expect(frames).toEqual([
+    expect.objectContaining({
+      type: 'generation-error',
+      error: expect.any(String),
+    }),
+  ]);
 });
 
-async function createServer(
-  iteratorFactory: (
-    request: Chat.Api.CompletionCreateParams,
-  ) => AsyncIterable<Uint8Array>,
-) {
-  const app = express();
-
-  app.use(express.json());
-
-  app.use(cors());
-
-  app.post('/chat', async (req, res) => {
-    const iterator = iteratorFactory(req.body);
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of iterator) {
-      res.write(chunk);
-    }
-
-    res.end();
+test('Writer thread persistence wraps generation with thread frames', async () => {
+  const savedThreads: Chat.Api.Message[][] = [];
+  const frames = await runProviderTextWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock) =>
+      writerTextWithAimock(aimock, () =>
+        HashbrownWriter.stream.text({
+          apiKey: 'test-not-used',
+          request: {
+            ...baseRequest('say hi briefly'),
+            threadId: 'writer-thread',
+          },
+          loadThread: async () => [
+            {
+              role: 'user',
+              content: 'previous message',
+            },
+          ],
+          saveThread: async (thread) => {
+            savedThreads.push(thread);
+            return 'writer-thread';
+          },
+        }),
+      ),
   });
 
-  const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-    const listener = app.listen(0, () => resolve(listener));
-  });
-
-  const address = server.address();
-
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('Failed to determine server address');
-  }
-
-  return {
-    url: `http://127.0.0.1:${address.port}/chat`,
-    close: () => server.close(),
-  };
-}
-
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-  }
-}
-
-async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {
-  const teardown = hashbrown.sizzle();
-
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-
-  teardown();
-}
-
-async function waitForNextIdle(hashbrown: Hashbrown<any, any>) {
-  await new Promise((resolve) => {
-    hashbrown.isLoading.subscribe((isLoading) => {
-      if (!isLoading) resolve(null);
-    });
-  });
-
-  const errorMessage = hashbrown
-    .messages()
-    .find((message) => message.role === 'error');
-
-  if (errorMessage) console.error(errorMessage);
-}
+  expect(frames.map((frame) => frame.type)).toEqual([
+    'thread-load-start',
+    'thread-load-success',
+    'generation-start',
+    ...generationChunks(frames).map((frame) => frame.type),
+    'generation-finish',
+    'thread-save-start',
+    'thread-save-success',
+  ]);
+  expect(savedThreads).toHaveLength(1);
+  expect(savedThreads[0].map((message) => message.content)).toContain(
+    'Hello from aimock.',
+  );
+});

--- a/tools/testing/aimock/aimock-runner.spec.ts
+++ b/tools/testing/aimock/aimock-runner.spec.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type AimockHandle, startAimock } from './aimock-runner';
+
+function createFixtureFile(workDir: string, name: string, userMessage: string) {
+  const fixturePath = join(workDir, name);
+  writeFileSync(
+    fixturePath,
+    JSON.stringify({
+      fixtures: [
+        {
+          match: { userMessage },
+          response: { content: 'Hello from aimock.' },
+        },
+      ],
+    }),
+  );
+  return fixturePath;
+}
+
+test('startAimock boots a replay server backed by one fixture file', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-aimock-'));
+  const fixturePath = createFixtureFile(workDir, 'text.json', 'say hi briefly');
+  let handle: AimockHandle | null = null;
+
+  try {
+    handle = await startAimock({ fixturePath });
+
+    expect(handle.port).toBeGreaterThan(0);
+    expect(handle.url).toMatch(/^http:\/\/.+/);
+    expect(handle.openAiBaseUrl).toBe(`${handle.url}/v1`);
+    expect(handle.anthropicBaseUrl).toBe(handle.url);
+    expect(handle.ollamaHost).toBe(handle.url);
+  } finally {
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('startAimock loads sorted JSON fixture files from a directory', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-aimock-'));
+  createFixtureFile(workDir, 'b.json', 'two');
+  createFixtureFile(workDir, 'a.json', 'one');
+  writeFileSync(join(workDir, 'README.md'), '# ignored');
+  let handle: AimockHandle | null = null;
+
+  try {
+    handle = await startAimock({ fixturePath: workDir });
+
+    expect(handle.port).toBeGreaterThan(0);
+  } finally {
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('AimockHandle stop is idempotent', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-aimock-'));
+  const fixturePath = createFixtureFile(workDir, 'text.json', 'say hi briefly');
+  let handle: AimockHandle | null = null;
+
+  try {
+    handle = await startAimock({ fixturePath });
+
+    await handle.stop();
+    await handle.stop();
+
+    expect(handle.port).toBeGreaterThan(0);
+  } finally {
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/tools/testing/aimock/aimock-runner.ts
+++ b/tools/testing/aimock/aimock-runner.ts
@@ -1,0 +1,95 @@
+import { LLMock } from '@copilotkit/aimock';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Running aimock server handle for deterministic provider e2e tests.
+ */
+export interface AimockHandle {
+  /** Port the mock server is listening on. */
+  readonly port: number;
+  /** Raw aimock server URL without a provider-specific path suffix. */
+  readonly url: string;
+  /** OpenAI-compatible base URL including `/v1`. */
+  readonly openAiBaseUrl: string;
+  /** Anthropic-compatible base URL without `/v1`; the SDK appends it. */
+  readonly anthropicBaseUrl: string;
+  /** Ollama-compatible host URL without `/v1`. */
+  readonly ollamaHost: string;
+  /** Stop the mock server. Safe to call more than once. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Options for starting deterministic aimock replay.
+ */
+export interface AimockStartOptions {
+  /** Path to one fixture file or a directory of `.json` fixture files. */
+  readonly fixturePath: string;
+  /** Optional chunk size passed through to aimock. */
+  readonly chunkSize?: number;
+}
+
+type FixtureFileEntry = Record<string, unknown>;
+
+function loadFixtureEntries(fixturePath: string): FixtureFileEntry[] {
+  const stats = statSync(fixturePath);
+  const entries: FixtureFileEntry[] = [];
+  const readFixtureFile = (filePath: string) => {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as { fixtures?: FixtureFileEntry[] };
+    for (const fixture of parsed.fixtures ?? []) {
+      entries.push(fixture);
+    }
+  };
+
+  if (!stats.isDirectory()) {
+    readFixtureFile(fixturePath);
+    return entries;
+  }
+
+  for (const file of readdirSync(fixturePath)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort()) {
+    readFixtureFile(join(fixturePath, file));
+  }
+
+  return entries;
+}
+
+/**
+ * Start aimock in replay mode with the supplied fixture file or directory.
+ */
+export async function startAimock(
+  options: AimockStartOptions,
+): Promise<AimockHandle> {
+  const entries = loadFixtureEntries(options.fixturePath);
+  const mock = new LLMock({
+    port: 0,
+    chunkSize: options.chunkSize ?? 4096,
+  });
+
+  if (entries.length > 0) {
+    mock.addFixturesFromJSON(entries as never);
+  }
+
+  await mock.start();
+
+  let stopped = false;
+  const url = mock.url;
+
+  return {
+    port: mock.port,
+    url,
+    openAiBaseUrl: `${url}/v1`,
+    anthropicBaseUrl: url,
+    ollamaHost: url,
+    async stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      await mock.stop();
+    },
+  };
+}

--- a/tools/testing/aimock/fixtures/error.json
+++ b/tools/testing/aimock/fixtures/error.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "return provider error" },
+      "response": {
+        "status": 429,
+        "error": {
+          "message": "Deterministic provider error from aimock.",
+          "type": "rate_limit_error",
+          "code": "rate_limit_exceeded"
+        }
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/streaming.json
+++ b/tools/testing/aimock/fixtures/streaming.json
@@ -1,0 +1,12 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "stream deterministic text" },
+      "chunkSize": 16,
+      "streamingProfile": { "ttft": 10, "tps": 100 },
+      "response": {
+        "content": "Streaming fixture response with enough text to cross several deterministic chunk boundaries."
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/structured-output.json
+++ b/tools/testing/aimock/fixtures/structured-output.json
@@ -1,0 +1,13 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "return structured output" },
+      "response": {
+        "content": {
+          "text": "Hello from structured aimock.",
+          "ok": true
+        }
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/text.json
+++ b/tools/testing/aimock/fixtures/text.json
@@ -1,0 +1,8 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "say hi briefly" },
+      "response": { "content": "Hello from aimock." }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/tool-call.json
+++ b/tools/testing/aimock/fixtures/tool-call.json
@@ -1,0 +1,18 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "call the lookup tool" },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_lookup_fixture",
+            "name": "lookup",
+            "arguments": {
+              "query": "hashbrown"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/index.ts
+++ b/tools/testing/aimock/index.ts
@@ -1,0 +1,3 @@
+export * from './aimock-runner';
+export * from './provider-e2e';
+export * from './writer-compat';

--- a/tools/testing/aimock/provider-e2e.spec.ts
+++ b/tools/testing/aimock/provider-e2e.spec.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { encodeFrame, type Frame } from '@hashbrownai/core';
+import type { AimockHandle } from './aimock-runner';
+import { runProviderTextWithAimock } from './provider-e2e';
+
+async function* openAiCompatibleTextStream(
+  aimock: AimockHandle,
+): AsyncIterable<Uint8Array> {
+  const response = await fetch(`${aimock.openAiBaseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer test-not-used',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      stream: true,
+      model: 'gpt-4.1-mini',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a deterministic test assistant.',
+        },
+        {
+          role: 'user',
+          content: 'say hi briefly',
+        },
+      ],
+    }),
+  });
+
+  if (!response.body) {
+    throw new Error('aimock did not return a response body.');
+  }
+
+  yield encodeFrame({ type: 'generation-start' });
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split('\n\n');
+    buffer = events.pop() ?? '';
+
+    for (const event of events) {
+      const data = event
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length))
+        .join('');
+
+      if (!data || data === '[DONE]') {
+        continue;
+      }
+
+      const chunk = JSON.parse(data) as {
+        choices: [{ delta: { content?: string } }];
+      };
+
+      yield encodeFrame({
+        type: 'generation-chunk',
+        chunk: {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: chunk.choices[0].delta.content ?? '',
+              },
+              finishReason: null,
+            },
+          ],
+        },
+      });
+    }
+  }
+
+  yield encodeFrame({ type: 'generation-finish' });
+}
+
+test('runProviderTextWithAimock collects Hashbrown frames from an aimock-backed provider stream', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-provider-e2e-'));
+  const fixturePath = join(workDir, 'text.json');
+  writeFileSync(
+    fixturePath,
+    JSON.stringify({
+      fixtures: [
+        {
+          match: { userMessage: 'say hi briefly' },
+          response: { content: 'Hello from aimock.' },
+        },
+      ],
+    }),
+  );
+
+  try {
+    const frames: Frame[] = await runProviderTextWithAimock({
+      fixturePath,
+      createStream: openAiCompatibleTextStream,
+    });
+
+    expect(frames[0].type).toBe('generation-start');
+    expect(frames.at(-1)?.type).toBe('generation-finish');
+    expect(frames.some((frame) => frame.type === 'generation-chunk')).toBe(
+      true,
+    );
+    expect(
+      frames
+        .filter((frame) => frame.type === 'generation-chunk')
+        .map((frame) => frame.chunk.choices[0].delta.content ?? '')
+        .join(''),
+    ).toBe('Hello from aimock.');
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/tools/testing/aimock/provider-e2e.ts
+++ b/tools/testing/aimock/provider-e2e.ts
@@ -1,0 +1,59 @@
+import { decodeFrames, type Frame } from '@hashbrownai/core';
+import { type AimockHandle, startAimock } from './aimock-runner';
+
+/**
+ * Options for running a provider stream against an aimock fixture.
+ */
+export interface ProviderTextAimockRunOptions {
+  /** Path to one fixture file or a directory of `.json` fixture files. */
+  readonly fixturePath: string;
+  /** Create the provider stream after aimock is started. */
+  readonly createStream: (aimock: AimockHandle) => AsyncIterable<Uint8Array>;
+}
+
+function toReadableStream(
+  iterable: AsyncIterable<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const iterator = iterable[Symbol.asyncIterator]();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const next = await iterator.next();
+      if (next.done) {
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(next.value);
+    },
+    async cancel() {
+      await iterator.return?.();
+    },
+  });
+}
+
+/**
+ * Run a Hashbrown provider text stream against aimock and collect frames.
+ */
+export async function runProviderTextWithAimock(
+  options: ProviderTextAimockRunOptions,
+): Promise<Frame[]> {
+  const aimock = await startAimock({ fixturePath: options.fixturePath });
+  const abortController = new AbortController();
+
+  try {
+    const stream = toReadableStream(options.createStream(aimock));
+    const frames: Frame[] = [];
+
+    for await (const frame of decodeFrames(stream, {
+      signal: abortController.signal,
+    })) {
+      frames.push(frame);
+    }
+
+    return frames;
+  } finally {
+    abortController.abort();
+    await aimock.stop();
+  }
+}

--- a/tools/testing/aimock/writer-compat.ts
+++ b/tools/testing/aimock/writer-compat.ts
@@ -1,0 +1,130 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { AimockHandle } from './aimock-runner';
+
+/**
+ * Local compatibility server that maps Writer SDK chat requests to aimock's
+ * OpenAI-compatible chat completions endpoint.
+ */
+export interface WriterCompatHandle {
+  /** Base URL passed to the Writer SDK. */
+  readonly baseUrl: string;
+  /** Stop the compatibility server. Safe to call more than once. */
+  stop(): Promise<void>;
+}
+
+function readRequestBody(request: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    request.on('data', (chunk: Buffer) => chunks.push(chunk));
+    request.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    request.on('error', reject);
+  });
+}
+
+function writeJsonError(
+  response: ServerResponse,
+  status: number,
+  message: string,
+): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ error: { message } }));
+}
+
+function normalizeWriterRequest(rawBody: string): string {
+  const body = JSON.parse(rawBody) as Record<string, unknown>;
+  const toolChoice = body['tool_choice'];
+
+  return JSON.stringify({
+    ...body,
+    tool_choice:
+      toolChoice &&
+      typeof toolChoice === 'object' &&
+      !Array.isArray(toolChoice) &&
+      'value' in toolChoice
+        ? (toolChoice as { value: unknown }).value
+        : toolChoice,
+  });
+}
+
+/**
+ * Start a compatibility server for Writer SDK e2e tests backed by aimock.
+ */
+export async function startWriterCompatServer(
+  aimock: AimockHandle,
+): Promise<WriterCompatHandle> {
+  const server = createServer(async (request, response) => {
+    if (request.method !== 'POST' || request.url !== '/v1/chat') {
+      writeJsonError(response, 404, 'Not found');
+      return;
+    }
+
+    try {
+      const rawBody = await readRequestBody(request);
+      const upstream = await fetch(`${aimock.openAiBaseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          authorization: request.headers.authorization ?? '',
+          'content-type': 'application/json',
+        },
+        body: normalizeWriterRequest(rawBody),
+      });
+
+      response.writeHead(upstream.status, {
+        'content-type':
+          upstream.headers.get('content-type') ?? 'application/json',
+      });
+
+      if (!upstream.body) {
+        response.end();
+        return;
+      }
+
+      const reader = upstream.body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        response.write(value);
+      }
+
+      response.end();
+    } catch (error: unknown) {
+      writeJsonError(
+        response,
+        500,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  let stopped = false;
+  const address = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}

--- a/tools/testing/jest.config.ts
+++ b/tools/testing/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'testing',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/tools/testing',
+};

--- a/tools/testing/project.json
+++ b/tools/testing/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "testing",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "tools/testing",
+  "projectType": "library",
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/tools/testing"],
+      "options": {
+        "jestConfig": "tools/testing/jest.config.ts",
+        "passWithNoTests": false
+      }
+    }
+  }
+}

--- a/tools/testing/tsconfig.json
+++ b/tools/testing/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": []
+}

--- a/tools/testing/tsconfig.spec.json
+++ b/tools/testing/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@hashbrownai/ollama": ["packages/ollama/src/index.ts"],
       "@hashbrownai/openai": ["packages/openai/src/index.ts"],
       "@hashbrownai/react": ["packages/react/src/index.ts"],
+      "@hashbrownai/testing/aimock": ["tools/testing/aimock/index.ts"],
       "@hashbrownai/vox": ["packages/vox/src/index.ts"],
       "@hashbrownai/vox/loader": [
         "packages/vox/src/assets/vad_audio_worklet.single.js"


### PR DESCRIPTION
## Summary

- add a shared aimock-backed provider e2e harness and deterministic fixtures under `tools/testing`
- migrate provider integration/e2e specs to local fixture replay for OpenAI, Anthropic, Azure, Google, Bedrock, Ollama, and Writer
- add test-only provider base URL seams for Google and Ollama plus a Writer compatibility bridge
- include affected `e2e` targets in PR CI and preserve the public Angular `MagicText` export while satisfying component lint rules

## Validation

- `git diff --check`
- `NX_DAEMON=false npx nx affected -t lint,test,build,e2e --parallel=3 --uncommitted`

## Notes

- The affected Nx run completed successfully locally. It emitted existing warning noise for stale browser metadata, bundle sizes, jsdom CSS parsing around `@starting-style`, and existing lint warnings.
- `@copilotkit/aimock` declares a Node >=24 engine, but the local Node 22.14.0 install and test run completed successfully.
