### PR TITLE
feat: add structured output modes

### DIFF
--- a/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
@@ -1,8 +1,7 @@
-import { act, renderHook } from '@testing-library/react';
-import { type ReactNode } from 'react';
+import { TestBed } from '@angular/core/testing';
 import { s } from '@hashbrownai/core';
-import { HashbrownProvider } from '../hashbrown-provider';
-import { useStructuredChat } from './use-structured-chat';
+import { provideHashbrown } from '../providers/provide-hashbrown.fn';
+import { structuredChatResource } from './structured-chat-resource.fn';
 
 const fryHashbrownMock = vi.hoisted(() => vi.fn());
 
@@ -15,56 +14,26 @@ vi.mock('@hashbrownai/core', async (importOriginal) => {
   };
 });
 
-test('useStructuredChat initializes with the provided message history', () => {
-  const messages = [
-    {
-      role: 'user' as const,
-      content: 'What is the current portfolio risk?',
-    },
-  ];
+test('structuredChatResource passes structured output options to Hashbrown', () => {
   fryHashbrownMock.mockReset();
   fryHashbrownMock.mockImplementation((init) =>
     createHashbrownStub({ messages: init.messages ?? [] }),
   );
 
-  const { result } = renderHook(
-    () =>
-      useStructuredChat({
-        model: 'gpt-4.1',
-        system: 'You are a portfolio analyst.',
-        schema: s.object('risk summary', {
-          risk: s.string('Risk level'),
-        }),
-        messages,
-      }),
-    { wrapper: ProviderWrapper },
-  );
-
-  expect(result.current.messages).toEqual(messages);
-});
-
-test('useStructuredChat passes structured output options to Hashbrown', async () => {
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockImplementation((init) =>
-    createHashbrownStub({ messages: init.messages ?? [] }),
-  );
-
-  renderHook(
-    () =>
-      useStructuredChat({
-        model: 'gpt-4.1',
-        system: 'You are a portfolio analyst.',
-        schema: s.object('risk summary', {
-          risk: s.string('Risk level'),
-        }),
-        structuredOutput: { mode: 'json' },
-      }),
-    { wrapper: ProviderWrapper },
-  );
-
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model: 'gpt-4.1',
+      system: 'You are a portfolio analyst.',
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+      structuredOutput: { mode: 'json' },
+    }),
+  );
 
   expect(fryHashbrownMock).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -72,10 +41,6 @@ test('useStructuredChat passes structured output options to Hashbrown', async ()
     }),
   );
 });
-
-function ProviderWrapper({ children }: { children: ReactNode }) {
-  return <HashbrownProvider url="/chat">{children}</HashbrownProvider>;
-}
 
 function createHashbrownStub({ messages }: { messages: unknown[] }) {
   return {

--- a/packages/angular/src/resources/structured-chat-resource.fn.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.ts
@@ -30,8 +30,10 @@ import { toDeepSignal } from '../utils/deep-signal';
  * @typeParam Output - The type of the output from the chat.
  * @typeParam Tools - The set of tool definitions available to the chat.
  */
-export interface StructuredChatResourceRef<Output, Tools extends Chat.AnyTool>
-  extends Resource<Chat.Message<Output, Tools>[]> {
+export interface StructuredChatResourceRef<
+  Output,
+  Tools extends Chat.AnyTool,
+> extends Resource<Chat.Message<Output, Tools>[]> {
   /**
    * Indicates whether the underlying chat call is currently sending a message.
    */
@@ -161,6 +163,10 @@ export interface StructuredChatResourceOptions<
    */
   transport?: TransportOrFactory;
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+  /**
    * Whether this structured chat is generating UI content.
    */
   ui?: boolean;
@@ -204,6 +210,7 @@ export function structuredChatResource<
     debounce: options.debounce,
     retries: options.retries,
     transport: options.transport ?? config.transport,
+    structuredOutput: options.structuredOutput,
     ui: options.ui ?? false,
     threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
   });
@@ -218,6 +225,7 @@ export function structuredChatResource<
     hashbrown.updateOptions({
       model,
       system,
+      structuredOutput: options.structuredOutput,
       ui: options.ui ?? false,
       threadId,
     });

--- a/packages/angular/src/resources/structured-completion-resource.fn.ts
+++ b/packages/angular/src/resources/structured-completion-resource.fn.ts
@@ -15,8 +15,9 @@ import { toDeepSignal } from '../utils/deep-signal';
  *
  * @public
  */
-export interface StructuredCompletionResourceRef<Output>
-  extends Resource<Output | null> {
+export interface StructuredCompletionResourceRef<
+  Output,
+> extends Resource<Output | null> {
   /**
    * Indicates whether the underlying completion call is currently sending a message.
    */
@@ -110,6 +111,10 @@ export interface StructuredCompletionResourceOptions<
    */
   transport?: TransportOrFactory;
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+  /**
    * Whether this completion is UI generating.
    */
   ui?: boolean;
@@ -156,6 +161,7 @@ export function structuredCompletionResource<
     retries,
     debounce,
     transport: options.transport,
+    structuredOutput: options.structuredOutput,
     ui: options.ui ?? false,
     threadId: options.threadId,
   });

--- a/packages/angular/src/resources/ui-chat-resource.fn.ts
+++ b/packages/angular/src/resources/ui-chat-resource.fn.ts
@@ -86,6 +86,11 @@ export interface UiChatResourceOptions<Tools extends Chat.AnyTool> {
   transport?: TransportOrFactory;
 
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
+  /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
   threadId?: SignalLike<string | undefined>;
@@ -96,8 +101,9 @@ export interface UiChatResourceOptions<Tools extends Chat.AnyTool> {
  *
  * @public
  */
-export interface UiChatResourceRef<Tools extends Chat.AnyTool>
-  extends Resource<UiChatMessage<Tools>[]> {
+export interface UiChatResourceRef<Tools extends Chat.AnyTool> extends Resource<
+  UiChatMessage<Tools>[]
+> {
   /**
    * Send a new user message to the chat.
    *
@@ -162,6 +168,7 @@ export function uiChatResource<Tools extends Chat.AnyTool>(
     debounce: args.debounce,
     apiUrl: args.apiUrl,
     transport: args.transport,
+    structuredOutput: args.structuredOutput,
     ui: true,
     threadId: args.threadId,
   });
@@ -173,9 +180,7 @@ export function uiChatResource<Tools extends Chat.AnyTool>(
       return messages.map((message): UiChatMessage<Tools> => {
         if (message.role === 'assistant') {
           const content = message.content as
-            | s.Infer<typeof internalSchema>
-            | ''
-            | undefined;
+            s.Infer<typeof internalSchema> | '' | undefined;
 
           if (!content) {
             return {

--- a/packages/angular/src/resources/ui-completion-resource.fn.ts
+++ b/packages/angular/src/resources/ui-completion-resource.fn.ts
@@ -82,6 +82,11 @@ export interface UiCompletionResourceOptions<
   transport?: TransportOrFactory;
 
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
+  /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
   threadId?: SignalLike<string | undefined>;
@@ -92,8 +97,9 @@ export interface UiCompletionResourceOptions<
  *
  * @public
  */
-export interface UiCompletionResourceRef<Tools extends Chat.AnyTool>
-  extends Resource<UiAssistantMessage<Tools> | null> {
+export interface UiCompletionResourceRef<
+  Tools extends Chat.AnyTool,
+> extends Resource<UiAssistantMessage<Tools> | null> {
   /**
    * Indicates whether the underlying completion call is currently sending a request.
    */
@@ -169,6 +175,7 @@ export function uiCompletionResource<
     retries: options.retries,
     debounce: options.debounce,
     transport: options.transport,
+    structuredOutput: options.structuredOutput,
     ui: true,
     threadId: options.threadId,
   });

--- a/packages/azure/src/integration.spec.ts
+++ b/packages/azure/src/integration.spec.ts
@@ -11,6 +11,30 @@ const AZURE_ENDPOINT = process.env['AZURE_ENDPOINT'] ?? '';
 
 jest.setTimeout(60_000);
 
+test('Azure JSON response format mode requests JSON object output', async () => {
+  let capturedResponseFormat: unknown;
+
+  await consumeProviderStream(
+    HashbrownAzure.stream.text({
+      apiKey: 'test-api-key',
+      endpoint: 'https://example.openai.azure.com/',
+      request: {
+        operation: 'generate',
+        model: 'gpt-4o@2025-01-01-preview',
+        system: 'Respond with JSON.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        responseFormatMode: 'json',
+      },
+      transformRequestOptions: (options) => {
+        capturedResponseFormat = options.response_format;
+        throw new Error('stop');
+      },
+    }),
+  );
+
+  expect(capturedResponseFormat).toEqual({ type: 'json_object' });
+});
+
 test('Azure OpenAI Text Streaming', async () => {
   const server = await createServer((request) =>
     HashbrownAzure.stream.text({
@@ -351,6 +375,14 @@ async function createServer(
     url: `http://127.0.0.1:${address.port}/chat`,
     close: () => server.close(),
   };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
 }
 
 async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {

--- a/packages/azure/src/stream/text.fn.ts
+++ b/packages/azure/src/stream/text.fn.ts
@@ -37,8 +37,10 @@ type ThreadfulOptions = BaseAzureTextStreamOptions & ThreadPersistenceOptions;
 
 export type AzureTextStreamOptions = ThreadlessOptions | ThreadfulOptions;
 
-export interface AzureCompletionCreateParams
-  extends Omit<Chat.Api.CompletionCreateParams, 'model'> {
+export interface AzureCompletionCreateParams extends Omit<
+  Chat.Api.CompletionCreateParams,
+  'model'
+> {
   model: AzureKnownModelIds;
 }
 
@@ -60,6 +62,7 @@ export async function* text(
     model: modelAndVersion,
     tools,
     responseFormat,
+    responseFormatMode,
     system,
     toolChoice,
   } = request;
@@ -189,17 +192,7 @@ export async function* text(
             }))
           : undefined,
       tool_choice: toolChoice,
-      response_format: responseFormat
-        ? {
-            type: 'json_schema',
-            json_schema: {
-              strict: true,
-              name: 'schema',
-              description: '',
-              schema: responseFormat as Record<string, unknown>,
-            },
-          }
-        : undefined,
+      response_format: createResponseFormat(responseFormatMode, responseFormat),
     };
 
     const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =
@@ -275,6 +268,29 @@ export async function* text(
       return;
     }
   }
+}
+
+function createResponseFormat(
+  responseFormatMode: Chat.Api.ResponseFormatMode | undefined,
+  responseFormat: object | undefined,
+): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
+  if (responseFormatMode === 'json') {
+    return { type: 'json_object' };
+  }
+
+  if (!responseFormat) {
+    return undefined;
+  }
+
+  return {
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: responseFormat as Record<string, unknown>,
+    },
+  };
 }
 
 function normalizeError(error: unknown): { message: string; stack?: string } {

--- a/packages/core/src/actions/dev.actions.ts
+++ b/packages/core/src/actions/dev.actions.ts
@@ -12,6 +12,7 @@ export default createActionGroup('dev', {
     messages?: Chat.AnyMessage[];
     tools?: Chat.AnyTool[];
     responseSchema?: s.SchemaOutput;
+    structuredOutput?: Chat.Api.StructuredOutputOptions;
     middleware?: Chat.Middleware[];
     emulateStructuredOutput?: boolean;
     retries?: number;
@@ -35,6 +36,7 @@ export default createActionGroup('dev', {
     system?: string;
     tools?: Chat.AnyTool[];
     responseSchema?: s.SchemaOutput;
+    structuredOutput?: Chat.Api.StructuredOutputOptions;
     middleware?: Chat.Middleware[];
     emulateStructuredOutput?: boolean;
     debounce?: number;

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1,4 +1,5 @@
 import { Chat } from '../models';
+import { s } from '../schema';
 import { apiActions, devActions } from '../actions';
 import {
   selectApiMessages,
@@ -14,6 +15,7 @@ import {
   selectRetries,
   selectShouldGenerateMessage,
   selectStreamingMessageError,
+  selectStructuredOutput,
   selectSystem,
   selectThreadId,
   selectToolEntities,
@@ -45,8 +47,7 @@ jest.mock('../transport', () => {
   };
 });
 
-// In tests we don't care about selector input typing; loosen to avoid variance
-type SelectorKey = (state: any) => unknown;
+type SelectorKey = (state: never) => unknown;
 type ActionLike = { type: string; payload?: unknown };
 type TestHandler = {
   types: string[];
@@ -74,6 +75,7 @@ function createTestStore(selectorOverrides: SelectorMap = new Map()) {
     [selectToolEntities, {}],
     [selectSystem, 'You are a test bot'],
     [selectEmulateStructuredOutput, false],
+    [selectStructuredOutput, undefined],
     [selectThreadId, undefined],
     [selectTransport, { kind: 'test-transport' }],
     [selectUiRequested, false],
@@ -506,6 +508,136 @@ test('updateMessagesWithDelta returns null when nothing to update', () => {
 
   expect(message).toBeNull();
 });
+
+test('generateMessage sends schema response format mode by default for structured output', async () => {
+  const send = mockSuccessfulSelection();
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectResponseSchema, s.object('response', {})],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: {},
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      params: expect.objectContaining({
+        responseFormat: expect.any(Object),
+        responseFormatMode: 'schema',
+        toolChoice: undefined,
+      }),
+    }),
+  );
+
+  teardown?.();
+});
+
+test('generateMessage sends json response format mode without provider schema', async () => {
+  const send = mockSuccessfulSelection();
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectResponseSchema, s.object('response', {})],
+      [selectStructuredOutput, { mode: 'json' }],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: {},
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      params: expect.objectContaining({
+        responseFormat: undefined,
+        responseFormatMode: 'json',
+        toolChoice: undefined,
+      }),
+    }),
+  );
+
+  teardown?.();
+});
+
+test('generateMessage lets resource-level tool mode override strict structured output', async () => {
+  const send = mockSuccessfulSelection();
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectResponseSchema, s.object('response', {})],
+      [selectStructuredOutput, { mode: 'tool' }],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: {},
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      params: expect.objectContaining({
+        responseFormat: undefined,
+        responseFormatMode: undefined,
+        toolChoice: 'required',
+      }),
+    }),
+  );
+
+  teardown?.();
+});
+
+function mockSuccessfulSelection() {
+  const ModelResolverMock = jest.mocked(ModelResolver);
+  const send = jest.fn(async () => ({
+    frames: (async function* () {
+      yield { type: 'generation-start' as const };
+      yield { type: 'generation-finish' as const };
+    })(),
+  }));
+  const selection = {
+    spec: { name: 'selected-model' },
+    transport: { send },
+    metadata: { chosenSpec: 'selected-model', skippedSpecs: [] },
+  };
+
+  ModelResolverMock.mockImplementation(
+    () =>
+      ({
+        select: jest.fn(async () => selection),
+        skipFromError: jest.fn(),
+        getMetadata: jest.fn(() => selection.metadata),
+      }) as unknown as ModelResolver,
+  );
+
+  return send;
+}
 
 describe('generateMessage effect', () => {
   const ModelResolverMock = jest.mocked(ModelResolver);

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -19,6 +19,7 @@ import {
   selectRetries,
   selectShouldGenerateMessage,
   selectStreamingMessageError,
+  selectStructuredOutput,
   selectSystem,
   selectThreadId,
   selectToolEntities,
@@ -57,6 +58,11 @@ export const generateMessage = createEffect((store) => {
       const toolsByName = store.read(selectToolEntities);
       const system = store.read(selectSystem);
       const emulateStructuredOutput = store.read(selectEmulateStructuredOutput);
+      const structuredOutput = store.read(selectStructuredOutput);
+      const structuredOutputMode = responseSchema
+        ? (structuredOutput?.mode ??
+          (emulateStructuredOutput ? 'tool' : 'strict'))
+        : undefined;
       const shouldGenerateMessage = store.read(selectShouldGenerateMessage);
       const threadId = store.read(selectThreadId);
       const shouldLoadThread = Boolean(threadId) && messages.length === 0;
@@ -79,19 +85,24 @@ export const generateMessage = createEffect((store) => {
         system,
         messages: messagePayload,
         tools,
-        toolChoice:
-          emulateStructuredOutput && responseSchema ? 'required' : undefined,
+        toolChoice: structuredOutputMode === 'tool' ? 'required' : undefined,
         responseFormat:
-          !emulateStructuredOutput && responseSchema
+          structuredOutputMode === 'strict' && responseSchema
             ? s.toJsonSchema(responseSchema)
             : undefined,
+        responseFormatMode:
+          structuredOutputMode === 'strict'
+            ? 'schema'
+            : structuredOutputMode === 'json'
+              ? 'json'
+              : undefined,
         threadId: threadId,
       };
 
       const requestedFeatures: RequestedFeatures = {
         tools:
           Boolean(params.tools?.length) || params.toolChoice === 'required',
-        structured: Boolean(params.responseFormat),
+        structured: Boolean(params.responseFormatMode),
         ui: store.read(selectUiRequested),
         threads: Boolean(threadId),
       };

--- a/packages/core/src/hashbrown.ts
+++ b/packages/core/src/hashbrown.ts
@@ -79,6 +79,7 @@ export interface Hashbrown<Output, Tools extends Chat.AnyTool> {
       system: string;
       tools: Tools[];
       responseSchema: s.SchemaOutput;
+      structuredOutput: Chat.Api.StructuredOutputOptions;
       middleware: Chat.Middleware[];
       emulateStructuredOutput: boolean;
       debounce: number;
@@ -110,6 +111,7 @@ export interface Hashbrown<Output, Tools extends Chat.AnyTool> {
  *   - `messages`: Initial message history
  *   - `tools`: Array of tools to enable in the instance
  *   - `responseSchema`: JSON schema for validating structured output
+ *   - `structuredOutput`: Resource-level structured output mode
  *   - `middleware`: Middleware functions to run on messages
  *   - `emulateStructuredOutput`: Whether to emulate structured output behavior
  *   - `debounce`: Debounce interval in milliseconds for sending messages
@@ -124,6 +126,7 @@ export function fryHashbrown<Tools extends Chat.AnyTool>(init: {
   messages?: Chat.Message<string, Tools>[];
   tools?: Tools[];
   middleware?: Chat.Middleware[];
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
   emulateStructuredOutput?: boolean;
   debounce?: number;
   retries?: number;
@@ -146,6 +149,7 @@ export function fryHashbrown<
   messages?: Chat.Message<Output, Tools>[];
   tools?: Tools[];
   responseSchema: Schema;
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
   middleware?: Chat.Middleware[];
   emulateStructuredOutput?: boolean;
   debounce?: number;
@@ -165,6 +169,7 @@ export function fryHashbrown(init: {
   messages?: Chat.Message<string, Chat.AnyTool>[];
   tools?: Chat.AnyTool[];
   responseSchema?: s.SchemaOutput;
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
   middleware?: Chat.Middleware[];
   emulateStructuredOutput?: boolean;
   debounce?: number;
@@ -213,6 +218,7 @@ export function fryHashbrown(init: {
       messages: init.messages as Chat.AnyMessage[],
       tools: init.tools as Chat.AnyTool[],
       responseSchema: init.responseSchema,
+      structuredOutput: init.structuredOutput,
       middleware: init.middleware,
       emulateStructuredOutput: init.emulateStructuredOutput,
       debounce: init.debounce,
@@ -253,6 +259,7 @@ export function fryHashbrown(init: {
       system: string;
       tools: Chat.AnyTool[];
       responseSchema: s.SchemaOutput;
+      structuredOutput: Chat.Api.StructuredOutputOptions;
       middleware: Chat.Middleware[];
       emulateStructuredOutput: boolean;
       debounce: number;

--- a/packages/core/src/models/api.models.ts
+++ b/packages/core/src/models/api.models.ts
@@ -64,10 +64,7 @@ export interface ToolMessage {
  * @public
  */
 export type Message =
-  | UserMessage
-  | ErrorMessage
-  | AssistantMessage
-  | ToolMessage;
+  UserMessage | ErrorMessage | AssistantMessage | ToolMessage;
 
 /**
  * @public
@@ -95,6 +92,36 @@ export interface CompletionChunk {
 export type CompletionToolChoiceOption = 'auto' | 'none' | 'required';
 
 /**
+ * Controls how structured resource schemas are enforced by the provider.
+ *
+ * @public
+ */
+export type StructuredOutputMode = 'strict' | 'json' | 'tool';
+
+/**
+ * Options for structured output generation.
+ *
+ * @public
+ */
+export interface StructuredOutputOptions {
+  /**
+   * The structured output mode to use.
+   *
+   * - `strict` sends the schema to providers that support schema-constrained output.
+   * - `json` asks the provider for JSON without schema-constrained decoding.
+   * - `tool` uses the reserved output tool for emulated structured output.
+   */
+  mode?: StructuredOutputMode;
+}
+
+/**
+ * Provider-facing response format mode.
+ *
+ * @public
+ */
+export type ResponseFormatMode = 'schema' | 'json';
+
+/**
  * @public
  */
 export interface CompletionCreateParams {
@@ -103,6 +130,7 @@ export interface CompletionCreateParams {
   system: string;
   messages: Message[];
   responseFormat?: object;
+  responseFormatMode?: ResponseFormatMode;
   toolChoice?: CompletionToolChoiceOption;
   tools?: Tool[];
   threadId?: string;

--- a/packages/core/src/reducers/config.reducer.ts
+++ b/packages/core/src/reducers/config.reducer.ts
@@ -10,6 +10,7 @@ export interface ConfigState {
   system: string;
   debounce: number;
   responseSchema?: s.HashbrownType;
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
   middleware?: Chat.Middleware[];
   emulateStructuredOutput: boolean;
   retries: number;
@@ -42,6 +43,7 @@ export const reducer = createReducer(
       system: action.payload.system,
       debounce: action.payload.debounce ?? state.debounce,
       responseSchema,
+      structuredOutput: action.payload.structuredOutput,
       middleware: action.payload.middleware,
       emulateStructuredOutput:
         action.payload.emulateStructuredOutput ?? state.emulateStructuredOutput,
@@ -82,6 +84,8 @@ export const selectSystem = (state: ConfigState) => state.system;
 export const selectDebounce = (state: ConfigState) => state.debounce;
 export const selectResponseSchema = (state: ConfigState) =>
   state.responseSchema;
+export const selectStructuredOutput = (state: ConfigState) =>
+  state.structuredOutput;
 export const selectMiddleware = (state: ConfigState) => state.middleware;
 export const selectEmulateStructuredOutput = (state: ConfigState) =>
   state.emulateStructuredOutput;

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -207,6 +207,10 @@ export const selectResponseSchema = select(
   selectConfigState,
   fromConfig.selectResponseSchema,
 );
+export const selectStructuredOutput = select(
+  selectConfigState,
+  fromConfig.selectStructuredOutput,
+);
 export const selectEmulateStructuredOutput = select(
   selectConfigState,
   fromConfig.selectEmulateStructuredOutput,

--- a/packages/google/src/integration.spec.ts
+++ b/packages/google/src/integration.spec.ts
@@ -11,6 +11,34 @@ const VERTEX_AI_LOCATION = process.env['GOOGLE_CLOUD_LOCATION'] ?? '';
 
 jest.setTimeout(60_000);
 
+test('Google JSON response format mode requests JSON without a schema', async () => {
+  let capturedConfig: unknown;
+
+  await consumeProviderStream(
+    HashbrownGoogle.stream.text({
+      apiKey: 'test-api-key',
+      request: {
+        operation: 'generate',
+        model: 'gemini-2.5-flash',
+        system: 'Respond with JSON.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        responseFormatMode: 'json',
+      },
+      transformRequestOptions: (options) => {
+        capturedConfig = options.config;
+        throw new Error('stop');
+      },
+    }),
+  );
+
+  expect(capturedConfig).toEqual(
+    expect.objectContaining({
+      responseMimeType: 'application/json',
+      responseJsonSchema: undefined,
+    }),
+  );
+});
+
 test('Google Text Streaming', async () => {
   const server = await createServer((request) =>
     HashbrownGoogle.stream.text({
@@ -525,6 +553,14 @@ async function createServer(
     url: `http://127.0.0.1:${address.port}/chat`,
     close: () => server.close(),
   };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
 }
 
 async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {

--- a/packages/google/src/stream/text.fn.ts
+++ b/packages/google/src/stream/text.fn.ts
@@ -61,7 +61,14 @@ export async function* text(
   options: GoogleTextStreamOptions,
 ): AsyncIterable<Uint8Array> {
   const { request, transformRequestOptions, loadThread, saveThread } = options;
-  const { model, tools, responseFormat, toolChoice, system } = request;
+  const {
+    model,
+    tools,
+    responseFormat,
+    responseFormatMode,
+    toolChoice,
+    system,
+  } = request;
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
   let effectiveThreadId = threadId;
@@ -214,8 +221,12 @@ export async function* text(
       systemInstruction: {
         parts: [{ text: system }],
       },
-      responseMimeType: responseFormat ? 'application/json' : 'text/plain',
-      responseJsonSchema: responseFormat,
+      responseMimeType:
+        responseFormatMode === 'json' || responseFormat
+          ? 'application/json'
+          : 'text/plain',
+      responseJsonSchema:
+        responseFormatMode === 'json' ? undefined : responseFormat,
     };
 
     // Only include tools and toolConfig when there are actual tools

--- a/packages/ollama/src/stream/text.fn.spec.ts
+++ b/packages/ollama/src/stream/text.fn.spec.ts
@@ -140,6 +140,27 @@ test('passes transformed request options to the selected client', async () => {
   );
 });
 
+test('uses Ollama JSON format for JSON response format mode', async () => {
+  resetOllamaMocks();
+  const chat = jest.fn().mockResolvedValue(createOllamaStream());
+  mockedDefaultClient.chat = chat;
+
+  await consumeStream(
+    text({
+      request: {
+        ...createRequest(),
+        responseFormatMode: 'json',
+      },
+    }),
+  );
+
+  expect(chat).toHaveBeenCalledWith(
+    expect.objectContaining({
+      format: 'json',
+    }),
+  );
+});
+
 async function consumeStream(stream: AsyncIterable<Uint8Array>): Promise<void> {
   for await (const chunk of stream) {
     void chunk;

--- a/packages/ollama/src/stream/text.fn.ts
+++ b/packages/ollama/src/stream/text.fn.ts
@@ -55,7 +55,7 @@ export async function* text(
   options: OpenAITextStreamOptions,
 ): AsyncIterable<Uint8Array> {
   const { request, transformRequestOptions, loadThread, saveThread } = options;
-  const { model, tools, responseFormat, system } = request;
+  const { model, tools, responseFormat, responseFormatMode, system } = request;
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
   let effectiveThreadId = threadId;
@@ -167,7 +167,7 @@ export async function* text(
               },
             }))
           : undefined,
-      format: responseFormat ? responseFormat : undefined,
+      format: responseFormatMode === 'json' ? 'json' : responseFormat,
     };
 
     const resolvedOptions: ChatRequest & { stream: true } =

--- a/packages/openai/src/integration.spec.ts
+++ b/packages/openai/src/integration.spec.ts
@@ -11,6 +11,29 @@ const OPENAI_MODEL = (process.env['OPENAI_MODEL'] ??
 
 jest.setTimeout(60_000);
 
+test('OpenAI JSON response format mode requests JSON object output', async () => {
+  let capturedResponseFormat: unknown;
+
+  await consumeProviderStream(
+    HashbrownOpenAI.stream.text({
+      apiKey: 'test-api-key',
+      request: {
+        operation: 'generate',
+        model: OPENAI_MODEL,
+        system: 'Respond with JSON.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        responseFormatMode: 'json',
+      },
+      transformRequestOptions: (options) => {
+        capturedResponseFormat = options.response_format;
+        throw new Error('stop');
+      },
+    }),
+  );
+
+  expect(capturedResponseFormat).toEqual({ type: 'json_object' });
+});
+
 test('OpenAI Text Streaming', async () => {
   const server = await createServer((request) =>
     HashbrownOpenAI.stream.text({
@@ -358,6 +381,14 @@ async function createServer(
     url: `http://127.0.0.1:${address.port}/chat`,
     close: () => server.close(),
   };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
 }
 
 async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -50,7 +50,14 @@ export async function* text(
     loadThread,
     saveThread,
   } = options;
-  const { model, tools, responseFormat, toolChoice, system } = request;
+  const {
+    model,
+    tools,
+    responseFormat,
+    responseFormatMode,
+    toolChoice,
+    system,
+  } = request;
   const threadId = request.threadId;
   let loadedThread: Chat.Api.Message[] = [];
   let effectiveThreadId = threadId;
@@ -171,17 +178,7 @@ export async function* text(
             }))
           : undefined,
       tool_choice: toolChoice,
-      response_format: responseFormat
-        ? {
-            type: 'json_schema',
-            json_schema: {
-              strict: true,
-              name: 'schema',
-              description: '',
-              schema: responseFormat as Record<string, unknown>,
-            },
-          }
-        : undefined,
+      response_format: createResponseFormat(responseFormatMode, responseFormat),
     };
 
     const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =
@@ -260,6 +257,29 @@ export async function* text(
       return;
     }
   }
+}
+
+function createResponseFormat(
+  responseFormatMode: Chat.Api.ResponseFormatMode | undefined,
+  responseFormat: object | undefined,
+): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
+  if (responseFormatMode === 'json') {
+    return { type: 'json_object' };
+  }
+
+  if (!responseFormat) {
+    return undefined;
+  }
+
+  return {
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: responseFormat as Record<string, unknown>,
+    },
+  };
 }
 
 function normalizeError(error: unknown): { message: string; stack?: string } {

--- a/packages/react/src/hooks/use-structured-chat.tsx
+++ b/packages/react/src/hooks/use-structured-chat.tsx
@@ -78,6 +78,12 @@ export interface UseStructuredChatOptions<
    * Optional transport override for this hook.
    */
   transport?: TransportOrFactory;
+
+  /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
   /**
    * Whether this structured chat is expected to produce UI elements.
    */
@@ -253,6 +259,7 @@ export function useStructuredChat<
       debounce: options.debounceTime,
       retries: options.retries,
       transport: options.transport ?? config.transport,
+      structuredOutput: options.structuredOutput,
       ui: options.ui ?? false,
       threadId: options.threadId,
     });
@@ -285,6 +292,7 @@ export function useStructuredChat<
       debounce: options.debounceTime,
       retries: options.retries,
       transport: options.transport ?? config.transport,
+      structuredOutput: options.structuredOutput,
       ui: options.ui ?? false,
       threadId: options.threadId,
     });
@@ -301,6 +309,7 @@ export function useStructuredChat<
     options.debounceTime,
     options.retries,
     options.transport,
+    options.structuredOutput,
     options.ui,
     options.threadId,
   ]);
@@ -318,9 +327,7 @@ export function useStructuredChat<
   );
   const error = useHashbrownSignal(hashbrown.current.error);
   const sendingError = useHashbrownSignal(hashbrown.current.sendingError);
-  const generatingError = useHashbrownSignal(
-    hashbrown.current.generatingError,
-  );
+  const generatingError = useHashbrownSignal(hashbrown.current.generatingError);
   const lastAssistantMessage = useHashbrownSignal(
     hashbrown.current.lastAssistantMessage,
   );

--- a/packages/react/src/hooks/use-structured-completion.tsx
+++ b/packages/react/src/hooks/use-structured-completion.tsx
@@ -65,6 +65,12 @@ export interface UseStructuredCompletionOptions<
    * Optional transport override for this hook.
    */
   transport?: TransportOrFactory;
+
+  /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
   /**
    * Whether this completion should be treated as UI-generating.
    */

--- a/packages/react/src/hooks/use-ui-chat.tsx
+++ b/packages/react/src/hooks/use-ui-chat.tsx
@@ -64,9 +64,7 @@ export type UiErrorMessage = Chat.ErrorMessage;
  * @typeParam Tools - The set of tool definitions available to the chat.
  */
 export type UiChatMessage<Tools extends Chat.AnyTool> =
-  | UiAssistantMessage<Tools>
-  | UiErrorMessage
-  | UiUserMessage;
+  UiAssistantMessage<Tools> | UiErrorMessage | UiUserMessage;
 
 /**
  * Options for the `useUiChat` hook.
@@ -123,6 +121,11 @@ export interface UiChatOptions<Tools extends Chat.AnyTool> {
   transport?: TransportOrFactory;
 
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
+  /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
   threadId?: string;
@@ -165,11 +168,7 @@ export interface UiChatOptions<Tools extends Chat.AnyTool> {
 export const useUiChat = <Tools extends Chat.AnyTool>(
   options: UiChatOptions<Tools>,
 ) => {
-  const {
-    components: initialComponents,
-    examples,
-    ...chatOptions
-  } = options;
+  const { components: initialComponents, examples, ...chatOptions } = options;
   const [components, setComponents] = useState(initialComponents);
   const uiKit = useUiKit<ExposedComponent<any>>({ components, examples });
   const ui = useMemo(() => uiKit.schema, [uiKit.serializedSchema]);

--- a/packages/react/src/hooks/use-ui-completion.tsx
+++ b/packages/react/src/hooks/use-ui-completion.tsx
@@ -14,10 +14,7 @@ import {
   useState,
 } from 'react';
 import { ExposedComponent } from '../expose-component.fn';
-import {
-  UiAssistantMessage,
-  UiChatSchema,
-} from './use-ui-chat';
+import { UiAssistantMessage, UiChatSchema } from './use-ui-chat';
 import { useUiKit, type UiKitInput } from './use-ui-kit';
 import {
   useStructuredCompletion,
@@ -83,6 +80,11 @@ export interface UiCompletionOptions<
   transport?: TransportOrFactory;
 
   /**
+   * Controls how the provider is asked to produce structured output.
+   */
+  structuredOutput?: Chat.Api.StructuredOutputOptions;
+
+  /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
   threadId?: string;
@@ -93,8 +95,10 @@ export interface UiCompletionOptions<
  *
  * @public
  */
-export interface UseUiCompletionResult<Tools extends Chat.AnyTool>
-  extends Omit<UseStructuredCompletionResult<UiChatSchema>, 'output'> {
+export interface UseUiCompletionResult<Tools extends Chat.AnyTool> extends Omit<
+  UseStructuredCompletionResult<UiChatSchema>,
+  'output'
+> {
   /**
    * The assistant message that contains the rendered UI elements.
    */

--- a/packages/writer/src/integration.spec.ts
+++ b/packages/writer/src/integration.spec.ts
@@ -9,6 +9,29 @@ const WRITER_API_KEY = process.env['WRITER_API_KEY'] ?? '';
 
 jest.setTimeout(60_000);
 
+test('Writer JSON response format mode does not request a provider schema', async () => {
+  let capturedResponseFormat: unknown;
+
+  await consumeProviderStream(
+    HashbrownWriter.stream.text({
+      apiKey: 'test-api-key',
+      request: {
+        operation: 'generate',
+        model: 'palmyra-x5',
+        system: 'Respond with JSON.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        responseFormatMode: 'json',
+      },
+      transformRequestOptions: (options) => {
+        capturedResponseFormat = options.response_format;
+        throw new Error('stop');
+      },
+    }),
+  );
+
+  expect(capturedResponseFormat).toBeUndefined();
+});
+
 test('Writer Text Streaming', async () => {
   const server = await createServer((request) =>
     HashbrownWriter.stream.text({
@@ -369,6 +392,14 @@ async function createServer(
     url: `http://127.0.0.1:${address.port}/chat`,
     close: () => server.close(),
   };
+}
+
+async function consumeProviderStream(
+  stream: AsyncIterable<Uint8Array>,
+): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
 }
 
 async function waitUntilHashbrownIsSettled(hashbrown: Hashbrown<any, any>) {

--- a/packages/writer/src/stream/text.fn.ts
+++ b/packages/writer/src/stream/text.fn.ts
@@ -118,17 +118,10 @@ export async function* text(
       tool_choice: request.toolChoice
         ? { value: request.toolChoice }
         : undefined,
-      response_format: request.responseFormat
-        ? {
-            type: 'json_schema',
-            json_schema: {
-              strict: true,
-              name: 'schema',
-              description: '',
-              schema: request.responseFormat,
-            },
-          }
-        : undefined,
+      response_format: createResponseFormat(
+        request.responseFormatMode,
+        request.responseFormat,
+      ),
       tools:
         request.tools && request.tools.length > 0
           ? request.tools.map((tool) => ({
@@ -262,4 +255,29 @@ export async function* text(
       });
     }
   }
+}
+
+function createResponseFormat(
+  responseFormatMode: Chat.Api.ResponseFormatMode | undefined,
+  responseFormat: object | undefined,
+): Writer.Chat.ChatChatParams['response_format'] {
+  if (responseFormatMode === 'json') {
+    // Writer supports text or json_schema response formats, so JSON mode
+    // relies on Hashbrown's prompt guidance and local parsing.
+    return undefined;
+  }
+
+  if (!responseFormat) {
+    return undefined;
+  }
+
+  return {
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: responseFormat,
+    },
+  };
 }

--- a/www/analog/src/app/pages/docs/angular/concept/structured-output.md
+++ b/www/analog/src/app/pages/docs/angular/concept/structured-output.md
@@ -4,6 +4,7 @@ meta:
   - name: description
     content: 'Specify the JSON schema of the model response.'
 ---
+
 # Structured Output
 
 <p class="subtitle">Specify the JSON schema of the model response.</p>
@@ -76,19 +77,50 @@ The `schema` option accepts Skillet schemas, Standard JSON Schema objects (the `
 
 ---
 
+### Structured Output Modes
+
+Structured resources use provider schema enforcement by default. For very large or complex schemas, you can ask the provider for JSON without sending the full schema, while Hashbrown still parses, streams, validates, and retries locally.
+
+<hb-code-example header="use JSON mode for a complex schema">
+
+```ts
+chat = structuredChatResource({
+  model: 'gpt-4.1',
+  system: 'Return a dashboard configuration for the current user.',
+  schema: dashboardSchema,
+  structuredOutput: { mode: 'json' },
+  retries: 2,
+});
+```
+
+</hb-code-example>
+
+The available modes are:
+
+| Mode     | Behavior                                                                                     |
+| -------- | -------------------------------------------------------------------------------------------- |
+| `strict` | Default. Sends the schema to providers that support schema-constrained structured output.    |
+| `json`   | Requests JSON output without sending the provider schema. Hashbrown still validates locally. |
+| `tool`   | Uses Hashbrown's reserved output tool for emulated structured output.                        |
+
+Provider support differs. OpenAI and Azure use JSON object mode, Google sets the response MIME type to JSON, Ollama uses `format: 'json'`, and Writer omits `response_format` because its SDK currently supports only `text` and `json_schema`.
+
+---
+
 ### `StructuredChatResourceOptions`
 
-| Option      | Type                                     | Required | Description                                               |
-| ----------- | ---------------------------------------- | -------- | --------------------------------------------------------- |
-| `model`     | `KnownModelIds \| Signal<KnownModelIds>` | Yes      | The model to use for the structured chat resource         |
-| `system`    | `string \| Signal<string>`               | Yes      | The system prompt to use for the structured chat resource |
-| `schema`    | `s.SchemaOutput`                         | Yes      | The schema to use for the structured chat resource        |
-| `tools`     | `Tools[]`                                | No       | The tools to use for the structured chat resource         |
-| `messages`  | `Chat.Message<Output, Tools>[]`          | No       | The initial messages for the structured chat resource     |
-| `debugName` | `string`                                 | No       | The debug name for the structured chat resource           |
-| `debounce`  | `number`                                 | No       | The debounce time for the structured chat resource        |
-| `retries`   | `number`                                 | No       | The number of retries for the structured chat resource    |
-| `apiUrl`    | `string`                                 | No       | The API URL to use for the structured chat resource       |
+| Option             | Type                                     | Required | Description                                                     |
+| ------------------ | ---------------------------------------- | -------- | --------------------------------------------------------------- |
+| `model`            | `KnownModelIds \| Signal<KnownModelIds>` | Yes      | The model to use for the structured chat resource               |
+| `system`           | `string \| Signal<string>`               | Yes      | The system prompt to use for the structured chat resource       |
+| `schema`           | `s.SchemaOutput`                         | Yes      | The schema to use for the structured chat resource              |
+| `tools`            | `Tools[]`                                | No       | The tools to use for the structured chat resource               |
+| `messages`         | `Chat.Message<Output, Tools>[]`          | No       | The initial messages for the structured chat resource           |
+| `debugName`        | `string`                                 | No       | The debug name for the structured chat resource                 |
+| `debounce`         | `number`                                 | No       | The debounce time for the structured chat resource              |
+| `retries`          | `number`                                 | No       | The number of retries for the structured chat resource          |
+| `apiUrl`           | `string`                                 | No       | The API URL to use for the structured chat resource             |
+| `structuredOutput` | `StructuredOutputOptions`                | No       | Controls how the provider is asked to produce structured output |
 
 ---
 
@@ -173,15 +205,16 @@ When the user types a scene name, the LLM will predict which lights should be ad
 
 ### `StructuredCompletionResourceOptions`
 
-| Option      | Type                                 | Required | Description                                                     |
-| ----------- | ------------------------------------ | -------- | --------------------------------------------------------------- |
-| `model`     | `KnownModelIds`                      | Yes      | The model to use for the structured completion resource         |
-| `input`     | `Signal<null \| undefined \| Input>` | Yes      | The input to the structured completion resource                 |
-| `schema`    | `s.SchemaOutput`                     | Yes      | The schema to use for the structured completion resource        |
-| `system`    | `SignalLike<string>`                 | Yes      | The system prompt to use for the structured completion resource |
-| `tools`     | `Chat.AnyTool[]`                     | No       | The tools to use for the structured completion resource         |
-| `debugName` | `string`                             | No       | The debug name for the structured completion resource           |
-| `apiUrl`    | `string`                             | No       | The API URL to use for the structured completion resource       |
+| Option             | Type                                 | Required | Description                                                     |
+| ------------------ | ------------------------------------ | -------- | --------------------------------------------------------------- |
+| `model`            | `KnownModelIds`                      | Yes      | The model to use for the structured completion resource         |
+| `input`            | `Signal<null \| undefined \| Input>` | Yes      | The input to the structured completion resource                 |
+| `schema`           | `s.SchemaOutput`                     | Yes      | The schema to use for the structured completion resource        |
+| `system`           | `SignalLike<string>`                 | Yes      | The system prompt to use for the structured completion resource |
+| `tools`            | `Chat.AnyTool[]`                     | No       | The tools to use for the structured completion resource         |
+| `debugName`        | `string`                             | No       | The debug name for the structured completion resource           |
+| `apiUrl`           | `string`                             | No       | The API URL to use for the structured completion resource       |
+| `structuredOutput` | `StructuredOutputOptions`            | No       | Controls how the provider is asked to produce structured output |
 
 ---
 

--- a/www/analog/src/app/pages/docs/react/concept/structured-output.md
+++ b/www/analog/src/app/pages/docs/react/concept/structured-output.md
@@ -4,6 +4,7 @@ meta:
   - name: description
     content: 'Specify the JSON schema of the model response.'
 ---
+
 # Structured Output
 
 <p class="subtitle">Specify the JSON schema of the model response.</p>
@@ -81,18 +82,49 @@ The `schema` option accepts Skillet schemas, Standard JSON Schema objects (the `
 
 ---
 
+### Structured Output Modes
+
+Structured resources use provider schema enforcement by default. For very large or complex schemas, you can ask the provider for JSON without sending the full schema, while Hashbrown still parses, streams, validates, and retries locally.
+
+<hb-code-example header="use JSON mode for a complex schema">
+
+```tsx
+const chat = useStructuredChat({
+  model: 'gpt-4.1',
+  system: 'Return a dashboard configuration for the current user.',
+  schema: dashboardSchema,
+  structuredOutput: { mode: 'json' },
+  retries: 2,
+});
+```
+
+</hb-code-example>
+
+The available modes are:
+
+| Mode     | Behavior                                                                                     |
+| -------- | -------------------------------------------------------------------------------------------- |
+| `strict` | Default. Sends the schema to providers that support schema-constrained structured output.    |
+| `json`   | Requests JSON output without sending the provider schema. Hashbrown still validates locally. |
+| `tool`   | Uses Hashbrown's reserved output tool for emulated structured output.                        |
+
+Provider support differs. OpenAI and Azure use JSON object mode, Google sets the response MIME type to JSON, Ollama uses `format: 'json'`, and Writer omits `response_format` because its SDK currently supports only `text` and `json_schema`.
+
+---
+
 ### `UseStructuredChatOptions`
 
-| Option         | Type                            | Required | Description                                         |
-| -------------- | ------------------------------- | -------- | --------------------------------------------------- |
-| `model`        | `KnownModelIds`                 | Yes      | The model to use for the structured chat            |
-| `system`       | `string`                        | Yes      | The system prompt to use for the structured chat    |
-| `schema`       | `s.SchemaOutput`                | Yes      | The schema to use for the structured chat           |
-| `tools`        | `Tools[]`                       | No       | The tools to make available for the structured chat |
-| `messages`     | `Chat.Message<Output, Tools>[]` | No       | The initial messages for the structured chat        |
-| `debugName`    | `string`                        | No       | The debug name for the structured chat              |
-| `debounceTime` | `number`                        | No       | The debounce time between sends to the endpoint     |
-| `retries`      | `number`                        | No       | The number of retries if an error is received       |
+| Option             | Type                            | Required | Description                                                     |
+| ------------------ | ------------------------------- | -------- | --------------------------------------------------------------- |
+| `model`            | `KnownModelIds`                 | Yes      | The model to use for the structured chat                        |
+| `system`           | `string`                        | Yes      | The system prompt to use for the structured chat                |
+| `schema`           | `s.SchemaOutput`                | Yes      | The schema to use for the structured chat                       |
+| `tools`            | `Tools[]`                       | No       | The tools to make available for the structured chat             |
+| `messages`         | `Chat.Message<Output, Tools>[]` | No       | The initial messages for the structured chat                    |
+| `debugName`        | `string`                        | No       | The debug name for the structured chat                          |
+| `debounceTime`     | `number`                        | No       | The debounce time between sends to the endpoint                 |
+| `retries`          | `number`                        | No       | The number of retries if an error is received                   |
+| `structuredOutput` | `StructuredOutputOptions`       | No       | Controls how the provider is asked to produce structured output |
 
 ---
 
@@ -185,16 +217,17 @@ Let's review the code above.
 
 ### `UseStructuredCompletionOptions`
 
-| Option         | Type                         | Required | Description                                               |
-| -------------- | ---------------------------- | -------- | --------------------------------------------------------- |
-| `model`        | `KnownModelIds`              | Yes      | The model to use for the structured completion            |
-| `input`        | `Input \| null \| undefined` | Yes      | The input to the structured completion                    |
-| `schema`       | `s.SchemaOutput`             | Yes      | The schema to use for the structured completion           |
-| `system`       | `string`                     | Yes      | The system prompt to use for the structured completion    |
-| `tools`        | `Chat.AnyTool[]`             | No       | The tools to make available for the structured completion |
-| `debugName`    | `string`                     | No       | The debug name for the structured completion              |
-| `debounceTime` | `number`                     | No       | The debounce time between sends to the endpoint           |
-| `retries`      | `number`                     | No       | The number of retries if an error is received             |
+| Option             | Type                         | Required | Description                                                     |
+| ------------------ | ---------------------------- | -------- | --------------------------------------------------------------- |
+| `model`            | `KnownModelIds`              | Yes      | The model to use for the structured completion                  |
+| `input`            | `Input \| null \| undefined` | Yes      | The input to the structured completion                          |
+| `schema`           | `s.SchemaOutput`             | Yes      | The schema to use for the structured completion                 |
+| `system`           | `string`                     | Yes      | The system prompt to use for the structured completion          |
+| `tools`            | `Chat.AnyTool[]`             | No       | The tools to make available for the structured completion       |
+| `debugName`        | `string`                     | No       | The debug name for the structured completion                    |
+| `debounceTime`     | `number`                     | No       | The debounce time between sends to the endpoint                 |
+| `retries`          | `number`                     | No       | The number of retries if an error is received                   |
+| `structuredOutput` | `StructuredOutputOptions`    | No       | Controls how the provider is asked to produce structured output |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds resource-level `structuredOutput` options for strict schema, JSON-only, and tool-emulated structured output modes.
- Maps JSON mode across provider adapters: OpenAI/Azure use JSON object output, Google requests JSON MIME output, Ollama uses `format: 'json'`, and Writer omits unsupported provider response formatting while Hashbrown validates locally.
- Passes the option through React and Angular structured/UI resources and documents the advanced JSON-mode workflow.

Closes #467

## Test Plan
- `npx nx build core`
- `npx nx test core`
- `npx nx lint core`
- `npx nx build react`
- `npx vitest run --config packages/react/vite.config.ts`
- `npx nx build angular`
- `npx nx test angular`
- `npx nx lint angular`
- `npx nx run-many -t build -p openai azure google ollama writer`
- `npx nx run-many -t test -p openai azure google ollama writer`
- `npx nx run-many -t lint -p openai azure google ollama`
- `npx nx e2e openai -- -t \"OpenAI JSON response format mode\"`
- `npx nx e2e azure -- -t \"Azure JSON response format mode\"`
- `npx nx e2e google -- -t \"Google JSON response format mode\"`
- `npx nx e2e writer -- -t \"Writer JSON response format mode\"`
- `npx nx test ollama -- --runTestsByPath packages/ollama/src/stream/text.fn.spec.ts`
- `npx nx build-api-report core`
- `npx nx build-api-report react`
- `npx nx build-api-report angular`
- `npx nx run-many -t build-api-report -p openai azure google ollama writer`
- `npx nx build www`
- `npx nx test www`
- `git diff --check`

Notes: provider `test` targets for OpenAI/Azure/Google/Writer currently report no tests by configuration; focused request-mapping checks run through their `e2e` targets without network calls. Nx flagged `angular:build:production` as flaky after an earlier parallel build race, but a standalone rerun and dependent docs/API builds succeeded.