### PR TITLE
chore: clean up warning noise

### DIFF
--- a/packages/angular/src/components/magic-text-renderer.component.ts
+++ b/packages/angular/src/components/magic-text-renderer.component.ts
@@ -91,9 +91,11 @@ export class MagicTextRenderNode {
     inject<TemplateRef<MagicTextNodeRenderContext>>(TemplateRef);
 
   static ngTemplateContextGuard(
-    dir: MagicTextRenderNode,
-    context: unknown,
-  ): context is $Implicit<MagicTextNodeRenderContext> {
+    _dir: MagicTextRenderNode,
+    _context: unknown,
+  ): _context is $Implicit<MagicTextNodeRenderContext> {
+    void _context;
+
     return true;
   }
 }
@@ -105,9 +107,11 @@ export class MagicTextRenderTextSegment {
     inject<TemplateRef<MagicTextTextSegmentRenderContext>>(TemplateRef);
 
   static ngTemplateContextGuard(
-    dir: MagicTextRenderTextSegment,
-    context: unknown,
-  ): context is $Implicit<MagicTextTextSegmentRenderContext> {
+    _dir: MagicTextRenderTextSegment,
+    _context: unknown,
+  ): _context is $Implicit<MagicTextTextSegmentRenderContext> {
+    void _context;
+
     return true;
   }
 }
@@ -118,9 +122,11 @@ export class MagicTextRenderCaret {
   readonly template = inject<TemplateRef<MagicTextCaretContext>>(TemplateRef);
 
   static ngTemplateContextGuard(
-    dir: MagicTextRenderCaret,
-    context: unknown,
-  ): context is $Implicit<MagicTextCaretContext> {
+    _dir: MagicTextRenderCaret,
+    _context: unknown,
+  ): _context is $Implicit<MagicTextCaretContext> {
+    void _context;
+
     return true;
   }
 }
@@ -132,10 +138,12 @@ export class MagicTextRenderCitation {
     inject<TemplateRef<MagicTextCitationRenderContext>>(TemplateRef);
 
   static ngTemplateContextGuard(
-    dir: MagicTextRenderCitation,
-    context: unknown,
-  ): context is $Implicit<MagicTextCitationRenderContext> &
+    _dir: MagicTextRenderCitation,
+    _context: unknown,
+  ): _context is $Implicit<MagicTextCitationRenderContext> &
     MagicTextCitationRenderContext {
+    void _context;
+
     return true;
   }
 }

--- a/packages/core/src/models/internal_helpers.ts
+++ b/packages/core/src/models/internal_helpers.ts
@@ -84,6 +84,9 @@ export function toViewMessagesFromInternal(
   outputSchema?: s.HashbrownType,
   streaming = true,
 ): Chat.AnyMessage[] {
+  void outputSchema;
+  void streaming;
+
   switch (message.role) {
     case 'user': {
       return [

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -148,7 +148,6 @@ export const reducer = createReducer(
 
       const config = state.configSnapshot;
       const responseSchema = config?.responseSchema;
-      const emulateStructuredOutput = config?.emulateStructuredOutput ?? false;
       const toolsByName = config?.toolsByName ?? {};
 
       const delta = choice.delta;

--- a/packages/ollama/src/stream/text.fn.ts
+++ b/packages/ollama/src/stream/text.fn.ts
@@ -195,7 +195,7 @@ export async function* text(
                 index,
                 function: {
                   ...toolCall.function,
-                  arguments: toolCall.function.arguments as any,
+                  arguments: toolCall.function.arguments as unknown as string,
                 },
               })),
             },
@@ -286,11 +286,9 @@ function normalizeError(error: unknown): { message: string; stack?: string } {
   return { message: String(error) };
 }
 
-function normalizeToolArguments(args: unknown): {
-  [key: string]: any;
-} {
+function normalizeToolArguments(args: unknown): Record<string, unknown> {
   if (args && typeof args === 'object') {
-    return args as { [key: string]: any };
+    return args as Record<string, unknown>;
   }
 
   if (typeof args === 'string') {
@@ -304,7 +302,7 @@ function normalizeToolArguments(args: unknown): {
         }
       }
       if (parsed && typeof parsed === 'object') {
-        return parsed as { [key: string]: any };
+        return parsed as Record<string, unknown>;
       }
     } catch {
       // Fall through to empty object when args are not valid JSON.


### PR DESCRIPTION
## Summary
- remove stale structured-output local state in the streaming reducer
- explicitly acknowledge compatibility-only helper and Angular template guard parameters
- narrow Ollama tool argument typing away from `any`

## Validation
- `npx nx lint core`
- `npx nx lint angular`
- `npx nx lint ollama`
- `npx nx test core`
- `npx nx test angular -- --run packages/angular/src/components/magic-text-renderer.component.spec.ts`
- `npx nx test ollama`
- `npx nx build core`
- `npx nx build angular`
- `npx nx build ollama`
- `git diff --check`

Note: existing broader tooling warnings remain visible, including the `NO_COLOR`/`FORCE_COLOR` Node warning, jsdom CSS parser output in Angular tests, and Rollup source map warnings in core builds.