### PR TITLE
chore: reduce tooling warning noise

### DIFF
--- a/packages/angular/src/components/magic-text-renderer.component.ts
+++ b/packages/angular/src/components/magic-text-renderer.component.ts
@@ -806,10 +806,16 @@ export class MagicTextRenderCitation {
   `,
   styles: `
     .hb-magic-text-segment {
-      opacity: 1;
-      transition: opacity 400ms ease-out;
-      @starting-style {
+      animation: hb-magic-text-segment-enter 400ms ease-out;
+    }
+
+    @keyframes hb-magic-text-segment-enter {
+      from {
         opacity: 0;
+      }
+
+      to {
+        opacity: 1;
       }
     }
 

--- a/packages/angular/vite.config.mts
+++ b/packages/angular/vite.config.mts
@@ -9,7 +9,7 @@ import { defineConfig } from 'vite';
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   return {
-    plugins: [angular(), nxViteTsPaths()],
+    plugins: [angular({ tsconfig: './tsconfig.spec.json' }), nxViteTsPaths()],
     test: {
       globals: true,
       environment: 'jsdom',

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -24,6 +24,7 @@
         "outputFileName": "index",
         "outputFileExtensionForEsm": ".mjs",
         "outputFileExtensionForCjs": ".cjs",
+        "sourceMap": true,
         "useLegacyTypescriptPlugin": false,
         "assets": [
           {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,9 +11,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.esm.js",
-      "require": "./index.cjs.js",
-      "types": "./index.d.ts"
+      "require": "./index.cjs.js"
     }
   },
   "files": [

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -22,6 +22,7 @@
         "outputPath": "dist/packages/react",
         "format": ["esm", "cjs"],
         "generateExportsField": true,
+        "sourceMap": true,
         "useLegacyTypescriptPlugin": false,
         "assets": [
           {

--- a/packages/react/src/magic-text-renderer.tsx
+++ b/packages/react/src/magic-text-renderer.tsx
@@ -259,10 +259,16 @@ const DEFAULT_CITATION_CLASS = 'hb-magic-text-citation';
 const DEFAULT_CITATION_LABEL_CLASS = 'hb-magic-text-citation-label';
 const DEFAULT_STYLES = `
   .${DEFAULT_ROOT_CLASS} .hb-magic-text-segment {
-    opacity: 1;
-    transition: opacity 400ms ease-out;
-    @starting-style {
+    animation: hb-magic-text-segment-enter 400ms ease-out;
+  }
+
+  @keyframes hb-magic-text-segment-enter {
+    from {
       opacity: 0;
+    }
+
+    to {
+      opacity: 1;
     }
   }
 
@@ -516,10 +522,7 @@ function renderDefaultCitation(
         data-magic-text-node={node.type}
         data-node-open={String(!node.closed)}
       >
-        <span
-          role="doc-noteref"
-          className={DEFAULT_CITATION_LABEL_CLASS}
-        >
+        <span role="doc-noteref" className={DEFAULT_CITATION_LABEL_CLASS}>
           {label}
         </span>
       </sup>


### PR DESCRIPTION
## Summary
- replace `@starting-style` in magic text default styles with keyframe animations so jsdom can parse the stylesheet during tests
- point the Angular Vitest plugin at the existing spec tsconfig to avoid the missing `tsconfig.app.json` warning
- enable Rollup sourcemaps for core and React to match TypeScript source map output
- order React export conditions with `types` first to avoid the package export warning

## Validation
- `NX_DAEMON=false FORCE_COLOR=0 npx nx lint angular`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx test angular -- --run packages/angular/src/components/magic-text-renderer.component.spec.ts`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build angular`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx lint core`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx test core`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build core`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build react`
- `git diff --check`

## Notes
- `FORCE_COLOR=0` is used in local validation to isolate repository warnings from the current shell's `NO_COLOR` environment.
- React build still emits Nx's existing package-type/CJS-format message; resolving that needs a separate package-shape decision.