### PR TITLE
fix: ship react as dual package

### DIFF
--- a/packages/react/e2e/package-shape.e2e.spec.ts
+++ b/packages/react/e2e/package-shape.e2e.spec.ts
@@ -1,0 +1,116 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+type PackageJson = {
+  main?: string;
+  module?: string;
+  types?: string;
+  exports?: {
+    '.'?: {
+      types?: string;
+      import?: string;
+      require?: string;
+    };
+  };
+};
+
+const workspaceRoot = resolve(__dirname, '../../..');
+const reactDistPath = join(workspaceRoot, 'dist/packages/react');
+const coreDistPath = join(workspaceRoot, 'dist/packages/core');
+
+function readReactPackageJson(): PackageJson {
+  return JSON.parse(
+    readFileSync(join(reactDistPath, 'package.json'), 'utf8'),
+  ) as PackageJson;
+}
+
+function runNodePackageCheck(script: string, sandboxPath: string) {
+  return spawnSync(
+    process.execPath,
+    ['--input-type=module', '--eval', script],
+    {
+      cwd: sandboxPath,
+      env: {
+        ...process.env,
+        NODE_PATH: join(sandboxPath, 'node_modules'),
+      },
+      encoding: 'utf8',
+    },
+  );
+}
+
+function createPackageSandbox(): string {
+  const sandboxPath = mkdtempSync(join(tmpdir(), 'hashbrown-react-package-'));
+  const nodeModulesPath = join(sandboxPath, 'node_modules');
+  const scopePath = join(nodeModulesPath, '@hashbrownai');
+  mkdirSync(scopePath, { recursive: true });
+  cpSync(reactDistPath, join(scopePath, 'react'), { recursive: true });
+  cpSync(coreDistPath, join(scopePath, 'core'), { recursive: true });
+  symlinkSync(
+    join(workspaceRoot, 'node_modules/react'),
+    join(nodeModulesPath, 'react'),
+    'dir',
+  );
+  symlinkSync(
+    join(workspaceRoot, 'node_modules/react-dom'),
+    join(nodeModulesPath, 'react-dom'),
+    'dir',
+  );
+  return sandboxPath;
+}
+
+test('published React package metadata exposes ESM and CJS entrypoints', () => {
+  const packageJson = readReactPackageJson();
+
+  expect(packageJson.types).toBe('./index.d.ts');
+  expect(packageJson.module).toBe('./index.mjs');
+  expect(packageJson.main).toBe('./index.cjs');
+  expect(packageJson.exports?.['.']).toEqual({
+    types: './index.d.ts',
+    import: './index.mjs',
+    require: './index.cjs',
+  });
+  expect(existsSync(join(reactDistPath, 'index.d.ts'))).toBe(true);
+  expect(existsSync(join(reactDistPath, 'index.mjs'))).toBe(true);
+  expect(existsSync(join(reactDistPath, 'index.cjs'))).toBe(true);
+});
+
+test('published React package can be imported and required by package name', () => {
+  const sandboxPath = createPackageSandbox();
+
+  try {
+    const result = runNodePackageCheck(
+      `
+        import { createRequire } from 'node:module';
+
+        const require = createRequire(import.meta.url);
+        const cjs = require('@hashbrownai/react');
+        const esm = await import('@hashbrownai/react');
+
+        if (typeof cjs.HashbrownProvider !== 'function') {
+          throw new Error('CJS entrypoint did not expose HashbrownProvider');
+        }
+
+        if (typeof esm.HashbrownProvider !== 'function') {
+          throw new Error('ESM entrypoint did not expose HashbrownProvider');
+        }
+      `,
+      sandboxPath,
+    );
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  } finally {
+    rmSync(sandboxPath, { recursive: true, force: true });
+  }
+});

--- a/packages/react/jest.e2e.config.ts
+++ b/packages/react/jest.e2e.config.ts
@@ -1,0 +1,11 @@
+export default {
+  displayName: 'react-e2e',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.e2e.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/react-e2e',
+  testMatch: ['<rootDir>/**/*.e2e.spec.ts'],
+};

--- a/packages/react/package-output.config.cjs
+++ b/packages/react/package-output.config.cjs
@@ -1,0 +1,22 @@
+module.exports = (config) => {
+  if (!config.output) {
+    return config;
+  }
+
+  const outputs = Array.isArray(config.output)
+    ? config.output
+    : [config.output];
+
+  return {
+    ...config,
+    output: outputs.map((output) => {
+      const extension = output.format === 'cjs' ? 'cjs' : 'mjs';
+
+      return {
+        ...output,
+        entryFileNames: `[name].${extension}`,
+        chunkFileNames: `[name]-[hash].${extension}`,
+      };
+    }),
+  };
+};

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,16 +4,15 @@
   "description": "React components for Hashbrown AI",
   "license": "MIT",
   "sideEffects": false,
-  "type": "module",
-  "module": "./index.esm.js",
-  "main": "./index.cjs.js",
+  "module": "./index.mjs",
+  "main": "./index.cjs",
   "types": "./index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
-      "import": "./index.esm.js",
-      "require": "./index.cjs.js"
+      "import": "./index.mjs",
+      "require": "./index.cjs"
     }
   },
   "files": [

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -21,10 +21,17 @@
         "tsConfig": "packages/react/tsconfig.lib.json",
         "outputPath": "dist/packages/react",
         "format": ["esm", "cjs"],
-        "generateExportsField": true,
+        "rollupConfig": "packages/react/package-output.config.cjs",
+        "generateExportsField": false,
+        "generatePackageJson": false,
         "sourceMap": true,
         "useLegacyTypescriptPlugin": false,
         "assets": [
+          {
+            "input": "packages/react",
+            "glob": "package.json",
+            "output": "."
+          },
           {
             "input": "packages/react",
             "glob": "LICENSE",
@@ -40,6 +47,20 @@
       "dependsOn": [
         {
           "projects": ["core"],
+          "target": "build"
+        }
+      ]
+    },
+    "e2e": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/packages/react-e2e"],
+      "options": {
+        "jestConfig": "packages/react/jest.e2e.config.ts",
+        "passWithNoTests": false
+      },
+      "dependsOn": [
+        {
+          "projects": ["react"],
           "target": "build"
         }
       ]

--- a/packages/react/src/expose-component.fn.ts
+++ b/packages/react/src/expose-component.fn.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { s, ɵtypes, type ComponentFallbackProps } from '@hashbrownai/core';
+import { type ComponentFallbackProps, s, ɵtypes } from '@hashbrownai/core';
 import type { ComponentType } from 'react';
 
 /**

--- a/packages/react/src/hooks/use-ui-chat.tsx
+++ b/packages/react/src/hooks/use-ui-chat.tsx
@@ -11,7 +11,7 @@ import {
 import { ReactElement, useCallback, useMemo, useState } from 'react';
 import { ExposedComponent } from '../expose-component.fn';
 import { useStructuredChat } from './use-structured-chat';
-import { useUiKit, type UiKitInput } from './use-ui-kit';
+import { type UiKitInput, useUiKit } from './use-ui-kit';
 
 /**
  * Represents a UI component in the chat schema with its properties and children.

--- a/packages/react/src/hooks/use-ui-completion.tsx
+++ b/packages/react/src/hooks/use-ui-completion.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react';
 import { ExposedComponent } from '../expose-component.fn';
 import { UiAssistantMessage, UiChatSchema } from './use-ui-chat';
-import { useUiKit, type UiKitInput } from './use-ui-kit';
+import { type UiKitInput, useUiKit } from './use-ui-kit';
 import {
   useStructuredCompletion,
   type UseStructuredCompletionResult,

--- a/packages/react/src/hooks/use-ui-kit.tsx
+++ b/packages/react/src/hooks/use-ui-kit.tsx
@@ -3,9 +3,9 @@ import {
   type ComponentTree,
   type UiKit as CoreUiKit,
   type UiKitInput as CoreUiKitInput,
+  type SystemPrompt,
   type UiWrapper,
   ɵcreateUiKit,
-  type SystemPrompt,
 } from '@hashbrownai/core';
 import { useCallback, useMemo } from 'react';
 import type { ReactElement } from 'react';

--- a/packages/react/tsconfig.e2e.json
+++ b/packages/react/tsconfig.e2e.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": ["e2e/**/*.e2e.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- publish `@hashbrownai/react` with explicit ESM and CJS entrypoints (`index.mjs` and `index.cjs`)
- stop relying on Nx-generated React package metadata and copy the explicit package metadata into dist
- add a React e2e package-shape test that verifies dist metadata plus real Node `import` and `require` resolution
- fix React import-order lint errors surfaced by the inferred lint target

## Validation
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build react`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx test react`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx e2e react`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build-api-report react`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx eslint:lint react`
- `git diff --check`

Note: React lint exits 0 with existing warnings unrelated to this package-shape change.