### PR TITLE
feat: support reactive Angular resource options

### DIFF
--- a/docs/superpowers/plans/2026-07-07-angular-reactive-resource-options.md
+++ b/docs/superpowers/plans/2026-07-07-angular-reactive-resource-options.md
@@ -1,0 +1,611 @@
+# Angular Reactive Resource Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Angular chat and completion resources consistently accept Angular `Signal<T>` values for `model`, `apiUrl`, `system`, and `threadId`, and update the existing Hashbrown runtime when those values change.
+
+**Architecture:** Add a public Angular `ReactiveOption<T> = T | Signal<T>` helper and use it in resource option types. Root resources that own a `fryHashbrown(...)` runtime read reactive option values at initialization and from an Angular `effect()` that calls `hashbrown.updateOptions(...)`. Wrapper resources pass reactive options through to the root resource instead of unwrapping them.
+
+**Tech Stack:** Angular signals/resources, TypeScript, Vitest, Nx, Hashbrown core `fryHashbrown` runtime.
+
+---
+
+## File Structure
+
+- Modify `packages/angular/src/utils/types.ts`
+  - Add and export `ReactiveOption<T>`.
+  - Keep `SignalLike<T>` backward compatible unless the implementation can safely migrate all users.
+- Modify `packages/angular/src/utils/signals.ts`
+  - Reuse `readSignalLike()` for `ReactiveOption<T>` values.
+  - Do not document callback functions as public API.
+- Modify `packages/angular/src/resources/chat-resource.fn.ts`
+  - Use `ReactiveOption<T>` for `model`, `apiUrl`, `system`, and `threadId`.
+  - Add runtime option update effect.
+- Modify `packages/angular/src/resources/completion-resource.fn.ts`
+  - Use `ReactiveOption<T>` for `model`, `apiUrl`, `system`, and `threadId`.
+  - Add runtime option update effect without breaking input-to-message behavior.
+- Modify `packages/angular/src/resources/structured-chat-resource.fn.ts`
+  - Use `ReactiveOption<T>` for `model`, `apiUrl`, `system`, and `threadId`.
+  - Fix existing effect to read reactive values and include `apiUrl`.
+- Modify `packages/angular/src/resources/structured-completion-resource.fn.ts`
+  - Use `ReactiveOption<T>` in public options.
+  - Pass reactive options through to `structuredChatResource()`.
+- Modify `packages/angular/src/resources/ui-chat-resource.fn.ts`
+  - Use `ReactiveOption<T>` in public options.
+  - Keep `systemAsString` as a computed value and pass reactive `model`, `apiUrl`, and `threadId` through.
+- Modify `packages/angular/src/resources/ui-completion-resource.fn.ts`
+  - Use `ReactiveOption<T>` in public options.
+  - Keep `systemAsString` as a computed value and pass reactive `model`, `apiUrl`, and `threadId` through.
+- Modify `packages/angular/src/resources/chat-resource.fn.spec.ts`
+  - Add focused tests for reactive runtime options.
+- Create or modify `packages/angular/src/resources/completion-resource.fn.spec.ts`
+  - Add focused tests for reactive runtime options.
+- Modify `packages/angular/src/resources/structured-chat-resource.fn.spec.ts`
+  - Add focused tests for reactive runtime options.
+- Modify `packages/angular/src/resources/ui-chat-resource.spec.ts`
+  - Assert wrapper pass-through of reactive options.
+- Modify `packages/angular/src/resources/ui-completion-resource.spec.ts`
+  - Assert wrapper pass-through of reactive options.
+- Modify Angular docs under `www/analog/src/app/pages/docs/angular/**` only if API report/docs generation shows resource option pages need source examples beyond TSDoc.
+
+## Task 1: Add Public Reactive Option Type
+
+**Files:**
+- Modify: `packages/angular/src/utils/types.ts`
+- Read: `packages/angular/src/utils/index.ts`
+- Test through later type/build checks.
+
+- [ ] **Step 1: Add the type**
+
+Add a public TSDoc block and type:
+
+```ts
+/**
+ * A value that can be supplied directly or through an Angular signal.
+ *
+ * @public
+ * @typeParam T - The option value type.
+ */
+export type ReactiveOption<T> = T | Signal<T>;
+```
+
+- [ ] **Step 2: Keep `SignalLike<T>` stable**
+
+Leave existing `SignalLike<T>` exported unless every current consumer can be migrated in the same PR without breakage.
+
+Expected result: existing imports continue to compile.
+
+- [ ] **Step 3: Run a focused type check through Angular tests**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand
+```
+
+Expected: It may still pass before behavior changes. Any failure here should be unrelated to the new type and investigated before continuing.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/angular/src/utils/types.ts
+git commit -m "feat: add angular reactive option type"
+```
+
+## Task 2: Make `chatResource` Update Runtime Options Reactively
+
+**Files:**
+- Modify: `packages/angular/src/resources/chat-resource.fn.ts`
+- Modify: `packages/angular/src/resources/chat-resource.fn.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+In `packages/angular/src/resources/chat-resource.fn.spec.ts`, mock `fryHashbrown` using the existing pattern from `structured-chat-resource.fn.spec.ts`. Add a top-level test:
+
+```ts
+test('chatResource updates runtime options when option signals change', () => {
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/chat-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model,
+      apiUrl,
+      system,
+      threadId,
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/chat-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/chat-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+```
+
+Also assert initial `fryHashbrown` receives the signal values, not signal objects:
+
+```ts
+expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    model: 'gpt-4.1',
+    apiUrl: '/chat-a',
+    system: 'System A',
+    threadId: 'thread-a',
+  }),
+);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/chat-resource.fn.spec.ts
+```
+
+Expected: FAIL because `chatResource` does not currently call `updateOptions()` from an effect.
+
+- [ ] **Step 3: Implement minimal code**
+
+In `chat-resource.fn.ts`:
+
+- Import `effect`.
+- Change option types:
+
+```ts
+system: ReactiveOption<string>;
+model: ReactiveOption<ModelInput>;
+apiUrl?: ReactiveOption<string>;
+threadId?: ReactiveOption<string | undefined>;
+```
+
+- Read initial values:
+
+```ts
+apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+system: readSignalLike(options.system),
+model: readSignalLike(options.model),
+threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+```
+
+- Add an effect after `hashbrown` is created:
+
+```ts
+const optionsEffect = effect(() => {
+  hashbrown.updateOptions({
+    apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+    middleware: config.middleware?.map((m): Chat.Middleware => {
+      return (requestInit) =>
+        runInInjectionContext(injector, () => m(requestInit));
+    }),
+    system: readSignalLike(options.system),
+    model: readSignalLike(options.model),
+    tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
+    emulateStructuredOutput: config.emulateStructuredOutput,
+    debugName: options.debugName,
+    transport: options.transport ?? config.transport,
+    ui: false,
+    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+  });
+});
+```
+
+- Destroy it:
+
+```ts
+destroyRef.onDestroy(() => {
+  teardown();
+  optionsEffect.destroy();
+});
+```
+
+- [ ] **Step 4: Run focused test**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/chat-resource.fn.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/angular/src/resources/chat-resource.fn.ts packages/angular/src/resources/chat-resource.fn.spec.ts
+git commit -m "feat: update angular chat options reactively"
+```
+
+## Task 3: Make `completionResource` Update Runtime Options Reactively
+
+**Files:**
+- Modify: `packages/angular/src/resources/completion-resource.fn.ts`
+- Create or Modify: `packages/angular/src/resources/completion-resource.fn.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+If no spec exists, create `packages/angular/src/resources/completion-resource.fn.spec.ts`. Mock `fryHashbrown` and add a top-level test equivalent to:
+
+```ts
+test('completionResource updates runtime options when option signals change', () => {
+  const model = signal('gpt-4.1');
+  const apiUrl = signal('/completion-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model,
+      apiUrl,
+      system,
+      input,
+      threadId,
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/completion-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/completion-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+```
+
+Keep arrange/act/assert spacing and top-level `test(...)`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/completion-resource.fn.spec.ts
+```
+
+Expected: FAIL because runtime options are only read during initialization.
+
+- [ ] **Step 3: Implement minimal code**
+
+In `completion-resource.fn.ts`:
+
+- Use `ReactiveOption<string>` for `model`, `apiUrl`, `system`, and `threadId`.
+- Read initial values into `fryHashbrown`.
+- Add an `effect()` that calls `hashbrown.updateOptions(...)` with the latest values.
+- Keep the existing input effect that calls `hashbrown.setMessages(...)`.
+- Destroy the options effect with `destroyRef.onDestroy`.
+
+- [ ] **Step 4: Run focused test**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/completion-resource.fn.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/angular/src/resources/completion-resource.fn.ts packages/angular/src/resources/completion-resource.fn.spec.ts
+git commit -m "feat: update angular completion options reactively"
+```
+
+## Task 4: Make `structuredChatResource` Update All Runtime Options Reactively
+
+**Files:**
+- Modify: `packages/angular/src/resources/structured-chat-resource.fn.ts`
+- Modify: `packages/angular/src/resources/structured-chat-resource.fn.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add a top-level test:
+
+```ts
+test('structuredChatResource updates runtime options when option signals change', () => {
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/structured-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model,
+      apiUrl,
+      system,
+      threadId,
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/structured-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/structured-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+```
+
+Expected: FAIL because `model` is not read as a signal and `apiUrl` is not updated.
+
+- [ ] **Step 3: Implement minimal code**
+
+In `structured-chat-resource.fn.ts`:
+
+- Update option types to use `ReactiveOption<T>`.
+- Read `apiUrl`, `model`, `system`, and `threadId` with `readSignalLike()` for initialization.
+- Update the existing `optionsEffect` to read signal values and include `apiUrl`.
+- Keep existing `structuredOutput`, `ui`, and `threadId` behavior.
+
+- [ ] **Step 4: Run focused test**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/angular/src/resources/structured-chat-resource.fn.ts packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+git commit -m "feat: update angular structured chat options reactively"
+```
+
+## Task 5: Pass Reactive Options Through Wrapper Resources
+
+**Files:**
+- Modify: `packages/angular/src/resources/structured-completion-resource.fn.ts`
+- Modify: `packages/angular/src/resources/ui-chat-resource.fn.ts`
+- Modify: `packages/angular/src/resources/ui-completion-resource.fn.ts`
+- Modify: `packages/angular/src/resources/ui-chat-resource.spec.ts`
+- Modify: `packages/angular/src/resources/ui-completion-resource.spec.ts`
+- Create or Modify: `packages/angular/src/resources/structured-completion-resource.fn.spec.ts`
+
+- [ ] **Step 1: Write failing wrapper tests**
+
+For `structuredCompletionResource`, mock `structuredChatResource` and assert it receives signal objects for `model`, `apiUrl`, `system`, and `threadId`:
+
+```ts
+expect(structuredChatResourceMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    model,
+    apiUrl,
+    system,
+    threadId,
+  }),
+);
+```
+
+For `uiChatResource`, continue using the existing mocked `structuredChatResource` and assert:
+
+```ts
+expect(structuredChatResourceMock).toHaveBeenCalledWith(
+  expect.objectContaining({
+    model,
+    apiUrl,
+    threadId,
+  }),
+);
+```
+
+Do not assert `system` is the original signal for UI resources because UI resources intentionally compile `string | SystemPrompt` through `systemAsString` computed before passing it down. Assert `system: expect.any(Function)` instead.
+
+For `uiCompletionResource`, mock `structuredCompletionResource` and assert the same pass-through pattern.
+
+- [ ] **Step 2: Run wrapper tests to verify failures**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/structured-completion-resource.fn.spec.ts
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/ui-chat-resource.spec.ts
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand --testFile=packages/angular/src/resources/ui-completion-resource.spec.ts
+```
+
+Expected: FAIL where option types or pass-through behavior are still static.
+
+- [ ] **Step 3: Implement wrapper type updates**
+
+Update wrapper option interfaces:
+
+```ts
+model: ReactiveOption<ModelInput>;
+apiUrl?: ReactiveOption<string>;
+threadId?: ReactiveOption<string | undefined>;
+```
+
+For UI resources:
+
+```ts
+system: ReactiveOption<string | SystemPrompt>;
+```
+
+Keep `systemAsString` as a `computed(...)` and pass that computed to the delegated structured resource. Pass `model`, `apiUrl`, and `threadId` through unchanged.
+
+- [ ] **Step 4: Run wrapper tests**
+
+Run the same three focused commands from Step 2.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/angular/src/resources/structured-completion-resource.fn.ts packages/angular/src/resources/structured-completion-resource.fn.spec.ts packages/angular/src/resources/ui-chat-resource.fn.ts packages/angular/src/resources/ui-chat-resource.spec.ts packages/angular/src/resources/ui-completion-resource.fn.ts packages/angular/src/resources/ui-completion-resource.spec.ts
+git commit -m "feat: pass angular reactive options through wrappers"
+```
+
+## Task 6: API Report and Documentation
+
+**Files:**
+- Modify if needed: `packages/angular/angular.api.md` or generated API report artifacts for Angular.
+- Modify if needed: `www/analog/src/app/pages/docs/angular/**`
+
+- [ ] **Step 1: Run API report**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx build-api-report angular
+```
+
+Expected: If API Extractor reports changed public API output, update the checked-in Angular API report file according to the repo pattern.
+
+- [ ] **Step 2: Check generated report diff**
+
+Run:
+
+```sh
+git diff -- packages/angular
+```
+
+Expected: public API diff includes `ReactiveOption<T>` and widened resource option fields.
+
+- [ ] **Step 3: Update docs only if needed**
+
+Search docs:
+
+```sh
+rg "apiUrl|model|chatResource|structuredChatResource|uiChatResource" www/analog/src/app/pages/docs/angular -n
+```
+
+If resource docs include option tables or examples that explicitly say only `string`, update the relevant docs to mention `string | Signal<string>` or `ReactiveOption<T>`.
+
+- [ ] **Step 4: Commit API/docs changes**
+
+If files changed:
+
+```sh
+git add packages/angular www/analog/src/app/pages/docs/angular
+git commit -m "docs: document angular reactive resource options"
+```
+
+If no files changed, record that in the final implementation notes.
+
+## Task 7: Full Verification
+
+**Files:**
+- No source edits expected unless verification finds a real issue.
+
+- [ ] **Step 1: Run Angular test suite**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx test angular
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Angular lint**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx lint angular
+```
+
+Expected: PASS. Prefer fixing lint errors over suppressing them.
+
+- [ ] **Step 3: Run Angular build**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx build angular
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run API report**
+
+Run:
+
+```sh
+NX_DAEMON=false FORCE_COLOR=0 npx nx build-api-report angular
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run diff check**
+
+Run:
+
+```sh
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 6: Final commit if needed**
+
+If verification required fixes:
+
+```sh
+git add <changed-files>
+git commit -m "fix: stabilize angular reactive resource options"
+```
+
+Expected: branch contains focused commits and all verification output is known before PR.

--- a/docs/superpowers/specs/2026-07-07-angular-reactive-resource-options-design.md
+++ b/docs/superpowers/specs/2026-07-07-angular-reactive-resource-options-design.md
@@ -1,0 +1,191 @@
+# Angular Reactive Resource Options Design
+
+## Context
+
+Issue #393 asks for Angular resources to accept reactive `apiUrl` and `model` values so an app can switch model or backend configuration without creating one component/resource per provider. The reported use case is a chat UI where the user can switch between providers or models mid-conversation.
+
+The current Angular resource APIs are inconsistent:
+
+- `chatResource()` accepts `model: ModelInput | Signal<ModelInput>`, but reads it only when creating the Hashbrown runtime.
+- `completionResource()` accepts a signal-like `model`, but reads it only when creating the runtime.
+- `structuredChatResource()`, `structuredCompletionResource()`, `uiChatResource()`, and `uiCompletionResource()` mostly accept plain `ModelInput`.
+- `apiUrl` is currently a plain string across resources.
+- `system` and `threadId` already accept reactive values in some APIs, but not all resources consistently update the runtime when those values change.
+
+Core already supports this behavior through `hashbrown.updateOptions(...)`, which can update `apiUrl`, `model`, `system`, `threadId`, transport and related runtime options without recreating the Hashbrown instance.
+
+## Goals
+
+- Support Angular `Signal<T>` values for runtime resource options that can reasonably change after initialization.
+- Make `model`, `apiUrl`, `system`, and `threadId` consistent across Angular chat and completion resources.
+- Keep the public API surface minimal and Angular-native.
+- Reuse the existing Hashbrown runtime and `updateOptions(...)` instead of recreating resources.
+- Preserve current behavior for plain string/model values.
+- Preserve message history when model, API URL, system prompt, or thread ID changes.
+
+## Non-Goals
+
+- Do not expose plain callback functions as public reactive options.
+- Do not add global provider-level dynamic configuration for this issue.
+- Do not reset messages automatically when runtime options change.
+- Do not recreate the underlying `fryHashbrown(...)` instance when options change.
+- Do not change React APIs.
+- Do not redesign provider selection, fallback logic, or multi-provider orchestration.
+
+## API Design
+
+Add an Angular-specific public helper type:
+
+```ts
+export type ReactiveOption<T> = T | Signal<T>;
+```
+
+Use `ReactiveOption<T>` in Angular resource options for:
+
+```ts
+model: ReactiveOption<ModelInput>;
+apiUrl?: ReactiveOption<string>;
+threadId?: ReactiveOption<string | undefined>;
+```
+
+Use the matching system type for each resource:
+
+```ts
+system: ReactiveOption<string>;
+```
+
+For UI resources, where the system prompt can be a compiled Hashbrown `SystemPrompt`:
+
+```ts
+system: ReactiveOption<string | SystemPrompt>;
+```
+
+This keeps reactivity explicitly Angular-native. Internally, `readSignalLike()` may continue to tolerate functions for compatibility with existing implementation details, but public resource option types should not document or expose function callbacks.
+
+## Resource Coverage
+
+Apply the API consistently to:
+
+- `chatResource`
+- `completionResource`
+- `structuredChatResource`
+- `structuredCompletionResource`
+- `uiChatResource`
+- `uiCompletionResource`
+
+`structuredCompletionResource`, `uiChatResource`, and `uiCompletionResource` should pass reactive options through to their delegated resource instead of eagerly unwrapping values. This keeps the source of truth in the root resource that owns the Hashbrown runtime.
+
+## Runtime Behavior
+
+Each root resource that directly creates a Hashbrown runtime should:
+
+1. Read the current `ReactiveOption<T>` values when calling `fryHashbrown(...)`.
+2. Create the Hashbrown runtime once.
+3. Register an Angular `effect()` that reads the same reactive options and calls `hashbrown.updateOptions(...)`.
+4. Destroy the effect with the resource teardown.
+
+The runtime update should include the options owned by that resource:
+
+- `apiUrl`: read from `options.apiUrl` when provided, otherwise from the injected Hashbrown config.
+- `model`: read from `options.model`.
+- `system`: read from `options.system`.
+- `threadId`: read from `options.threadId` when provided.
+- Existing updateable options such as `structuredOutput`, `ui`, `transport`, `middleware`, `emulateStructuredOutput`, `debugName`, `debounce`, `retries`, and `tools` should continue to be passed where the resource already owns them.
+
+When a signal changes:
+
+- Current messages remain unchanged.
+- Existing subscriptions remain connected.
+- The next send, resend, or internally triggered completion request uses the latest runtime options.
+
+## Implementation Sketch
+
+Define and export the helper type from Angular utilities:
+
+```ts
+export type ReactiveOption<T> = T | Signal<T>;
+```
+
+Use it in option interfaces:
+
+```ts
+export interface ChatResourceOptions<Tools extends Chat.AnyTool> {
+  system: ReactiveOption<string>;
+  model: ReactiveOption<ModelInput>;
+  apiUrl?: ReactiveOption<string>;
+  threadId?: ReactiveOption<string | undefined>;
+}
+```
+
+Update root resource initialization:
+
+```ts
+const hashbrown = fryHashbrown({
+  apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+  model: readSignalLike(options.model),
+  system: readSignalLike(options.system),
+  threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+  // existing options...
+});
+```
+
+Add an effect:
+
+```ts
+const optionsEffect = effect(() => {
+  hashbrown.updateOptions({
+    apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+    model: readSignalLike(options.model),
+    system: readSignalLike(options.system),
+    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+    // existing updateable options...
+  });
+});
+
+destroyRef.onDestroy(() => {
+  teardown();
+  optionsEffect.destroy();
+});
+```
+
+The exact helper names can follow existing Angular package conventions. If repeating the read/update block across resources becomes noisy, add a small internal helper, but only if it reduces duplication without expanding the public API.
+
+## Developer Documentation
+
+Document that Angular resources accept either a plain value or an Angular signal for runtime options:
+
+```ts
+readonly model = signal('gpt-4.1');
+readonly apiUrl = computed(() => `/api/${this.provider()}/chat`);
+
+readonly chat = chatResource({
+  model: this.model,
+  apiUrl: this.apiUrl,
+  system: 'You are a helpful assistant.',
+});
+```
+
+When the signal changes, future requests use the new value while existing messages remain in place.
+
+## Testing
+
+Add focused Angular resource tests with `fryHashbrown` mocked:
+
+- `chatResource` passes initial signal values to `fryHashbrown`.
+- Updating `model`, `apiUrl`, `system`, and `threadId` signals calls `hashbrown.updateOptions(...)` with the latest values.
+- `completionResource` updates the same runtime options while preserving its existing input-to-message behavior.
+- `structuredChatResource` updates runtime options through its existing effect.
+- `structuredCompletionResource`, `uiChatResource`, and `uiCompletionResource` pass reactive options through to their delegated resource.
+- Plain value options continue to work.
+
+Use top-level `test(...)` only, matching the repository test style.
+
+Verification commands:
+
+```sh
+npx nx build angular
+npx nx test angular
+npx nx lint angular
+npx nx build-api-report angular
+```
+

--- a/packages/angular/src/public_api.ts
+++ b/packages/angular/src/public_api.ts
@@ -58,6 +58,7 @@ export {
   type UiKitInput,
   type UiKit,
   type UiKitOptions,
+  type ReactiveOption,
   type SignalLike,
   type TagNameRegistry,
   type UiAssistantMessage,

--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -124,6 +124,38 @@ test('chatResource updates runtime options when option signals change', () => {
   );
 });
 
+test('chatResource preserves direct model factory options', () => {
+  fryHashbrownMock.mockReset();
+  const model = vi.fn(() => ({
+    name: 'test-model',
+    transport: vi.fn(),
+  })) as unknown as ModelInput;
+  const system = signal('System A');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model,
+      system,
+    }),
+  );
+
+  expect(fryHashbrownMock.mock.calls[0]?.[0].model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+
+  system.set('System B');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions?.model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+});
+
 test('chatResource preserves an empty apiUrl option', () => {
   fryHashbrownMock.mockReset();
   const apiUrl = signal('');

--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -124,6 +124,81 @@ test('chatResource updates runtime options when option signals change', () => {
   );
 });
 
+test('chatResource preserves an empty apiUrl option', () => {
+  fryHashbrownMock.mockReset();
+  const apiUrl = signal('');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      apiUrl,
+      system: 'System A',
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+
+  apiUrl.set('/chat-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '/chat-b',
+    }),
+  );
+
+  apiUrl.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+});
+
+test('chatResource preserves a literal empty apiUrl option', () => {
+  fryHashbrownMock.mockReset();
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      apiUrl: '',
+      system: 'System A',
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+});
+
 function createHashbrownStub({ messages }: { messages: unknown[] }) {
   const messagesSignal = createSignal(messages);
 

--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -274,6 +274,37 @@ test('chatResource preserves a literal empty threadId option', () => {
   );
 });
 
+test('chatResource omits threadId from runtime updates when not provided', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal<ModelInput>('gpt-4.1');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model,
+      system: 'System A',
+    }),
+  );
+
+  model.set('gpt-4.2');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions).toEqual(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+    }),
+  );
+  expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
+    false,
+  );
+});
+
 function createHashbrownStub({ messages }: { messages: unknown[] }) {
   const messagesSignal = createSignal(messages);
 
@@ -300,6 +331,14 @@ function createHashbrownStub({ messages }: { messages: unknown[] }) {
     stop: vi.fn(),
     setMessages: vi.fn((nextMessages) => messagesSignal.set(nextMessages)),
   } as never;
+}
+
+function getLastUpdateOptions(hashbrown: {
+  updateOptions: { mock: { calls: [Record<string, unknown>][] } };
+}) {
+  const calls = hashbrown.updateOptions.mock.calls;
+
+  return calls[calls.length - 1]?.[0];
 }
 
 function createSignal<T>(initialValue: T) {

--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -1,8 +1,25 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import type { ModelInput } from '@hashbrownai/core';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { chatResource } from './chat-resource.fn';
 
+const fryHashbrownMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@hashbrownai/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hashbrownai/core')>();
+
+  return {
+    ...actual,
+    fryHashbrown: fryHashbrownMock,
+  };
+});
+
 test('chatResource initializes with the provided message history', () => {
+  fryHashbrownMock.mockReset();
+  fryHashbrownMock.mockImplementation((init) =>
+    createHashbrownStub({ messages: init.messages ?? [] }),
+  );
   const messages = [
     {
       role: 'user' as const,
@@ -26,6 +43,10 @@ test('chatResource initializes with the provided message history', () => {
 });
 
 test('chatResource allows replacing message history', () => {
+  fryHashbrownMock.mockReset();
+  fryHashbrownMock.mockImplementation((init) =>
+    createHashbrownStub({ messages: init.messages ?? [] }),
+  );
   const initialMessages = [
     {
       role: 'user' as const,
@@ -55,3 +76,99 @@ test('chatResource allows replacing message history', () => {
 
   expect(chat.value()).toEqual(nextMessages);
 });
+
+test('chatResource updates runtime options when option signals change', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/chat-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model,
+      apiUrl,
+      system,
+      threadId,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.1',
+      apiUrl: '/chat-a',
+      system: 'System A',
+      threadId: 'thread-a',
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/chat-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/chat-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+
+function createHashbrownStub({ messages }: { messages: unknown[] }) {
+  const messagesSignal = createSignal(messages);
+
+  return {
+    messages: messagesSignal,
+    isReceiving: createSignal(false),
+    isSending: createSignal(false),
+    isGenerating: createSignal(false),
+    isRunningToolCalls: createSignal(false),
+    isLoading: createSignal(false),
+    exhaustedRetries: createSignal(false),
+    error: createSignal(undefined),
+    sendingError: createSignal(undefined),
+    generatingError: createSignal(undefined),
+    lastAssistantMessage: createSignal(undefined),
+    isLoadingThread: createSignal(false),
+    isSavingThread: createSignal(false),
+    threadLoadError: createSignal(undefined),
+    threadSaveError: createSignal(undefined),
+    sizzle: vi.fn(() => vi.fn()),
+    updateOptions: vi.fn(),
+    sendMessage: vi.fn(),
+    resendMessages: vi.fn(),
+    stop: vi.fn(),
+    setMessages: vi.fn((nextMessages) => messagesSignal.set(nextMessages)),
+  } as never;
+}
+
+function createSignal<T>(initialValue: T) {
+  let value = initialValue;
+  const subscribers = new Set<(newValue: T) => void>();
+  const signal = (() => value) as {
+    (): T;
+    set(newValue: T): void;
+    subscribe(onChange: (newValue: T) => void): () => void;
+  };
+  signal.set = (newValue) => {
+    value = newValue;
+    subscribers.forEach((onChange) => onChange(newValue));
+  };
+  signal.subscribe = vi.fn((onChange) => {
+    subscribers.add(onChange);
+
+    return () => subscribers.delete(onChange);
+  });
+
+  return signal;
+}

--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -199,6 +199,81 @@ test('chatResource preserves a literal empty apiUrl option', () => {
   );
 });
 
+test('chatResource preserves an empty threadId option', () => {
+  fryHashbrownMock.mockReset();
+  const threadId = signal<string | undefined>('');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      system: 'System A',
+      threadId,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: 'thread-b',
+    }),
+  );
+
+  threadId.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+});
+
+test('chatResource preserves a literal empty threadId option', () => {
+  fryHashbrownMock.mockReset();
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({
+      model: 'gpt-4.1',
+      system: 'System A',
+      threadId: '',
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+});
+
 function createHashbrownStub({ messages }: { messages: unknown[] }) {
   const messagesSignal = createSignal(messages);
 

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -17,7 +17,11 @@ import {
   type TransportOrFactory,
 } from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
-import { readSignalLike, toNgSignal } from '../utils/signals';
+import {
+  readReactiveOption,
+  readSignalLike,
+  toNgSignal,
+} from '../utils/signals';
 import { ReactiveOption } from '../utils/types';
 import { bindToolToInjector } from '../utils/create-tool.fn';
 
@@ -188,15 +192,15 @@ export function chatResource<Tools extends Chat.AnyTool>(
   const hashbrown = fryHashbrown({
     apiUrl:
       options.apiUrl !== undefined
-        ? readSignalLike(options.apiUrl)
+        ? readReactiveOption(options.apiUrl)
         : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
     }),
-    system: readSignalLike(options.system),
+    system: readReactiveOption(options.system),
     messages: options.messages ? [...readSignalLike(options.messages)] : [],
-    model: readSignalLike(options.model),
+    model: readReactiveOption(options.model),
     tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
     emulateStructuredOutput: config.emulateStructuredOutput,
     debugName: options.debugName,
@@ -204,7 +208,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
     ui: false,
     threadId:
       options.threadId !== undefined
-        ? readSignalLike(options.threadId)
+        ? readReactiveOption(options.threadId)
         : undefined,
   });
 
@@ -212,21 +216,21 @@ export function chatResource<Tools extends Chat.AnyTool>(
     hashbrown.updateOptions({
       apiUrl:
         options.apiUrl !== undefined
-          ? readSignalLike(options.apiUrl)
+          ? readReactiveOption(options.apiUrl)
           : config.baseUrl,
       middleware: config.middleware?.map((m): Chat.Middleware => {
         return (requestInit) =>
           runInInjectionContext(injector, () => m(requestInit));
       }),
-      system: readSignalLike(options.system),
-      model: readSignalLike(options.model),
+      system: readReactiveOption(options.system),
+      model: readReactiveOption(options.model),
       tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
       emulateStructuredOutput: config.emulateStructuredOutput,
       debugName: options.debugName,
       transport: options.transport ?? config.transport,
       ui: false,
       ...(options.threadId !== undefined
-        ? { threadId: readSignalLike(options.threadId) }
+        ? { threadId: readReactiveOption(options.threadId) }
         : {}),
     });
   });

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -225,10 +225,9 @@ export function chatResource<Tools extends Chat.AnyTool>(
       debugName: options.debugName,
       transport: options.transport ?? config.transport,
       ui: false,
-      threadId:
-        options.threadId !== undefined
-          ? readSignalLike(options.threadId)
-          : undefined,
+      ...(options.threadId !== undefined
+        ? { threadId: readSignalLike(options.threadId) }
+        : {}),
     });
   });
 

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -202,7 +202,10 @@ export function chatResource<Tools extends Chat.AnyTool>(
     debugName: options.debugName,
     transport: options.transport ?? config.transport,
     ui: false,
-    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+    threadId:
+      options.threadId !== undefined
+        ? readSignalLike(options.threadId)
+        : undefined,
   });
 
   const optionsEffect = effect(() => {
@@ -222,7 +225,10 @@ export function chatResource<Tools extends Chat.AnyTool>(
       debugName: options.debugName,
       transport: options.transport ?? config.transport,
       ui: false,
-      threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+      threadId:
+        options.threadId !== undefined
+          ? readSignalLike(options.threadId)
+          : undefined,
     });
   });
 

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -2,6 +2,7 @@
 import {
   computed,
   DestroyRef,
+  effect,
   inject,
   Injector,
   Resource,
@@ -17,7 +18,7 @@ import {
 } from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
 import { readSignalLike, toNgSignal } from '../utils/signals';
-import { SignalLike } from '../utils/types';
+import { ReactiveOption } from '../utils/types';
 import { bindToolToInjector } from '../utils/create-tool.fn';
 
 /**
@@ -107,12 +108,12 @@ export interface ChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * The system prompt to use for the chat.
    */
-  system: string | Signal<string>;
+  system: ReactiveOption<string>;
 
   /**
    * The model to use for the chat.
    */
-  model: ModelInput | Signal<ModelInput>;
+  model: ReactiveOption<ModelInput>;
 
   /**
    * The tools to use for the chat.
@@ -142,7 +143,7 @@ export interface ChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * The API URL to use for the chat.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
 
   /**
    * Custom transport to use for this chat resource.
@@ -152,7 +153,7 @@ export interface ChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**
@@ -185,7 +186,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
   const hashbrown = fryHashbrown({
-    apiUrl: options.apiUrl ?? config.baseUrl,
+    apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
@@ -198,12 +199,33 @@ export function chatResource<Tools extends Chat.AnyTool>(
     debugName: options.debugName,
     transport: options.transport ?? config.transport,
     ui: false,
-    threadId: readSignalLike(options.threadId),
+    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+  });
+
+  const optionsEffect = effect(() => {
+    hashbrown.updateOptions({
+      apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+      middleware: config.middleware?.map((m): Chat.Middleware => {
+        return (requestInit) =>
+          runInInjectionContext(injector, () => m(requestInit));
+      }),
+      system: readSignalLike(options.system),
+      model: readSignalLike(options.model),
+      tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
+      emulateStructuredOutput: config.emulateStructuredOutput,
+      debugName: options.debugName,
+      transport: options.transport ?? config.transport,
+      ui: false,
+      threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+    });
   });
 
   const teardown = hashbrown.sizzle();
 
-  destroyRef.onDestroy(() => teardown());
+  destroyRef.onDestroy(() => {
+    teardown();
+    optionsEffect.destroy();
+  });
 
   const value = toNgSignal(
     hashbrown.messages,

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -186,7 +186,10 @@ export function chatResource<Tools extends Chat.AnyTool>(
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
   const hashbrown = fryHashbrown({
-    apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+    apiUrl:
+      options.apiUrl !== undefined
+        ? readSignalLike(options.apiUrl)
+        : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
@@ -204,7 +207,10 @@ export function chatResource<Tools extends Chat.AnyTool>(
 
   const optionsEffect = effect(() => {
     hashbrown.updateOptions({
-      apiUrl: options.apiUrl ? readSignalLike(options.apiUrl) : config.baseUrl,
+      apiUrl:
+        options.apiUrl !== undefined
+          ? readSignalLike(options.apiUrl)
+          : config.baseUrl,
       middleware: config.middleware?.map((m): Chat.Middleware => {
         return (requestInit) =>
           runInInjectionContext(injector, () => m(requestInit));

--- a/packages/angular/src/resources/completion-resource.fn.spec.ts
+++ b/packages/angular/src/resources/completion-resource.fn.spec.ts
@@ -1,0 +1,244 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideHashbrown } from '../providers/provide-hashbrown.fn';
+import { completionResource } from './completion-resource.fn';
+
+const fryHashbrownMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@hashbrownai/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hashbrownai/core')>();
+
+  return {
+    ...actual,
+    fryHashbrown: fryHashbrownMock,
+  };
+});
+
+test('completionResource updates runtime options when option signals change', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal('gpt-4.1');
+  const apiUrl = signal('/completion-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model,
+      apiUrl,
+      system,
+      input,
+      threadId,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.1',
+      apiUrl: '/completion-a',
+      system: 'System A',
+      threadId: 'thread-a',
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/completion-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/completion-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+
+test('completionResource preserves an empty apiUrl option', () => {
+  fryHashbrownMock.mockReset();
+  const apiUrl = signal('');
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model: 'gpt-4.1',
+      apiUrl,
+      system: 'System A',
+      input,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+
+  apiUrl.set('/completion-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '/completion-b',
+    }),
+  );
+
+  apiUrl.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+});
+
+test('completionResource preserves an empty threadId option', () => {
+  fryHashbrownMock.mockReset();
+  const input = signal('Summarize this');
+  const threadId = signal<string | undefined>('');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model: 'gpt-4.1',
+      system: 'System A',
+      input,
+      threadId,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: 'thread-b',
+    }),
+  );
+
+  threadId.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+});
+
+test('completionResource omits threadId from runtime updates when not provided', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal('gpt-4.1');
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model,
+      system: 'System A',
+      input,
+    }),
+  );
+
+  model.set('gpt-4.2');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions).toEqual(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+    }),
+  );
+  expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
+    false,
+  );
+});
+
+function createHashbrownStub({ messages }: { messages: unknown[] }) {
+  const messagesSignal = createSignal(messages);
+
+  return {
+    messages: messagesSignal,
+    isReceiving: createSignal(false),
+    isSending: createSignal(false),
+    isGenerating: createSignal(false),
+    isRunningToolCalls: createSignal(false),
+    isLoading: createSignal(false),
+    exhaustedRetries: createSignal(false),
+    error: createSignal(undefined),
+    sendingError: createSignal(undefined),
+    generatingError: createSignal(undefined),
+    lastAssistantMessage: createSignal(undefined),
+    isLoadingThread: createSignal(false),
+    isSavingThread: createSignal(false),
+    threadLoadError: createSignal(undefined),
+    threadSaveError: createSignal(undefined),
+    sizzle: vi.fn(() => vi.fn()),
+    updateOptions: vi.fn(),
+    sendMessage: vi.fn(),
+    resendMessages: vi.fn(),
+    stop: vi.fn(),
+    setMessages: vi.fn((nextMessages) => messagesSignal.set(nextMessages)),
+  } as never;
+}
+
+function getLastUpdateOptions(hashbrown: {
+  updateOptions: { mock: { calls: [Record<string, unknown>][] } };
+}) {
+  const calls = hashbrown.updateOptions.mock.calls;
+
+  return calls[calls.length - 1]?.[0];
+}
+
+function createSignal<T>(initialValue: T) {
+  let value = initialValue;
+  const subscribers = new Set<(newValue: T) => void>();
+  const signal = (() => value) as {
+    (): T;
+    set(newValue: T): void;
+    subscribe(onChange: (newValue: T) => void): () => void;
+  };
+  signal.set = (newValue) => {
+    value = newValue;
+    subscribers.forEach((onChange) => onChange(newValue));
+  };
+  signal.subscribe = vi.fn((onChange) => {
+    subscribers.add(onChange);
+
+    return () => subscribers.delete(onChange);
+  });
+
+  return signal;
+}

--- a/packages/angular/src/resources/completion-resource.fn.spec.ts
+++ b/packages/angular/src/resources/completion-resource.fn.spec.ts
@@ -1,5 +1,6 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import type { ModelInput } from '@hashbrownai/core';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { completionResource } from './completion-resource.fn';
 
@@ -59,6 +60,41 @@ test('completionResource updates runtime options when option signals change', ()
       apiUrl: '/completion-b',
       system: 'System B',
       threadId: 'thread-b',
+    }),
+  );
+});
+
+test('completionResource accepts fallback model input signals', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal<ModelInput>(['gpt-4.1', 'gpt-4.1-mini']);
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model,
+      system: 'System A',
+      input,
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: ['gpt-4.1', 'gpt-4.1-mini'],
+    }),
+  );
+
+  model.set(['gpt-4.2', 'gpt-4.2-mini']);
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: ['gpt-4.2', 'gpt-4.2-mini'],
     }),
   );
 });

--- a/packages/angular/src/resources/completion-resource.fn.spec.ts
+++ b/packages/angular/src/resources/completion-resource.fn.spec.ts
@@ -99,6 +99,40 @@ test('completionResource accepts fallback model input signals', () => {
   );
 });
 
+test('completionResource preserves direct model factory options', () => {
+  fryHashbrownMock.mockReset();
+  const model = vi.fn(() => ({
+    name: 'test-model',
+    transport: vi.fn(),
+  })) as unknown as ModelInput;
+  const system = signal('System A');
+  const input = signal('Summarize this');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    completionResource({
+      model,
+      system,
+      input,
+    }),
+  );
+
+  expect(fryHashbrownMock.mock.calls[0]?.[0].model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+
+  system.set('System B');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions?.model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+});
+
 test('completionResource preserves an empty apiUrl option', () => {
   fryHashbrownMock.mockReset();
   const apiUrl = signal('');

--- a/packages/angular/src/resources/completion-resource.fn.ts
+++ b/packages/angular/src/resources/completion-resource.fn.ts
@@ -18,7 +18,7 @@ import {
 } from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
 import { ReactiveOption } from '../utils/types';
-import { readSignalLike, toNgSignal } from '../utils/signals';
+import { readReactiveOption, toNgSignal } from '../utils/signals';
 
 /**
  * A reference to the completion resource.
@@ -123,21 +123,21 @@ export function completionResource<Input>(
     debugName: options.debugName,
     apiUrl:
       options.apiUrl !== undefined
-        ? readSignalLike(options.apiUrl)
+        ? readReactiveOption(options.apiUrl)
         : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
     }),
-    model: readSignalLike(model),
-    system: readSignalLike(system),
+    model: readReactiveOption(model),
+    system: readReactiveOption(system),
     messages: [],
     tools: [],
     retries: 3,
     transport: options.transport ?? config.transport,
     threadId:
       options.threadId !== undefined
-        ? readSignalLike(options.threadId)
+        ? readReactiveOption(options.threadId)
         : undefined,
   });
 
@@ -146,19 +146,19 @@ export function completionResource<Input>(
       debugName: options.debugName,
       apiUrl:
         options.apiUrl !== undefined
-          ? readSignalLike(options.apiUrl)
+          ? readReactiveOption(options.apiUrl)
           : config.baseUrl,
       middleware: config.middleware?.map((m): Chat.Middleware => {
         return (requestInit) =>
           runInInjectionContext(injector, () => m(requestInit));
       }),
-      model: readSignalLike(model),
-      system: readSignalLike(system),
+      model: readReactiveOption(model),
+      system: readReactiveOption(system),
       tools: [],
       retries: 3,
       transport: options.transport ?? config.transport,
       ...(options.threadId !== undefined
-        ? { threadId: readSignalLike(options.threadId) }
+        ? { threadId: readReactiveOption(options.threadId) }
         : {}),
     });
   });

--- a/packages/angular/src/resources/completion-resource.fn.ts
+++ b/packages/angular/src/resources/completion-resource.fn.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import { Chat, fryHashbrown, type TransportOrFactory } from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
-import { SignalLike } from '../utils/types';
+import { ReactiveOption } from '../utils/types';
 import { readSignalLike, toNgSignal } from '../utils/signals';
 
 /**
@@ -66,7 +66,7 @@ export interface CompletionResourceOptions<Input> {
   /**
    * The model to use for the completion.
    */
-  model: SignalLike<string>;
+  model: ReactiveOption<string>;
 
   /**
    * The input to the completion.
@@ -76,12 +76,12 @@ export interface CompletionResourceOptions<Input> {
   /**
    * The system prompt to use for the completion.
    */
-  system: SignalLike<string>;
+  system: ReactiveOption<string>;
 
   /**
    * The API URL to use for the completion.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
 
   /**
    * The debug name for the completion resource.
@@ -96,7 +96,7 @@ export interface CompletionResourceOptions<Input> {
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**
@@ -116,7 +116,10 @@ export function completionResource<Input>(
   const config = ɵinjectHashbrownConfig();
   const hashbrown = fryHashbrown({
     debugName: options.debugName,
-    apiUrl: options.apiUrl ?? config.baseUrl,
+    apiUrl:
+      options.apiUrl !== undefined
+        ? readSignalLike(options.apiUrl)
+        : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
@@ -127,12 +130,40 @@ export function completionResource<Input>(
     tools: [],
     retries: 3,
     transport: options.transport ?? config.transport,
-    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+    threadId:
+      options.threadId !== undefined
+        ? readSignalLike(options.threadId)
+        : undefined,
+  });
+
+  const optionsEffect = effect(() => {
+    hashbrown.updateOptions({
+      debugName: options.debugName,
+      apiUrl:
+        options.apiUrl !== undefined
+          ? readSignalLike(options.apiUrl)
+          : config.baseUrl,
+      middleware: config.middleware?.map((m): Chat.Middleware => {
+        return (requestInit) =>
+          runInInjectionContext(injector, () => m(requestInit));
+      }),
+      model: readSignalLike(model),
+      system: readSignalLike(system),
+      tools: [],
+      retries: 3,
+      transport: options.transport ?? config.transport,
+      ...(options.threadId !== undefined
+        ? { threadId: readSignalLike(options.threadId) }
+        : {}),
+    });
   });
 
   const teardown = hashbrown.sizzle();
 
-  destroyRef.onDestroy(() => teardown());
+  destroyRef.onDestroy(() => {
+    teardown();
+    optionsEffect.destroy();
+  });
 
   const messages = toNgSignal(hashbrown.messages);
   const isReceiving = toNgSignal(hashbrown.isReceiving);

--- a/packages/angular/src/resources/completion-resource.fn.ts
+++ b/packages/angular/src/resources/completion-resource.fn.ts
@@ -10,7 +10,12 @@ import {
   runInInjectionContext,
   Signal,
 } from '@angular/core';
-import { Chat, fryHashbrown, type TransportOrFactory } from '@hashbrownai/core';
+import {
+  Chat,
+  fryHashbrown,
+  type ModelInput,
+  type TransportOrFactory,
+} from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
 import { ReactiveOption } from '../utils/types';
 import { readSignalLike, toNgSignal } from '../utils/signals';
@@ -66,7 +71,7 @@ export interface CompletionResourceOptions<Input> {
   /**
    * The model to use for the completion.
    */
-  model: ReactiveOption<string>;
+  model: ReactiveOption<ModelInput>;
 
   /**
    * The input to the completion.

--- a/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
@@ -1,5 +1,7 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { s } from '@hashbrownai/core';
+import type { ModelInput } from '@hashbrownai/core';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { structuredChatResource } from './structured-chat-resource.fn';
 
@@ -42,9 +44,222 @@ test('structuredChatResource passes structured output options to Hashbrown', () 
   );
 });
 
+test('structuredChatResource updates runtime options when option signals change', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/structured-a');
+  const system = signal('System A');
+  const threadId = signal<string | undefined>('thread-a');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model,
+      apiUrl,
+      system,
+      threadId,
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.1',
+      apiUrl: '/structured-a',
+      system: 'System A',
+      threadId: 'thread-a',
+    }),
+  );
+
+  model.set('gpt-4.2');
+  apiUrl.set('/structured-b');
+  system.set('System B');
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+      apiUrl: '/structured-b',
+      system: 'System B',
+      threadId: 'thread-b',
+    }),
+  );
+});
+
+test('structuredChatResource preserves direct model factory options', () => {
+  fryHashbrownMock.mockReset();
+  const model = vi.fn(() => ({
+    name: 'test-model',
+    transport: vi.fn(),
+  })) as unknown as ModelInput;
+  const system = signal('System A');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model,
+      system,
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  expect(fryHashbrownMock.mock.calls[0]?.[0].model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+
+  system.set('System B');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions?.model).toBe(model);
+  expect(model).not.toHaveBeenCalled();
+});
+
+test('structuredChatResource preserves an empty apiUrl option', () => {
+  fryHashbrownMock.mockReset();
+  const apiUrl = signal('');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model: 'gpt-4.1',
+      apiUrl,
+      system: 'System A',
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+
+  apiUrl.set('/structured-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '/structured-b',
+    }),
+  );
+
+  apiUrl.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      apiUrl: '',
+    }),
+  );
+});
+
+test('structuredChatResource preserves an empty threadId option', () => {
+  fryHashbrownMock.mockReset();
+  const threadId = signal<string | undefined>('');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model: 'gpt-4.1',
+      system: 'System A',
+      threadId,
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  expect(fryHashbrownMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+
+  threadId.set('thread-b');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: 'thread-b',
+    }),
+  );
+
+  threadId.set('');
+  TestBed.flushEffects();
+
+  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      threadId: '',
+    }),
+  );
+});
+
+test('structuredChatResource omits threadId from runtime updates when not provided', () => {
+  fryHashbrownMock.mockReset();
+  const model = signal<ModelInput>('gpt-4.1');
+  const hashbrown = createHashbrownStub({ messages: [] });
+  fryHashbrownMock.mockReturnValue(hashbrown);
+
+  TestBed.configureTestingModule({
+    providers: [provideHashbrown({ baseUrl: '/chat' })],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    structuredChatResource({
+      model,
+      system: 'System A',
+      schema: s.object('risk summary', {
+        risk: s.string('Risk level'),
+      }),
+    }),
+  );
+
+  model.set('gpt-4.2');
+  TestBed.flushEffects();
+  const lastOptions = getLastUpdateOptions(hashbrown);
+
+  expect(lastOptions).toEqual(
+    expect.objectContaining({
+      model: 'gpt-4.2',
+    }),
+  );
+  expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
+    false,
+  );
+});
+
 function createHashbrownStub({ messages }: { messages: unknown[] }) {
+  const messagesSignal = createSignal(messages);
+
   return {
-    messages: createSignal(messages),
+    messages: messagesSignal,
     isReceiving: createSignal(false),
     isSending: createSignal(false),
     isGenerating: createSignal(false),
@@ -64,16 +279,35 @@ function createHashbrownStub({ messages }: { messages: unknown[] }) {
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),
     stop: vi.fn(),
-    setMessages: vi.fn(),
+    setMessages: vi.fn((nextMessages) => messagesSignal.set(nextMessages)),
   } as never;
 }
 
-function createSignal<T>(value: T) {
+function getLastUpdateOptions(hashbrown: {
+  updateOptions: { mock: { calls: [Record<string, unknown>][] } };
+}) {
+  const calls = hashbrown.updateOptions.mock.calls;
+
+  return calls[calls.length - 1]?.[0];
+}
+
+function createSignal<T>(initialValue: T) {
+  let value = initialValue;
+  const subscribers = new Set<(newValue: T) => void>();
   const signal = (() => value) as {
     (): T;
+    set(newValue: T): void;
     subscribe(onChange: (newValue: T) => void): () => void;
   };
-  signal.subscribe = vi.fn(() => () => undefined);
+  signal.set = (newValue) => {
+    value = newValue;
+    subscribers.forEach((onChange) => onChange(newValue));
+  };
+  signal.subscribe = vi.fn((onChange) => {
+    subscribers.add(onChange);
+
+    return () => subscribers.delete(onChange);
+  });
 
   return signal;
 }

--- a/packages/angular/src/resources/structured-chat-resource.fn.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.ts
@@ -18,8 +18,8 @@ import {
   type TransportOrFactory,
 } from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
-import { readSignalLike, toNgSignal } from '../utils/signals';
-import { SignalLike } from '../utils/types';
+import { readReactiveOption, toNgSignal } from '../utils/signals';
+import { ReactiveOption } from '../utils/types';
 import { bindToolToInjector } from '../utils/create-tool.fn';
 import { toDeepSignal } from '../utils/deep-signal';
 
@@ -116,12 +116,12 @@ export interface StructuredChatResourceOptions<
   /**
    * The model to use for the structured chat resource.
    */
-  model: ModelInput;
+  model: ReactiveOption<ModelInput>;
 
   /**
    * The system prompt to use for the structured chat resource.
    */
-  system: string | Signal<string>;
+  system: ReactiveOption<string>;
 
   /**
    * The schema to use for the structured chat resource.
@@ -156,7 +156,7 @@ export interface StructuredChatResourceOptions<
   /**
    * The API URL to use for the structured chat resource.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
 
   /**
    * Custom transport override for the structured chat resource.
@@ -174,7 +174,7 @@ export interface StructuredChatResourceOptions<
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**
@@ -195,14 +195,17 @@ export function structuredChatResource<
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
   const hashbrown = fryHashbrown<Schema, Tools, Output>({
-    apiUrl: options.apiUrl ?? config.baseUrl,
+    apiUrl:
+      options.apiUrl !== undefined
+        ? readReactiveOption(options.apiUrl)
+        : config.baseUrl,
     middleware: config.middleware?.map((m): Chat.Middleware => {
       return (requestInit) =>
         runInInjectionContext(injector, () => m(requestInit));
     }),
-    system: readSignalLike(options.system),
+    system: readReactiveOption(options.system),
     messages: [...(options.messages ?? [])],
-    model: options.model,
+    model: readReactiveOption(options.model),
     tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
     responseSchema: options.schema,
     debugName: options.debugName,
@@ -212,22 +215,25 @@ export function structuredChatResource<
     transport: options.transport ?? config.transport,
     structuredOutput: options.structuredOutput,
     ui: options.ui ?? false,
-    threadId: options.threadId ? readSignalLike(options.threadId) : undefined,
+    threadId:
+      options.threadId !== undefined
+        ? readReactiveOption(options.threadId)
+        : undefined,
   });
 
   const optionsEffect = effect(() => {
-    const model = options.model;
-    const system = readSignalLike(options.system);
-    const threadId = options.threadId
-      ? readSignalLike(options.threadId)
-      : undefined;
-
     hashbrown.updateOptions({
-      model,
-      system,
+      apiUrl:
+        options.apiUrl !== undefined
+          ? readReactiveOption(options.apiUrl)
+          : config.baseUrl,
+      model: readReactiveOption(options.model),
+      system: readReactiveOption(options.system),
       structuredOutput: options.structuredOutput,
       ui: options.ui ?? false,
-      threadId,
+      ...(options.threadId !== undefined
+        ? { threadId: readReactiveOption(options.threadId) }
+        : {}),
     });
   });
 

--- a/packages/angular/src/resources/structured-completion-resource.fn.spec.ts
+++ b/packages/angular/src/resources/structured-completion-resource.fn.spec.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResourceStatus, signal, type Signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { ModelInput } from '@hashbrownai/core';
+import { s } from '@hashbrownai/core';
+import { vi } from 'vitest';
+import { structuredChatResource } from './structured-chat-resource.fn';
+import { structuredCompletionResource } from './structured-completion-resource.fn';
+
+vi.mock('./structured-chat-resource.fn', () => ({
+  structuredChatResource: vi.fn(),
+}));
+
+const structuredChatResourceMock = vi.mocked(structuredChatResource);
+
+const createChatStub = (valueSignal: Signal<any[]>) => {
+  return {
+    value: valueSignal,
+    status: signal<ResourceStatus>('idle'),
+    error: signal<Error | undefined>(undefined),
+    isLoading: signal(false),
+    isSending: signal(false),
+    isReceiving: signal(false),
+    isGenerating: signal(false),
+    isRunningToolCalls: signal(false),
+    isLoadingThread: signal(false),
+    isSavingThread: signal(false),
+    sendingError: signal<Error | undefined>(undefined),
+    generatingError: signal<Error | undefined>(undefined),
+    threadLoadError: signal<{ error: string; stacktrace?: string } | undefined>(
+      undefined,
+    ),
+    threadSaveError: signal<{ error: string; stacktrace?: string } | undefined>(
+      undefined,
+    ),
+    lastAssistantMessage: signal(undefined),
+    sendMessage: vi.fn(),
+    resendMessages: vi.fn(),
+    setMessages: vi.fn(),
+    reload: vi.fn(),
+    stop: vi.fn(),
+    hasValue: vi.fn(),
+  } as unknown as ReturnType<typeof structuredChatResource>;
+};
+
+test('structuredCompletionResource passes reactive options through to structuredChatResource', () => {
+  // Arrange
+  structuredChatResourceMock.mockReset();
+  structuredChatResourceMock.mockReturnValue(createChatStub(signal<any[]>([])));
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/completion');
+  const system = signal('System prompt');
+  const threadId = signal<string | undefined>('thread-a');
+
+  // Act
+  TestBed.runInInjectionContext(() =>
+    structuredCompletionResource({
+      model,
+      apiUrl,
+      system,
+      threadId,
+      input: signal('Summarize this'),
+      schema: s.object('summary', {
+        summary: s.string('Summary'),
+      }),
+    }),
+  );
+
+  // Assert
+  expect(structuredChatResourceMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model,
+      apiUrl,
+      system,
+      threadId,
+    }),
+  );
+});

--- a/packages/angular/src/resources/structured-completion-resource.fn.ts
+++ b/packages/angular/src/resources/structured-completion-resource.fn.ts
@@ -6,7 +6,7 @@ import {
   s,
   type TransportOrFactory,
 } from '@hashbrownai/core';
-import { SignalLike } from '../utils/types';
+import { ReactiveOption } from '../utils/types';
 import { structuredChatResource } from './structured-chat-resource.fn';
 import { toDeepSignal } from '../utils/deep-signal';
 
@@ -72,7 +72,7 @@ export interface StructuredCompletionResourceOptions<
   /**
    * The model to use for the structured completion resource.
    */
-  model: ModelInput;
+  model: ReactiveOption<ModelInput>;
   /**
    * The input to the structured completion resource.
    */
@@ -84,7 +84,7 @@ export interface StructuredCompletionResourceOptions<
   /**
    * The system prompt to use for the structured completion resource.
    */
-  system: SignalLike<string>;
+  system: ReactiveOption<string>;
   /**
    * The tools to use for the structured completion resource.
    */
@@ -96,7 +96,7 @@ export interface StructuredCompletionResourceOptions<
   /**
    * The API URL to use for the structured completion resource.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
   /**
    * The number of retries for the structured completion resource.
    */
@@ -122,7 +122,7 @@ export interface StructuredCompletionResourceOptions<
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**

--- a/packages/angular/src/resources/ui-chat-resource.fn.ts
+++ b/packages/angular/src/resources/ui-chat-resource.fn.ts
@@ -15,7 +15,8 @@ import {
   UiAssistantMessage,
   UiChatMessage,
 } from '../utils/ui-chat.helpers';
-import { readSignalLike, SignalLike } from '../utils';
+import { readReactiveOption } from '../utils';
+import { ReactiveOption } from '../utils/types';
 import { createUiKit, type UiKitInput } from '../utils/ui-kit.fn';
 
 /**
@@ -44,12 +45,12 @@ export interface UiChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * The model to use for the UI chat resource.
    */
-  model: ModelInput;
+  model: ReactiveOption<ModelInput>;
 
   /**
    * The system prompt to use for the UI chat resource.
    */
-  system: string | Signal<string> | SystemPrompt | Signal<SystemPrompt>;
+  system: ReactiveOption<string | SystemPrompt>;
 
   /**
    * The initial messages for the UI chat resource.
@@ -78,7 +79,7 @@ export interface UiChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * The API URL to use for the UI chat resource.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
 
   /**
    * Custom transport override for the UI chat resource.
@@ -93,7 +94,7 @@ export interface UiChatResourceOptions<Tools extends Chat.AnyTool> {
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**
@@ -145,7 +146,7 @@ export function uiChatResource<Tools extends Chat.AnyTool>(
   });
   const internalSchema = uiKit.schema;
   const systemAsString = computed(() => {
-    const system = readSignalLike(args.system);
+    const system = readReactiveOption(args.system);
     if (typeof system === 'string') {
       return system;
     }

--- a/packages/angular/src/resources/ui-chat-resource.spec.ts
+++ b/packages/angular/src/resources/ui-chat-resource.spec.ts
@@ -155,12 +155,20 @@ test('uiChatResource passes reactive options through to structuredChatResource',
   });
 
   // Assert
-  expect(structuredChatResourceMock).toHaveBeenCalledWith(
+  const delegatedOptions = structuredChatResourceMock.mock.calls[0]?.[0];
+  const delegatedSystem = delegatedOptions?.system as Signal<string>;
+
+  expect(delegatedOptions).toEqual(
     expect.objectContaining({
       model,
       apiUrl,
-      system: expect.any(Function),
       threadId,
     }),
   );
+  expect(delegatedSystem).not.toBe(system);
+  expect(delegatedSystem()).toBe('System prompt');
+
+  system.set('Updated system prompt');
+
+  expect(delegatedSystem()).toBe('Updated system prompt');
 });

--- a/packages/angular/src/resources/ui-chat-resource.spec.ts
+++ b/packages/angular/src/resources/ui-chat-resource.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ResourceStatus, signal, type Signal } from '@angular/core';
-import { s } from '@hashbrownai/core';
+import { type ModelInput, s } from '@hashbrownai/core';
 import { vi } from 'vitest';
 import { uiChatResource } from './ui-chat-resource.fn';
 import { structuredChatResource } from './structured-chat-resource.fn';
@@ -128,4 +128,39 @@ test('uiChatResource provides empty tag registry when assistant has no content',
 
   // Assert
   expect((message as any)[TAG_NAME_REGISTRY]).toEqual({});
+});
+
+test('uiChatResource passes reactive options through to structuredChatResource', () => {
+  // Arrange
+  structuredChatResourceMock.mockReset();
+  structuredChatResourceMock.mockReturnValue(createChatStub(signal<any[]>([])));
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/ui-chat');
+  const system = signal('System prompt');
+  const threadId = signal<string | undefined>('thread-a');
+
+  // Act
+  uiChatResource({
+    components: [
+      {
+        component: class {},
+        name: 'Card',
+        description: 'Card component',
+      },
+    ],
+    model,
+    apiUrl,
+    system,
+    threadId,
+  });
+
+  // Assert
+  expect(structuredChatResourceMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model,
+      apiUrl,
+      system: expect.any(Function),
+      threadId,
+    }),
+  );
 });

--- a/packages/angular/src/resources/ui-completion-resource.fn.ts
+++ b/packages/angular/src/resources/ui-completion-resource.fn.ts
@@ -9,12 +9,12 @@ import {
 } from '@hashbrownai/core';
 import { ExposedComponent } from '../utils/expose-component.fn';
 import { structuredCompletionResource } from './structured-completion-resource.fn';
-import { readSignalLike } from '../utils';
+import { readReactiveOption } from '../utils';
 import {
   TAG_NAME_REGISTRY,
   UiAssistantMessage,
 } from '../utils/ui-chat.helpers';
-import { SignalLike } from '../utils/types';
+import { ReactiveOption } from '../utils/types';
 import { UiChatMessageOutput } from './ui-chat-resource.fn';
 import { createUiKit, type UiKitInput } from '../utils/ui-kit.fn';
 
@@ -44,12 +44,12 @@ export interface UiCompletionResourceOptions<
   /**
    * The model to use for the UI completion resource.
    */
-  model: ModelInput;
+  model: ReactiveOption<ModelInput>;
 
   /**
    * The system prompt to use for the UI completion resource.
    */
-  system: string | Signal<string> | SystemPrompt | Signal<SystemPrompt>;
+  system: ReactiveOption<string | SystemPrompt>;
 
   /**
    * The tools to use for the UI completion resource.
@@ -64,7 +64,7 @@ export interface UiCompletionResourceOptions<
   /**
    * The API URL to use for the UI completion resource.
    */
-  apiUrl?: string;
+  apiUrl?: ReactiveOption<string>;
 
   /**
    * The number of retries for the UI completion resource.
@@ -89,7 +89,7 @@ export interface UiCompletionResourceOptions<
   /**
    * Optional thread identifier used to load or continue an existing conversation.
    */
-  threadId?: SignalLike<string | undefined>;
+  threadId?: ReactiveOption<string | undefined>;
 }
 
 /**
@@ -141,9 +141,7 @@ export function uiCompletionResource<
   });
   const internalSchema = uiKit.schema;
   const systemAsString = computed(() => {
-    const system = readSignalLike(
-      options.system as SignalLike<string | SystemPrompt>,
-    );
+    const system = readReactiveOption(options.system);
 
     if (typeof system === 'string') {
       return system;

--- a/packages/angular/src/resources/ui-completion-resource.spec.ts
+++ b/packages/angular/src/resources/ui-completion-resource.spec.ts
@@ -171,12 +171,20 @@ test('uiCompletionResource passes reactive options through to structuredCompleti
   });
 
   // Assert
-  expect(structuredCompletionResourceMock).toHaveBeenCalledWith(
+  const delegatedOptions = structuredCompletionResourceMock.mock.calls[0]?.[0];
+  const delegatedSystem = delegatedOptions?.system as Signal<string>;
+
+  expect(delegatedOptions).toEqual(
     expect.objectContaining({
       model,
       apiUrl,
-      system: expect.any(Function),
       threadId,
     }),
   );
+  expect(delegatedSystem).not.toBe(system);
+  expect(delegatedSystem()).toBe('System prompt');
+
+  system.set('Updated system prompt');
+
+  expect(delegatedSystem()).toBe('Updated system prompt');
 });

--- a/packages/angular/src/resources/ui-completion-resource.spec.ts
+++ b/packages/angular/src/resources/ui-completion-resource.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ResourceStatus, signal, type Signal } from '@angular/core';
-import { s } from '@hashbrownai/core';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ModelInput, s } from '@hashbrownai/core';
+import { vi } from 'vitest';
 import { uiCompletionResource } from './ui-completion-resource.fn';
 import { structuredCompletionResource } from './structured-completion-resource.fn';
 import { TAG_NAME_REGISTRY } from '../utils';
@@ -29,70 +29,69 @@ const createCompletionStub = (valueSignal: Signal<any | null>) => {
   } as ReturnType<typeof structuredCompletionResource>;
 };
 
-describe('uiCompletionResource', () => {
-  beforeEach(() => {
-    structuredCompletionResourceMock.mockReset();
+test('uiCompletionResource wraps structured completion output with UI metadata', () => {
+  // Arrange
+  structuredCompletionResourceMock.mockReset();
+
+  const completionValue = signal<any | null>(null);
+  structuredCompletionResourceMock.mockReturnValue(
+    createCompletionStub(completionValue),
+  );
+
+  class TestComponent {}
+
+  const resource = uiCompletionResource({
+    components: [
+      {
+        component: TestComponent,
+        name: 'TestComponent',
+        description: 'test',
+        props: {
+          label: s.string('label'),
+        },
+      },
+    ],
+    input: signal('Describe a component'),
+    model: 'gpt-4o-mini',
+    system: 'system prompt',
   });
 
-  it('wraps structured completion output with UI metadata', () => {
-    const completionValue = signal<any | null>(null);
-    structuredCompletionResourceMock.mockReturnValue(
-      createCompletionStub(completionValue),
-    );
-
-    class TestComponent {}
-
-    const resource = uiCompletionResource({
-      components: [
-        {
-          component: TestComponent,
-          name: 'TestComponent',
-          description: 'test',
+  // Act
+  completionValue.set({
+    ui: [
+      {
+        TestComponent: {
           props: {
-            label: s.string('label'),
+            complete: true,
+            partialValue: { label: 'Hello' },
+            value: { label: 'Hello' },
           },
         },
-      ],
-      input: signal('Describe a component'),
-      model: 'gpt-4o-mini',
-      system: 'system prompt',
-    });
-
-    completionValue.set({
-      ui: [
-        {
-          TestComponent: {
-            props: {
-              complete: true,
-              partialValue: { label: 'Hello' },
-              value: { label: 'Hello' },
-            },
-          },
-        },
-      ],
-    });
-
-    const message = resource.value();
-
-    expect(message?.role).toBe('assistant');
-    expect(message?.content).toEqual({
-      ui: [
-        {
-          TestComponent: {
-            props: {
-              complete: true,
-              partialValue: { label: 'Hello' },
-              value: { label: 'Hello' },
-            },
-          },
-        },
-      ],
-    });
-    expect(message?.toolCalls).toEqual([]);
-    expect(message?.[TAG_NAME_REGISTRY]?.TestComponent?.component).toBe(
-      TestComponent,
-    );
+      },
+    ],
   });
+
+  const message = resource.value();
+
+  // Assert
+  expect(message?.role).toBe('assistant');
+  expect(message?.content).toEqual({
+    ui: [
+      {
+        TestComponent: {
+          props: {
+            complete: true,
+            partialValue: { label: 'Hello' },
+            value: { label: 'Hello' },
+          },
+        },
+      },
+    ],
+  });
+  expect(message?.toolCalls).toEqual([]);
+  expect(message?.[TAG_NAME_REGISTRY]?.TestComponent?.component).toBe(
+    TestComponent,
+  );
 });
 
 test('uiCompletionResource accepts UiKit inputs', () => {
@@ -142,4 +141,42 @@ test('uiCompletionResource accepts UiKit inputs', () => {
 
   // Assert
   expect(message?.[TAG_NAME_REGISTRY]?.Tile?.component).toBe(TileComponent);
+});
+
+test('uiCompletionResource passes reactive options through to structuredCompletionResource', () => {
+  // Arrange
+  structuredCompletionResourceMock.mockReset();
+  structuredCompletionResourceMock.mockReturnValue(
+    createCompletionStub(signal<any | null>(null)),
+  );
+  const model = signal<ModelInput>('gpt-4.1');
+  const apiUrl = signal('/ui-completion');
+  const system = signal('System prompt');
+  const threadId = signal<string | undefined>('thread-a');
+
+  // Act
+  uiCompletionResource({
+    components: [
+      {
+        component: class {},
+        name: 'Card',
+        description: 'Card component',
+      },
+    ],
+    input: signal('Describe a component'),
+    model,
+    apiUrl,
+    system,
+    threadId,
+  });
+
+  // Assert
+  expect(structuredCompletionResourceMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model,
+      apiUrl,
+      system: expect.any(Function),
+      threadId,
+    }),
+  );
 });

--- a/packages/angular/src/utils/signals.ts
+++ b/packages/angular/src/utils/signals.ts
@@ -6,7 +6,7 @@ import {
   signal,
   WritableSignal,
 } from '@angular/core';
-import { SignalLike } from './types';
+import type { ReactiveOption, SignalLike } from './types';
 
 export function readSignalLike<T>(signalLike: SignalLike<T>): T {
   if (isSignal(signalLike)) {
@@ -18,6 +18,16 @@ export function readSignalLike<T>(signalLike: SignalLike<T>): T {
   }
 
   return signalLike;
+}
+
+/**
+ * Reads a reactive option without invoking function values.
+ *
+ * @param option - The literal value or Angular signal to read.
+ * @returns The current option value.
+ */
+export function readReactiveOption<T>(option: ReactiveOption<T>): T {
+  return isSignal(option) ? option() : option;
 }
 
 type TeardownFn = () => void;

--- a/packages/angular/src/utils/types.ts
+++ b/packages/angular/src/utils/types.ts
@@ -1,6 +1,14 @@
 import { Signal } from '@angular/core';
 
 /**
+ * A value that can be supplied directly or through an Angular signal.
+ *
+ * @public
+ * @typeParam T - The option value type.
+ */
+export type ReactiveOption<T> = T | Signal<T>;
+
+/**
  * A type that represents a signal or a value.
  *
  * @public

--- a/www/analog/src/app/pages/docs/angular/concept/components.md
+++ b/www/analog/src/app/pages/docs/angular/concept/components.md
@@ -173,13 +173,14 @@ chat = uiChatResource({
 | Option       | Type                                                  | Required | Description                                       |
 | ------------ | ----------------------------------------------------- | -------- | ------------------------------------------------- |
 | `components` | `ExposedComponent<any>[]`                             | Yes      | The components to use for the UI chat resource    |
-| `model`      | `KnownModelIds`                                       | Yes      | The model to use for the UI chat resource         |
-| `system`     | `string \| Signal<string>`                            | Yes      | The system prompt to use for the UI chat resource |
+| `model`      | `ReactiveOption<ModelInput>`                          | Yes      | The model to use for the UI chat resource         |
+| `system`     | `ReactiveOption<string \| SystemPrompt>`              | Yes      | The system prompt to use for the UI chat resource |
 | `messages`   | `Chat.Message<s.Infer<UiChatMessageOutput>, Tools>[]` | No       | The initial messages for the UI chat resource     |
 | `tools`      | `Tools[]`                                             | No       | The tools to use for the UI chat resource         |
 | `debugName`  | `string`                                              | No       | The debug name for the UI chat resource           |
 | `debounce`   | `number`                                              | No       | The debounce time for the UI chat resource        |
-| `apiUrl`     | `string`                                              | No       | The API URL to use for the UI chat resource       |
+| `apiUrl`     | `ReactiveOption<string>`                              | No       | The API URL to use for the UI chat resource       |
+| `threadId`   | `ReactiveOption<string \| undefined>`                 | No       | Thread identifier used to load or continue a conversation |
 
 ---
 

--- a/www/analog/src/app/pages/docs/angular/concept/structured-output.md
+++ b/www/analog/src/app/pages/docs/angular/concept/structured-output.md
@@ -111,15 +111,16 @@ Provider support differs. OpenAI and Azure use JSON object mode, Google sets the
 
 | Option             | Type                                     | Required | Description                                                     |
 | ------------------ | ---------------------------------------- | -------- | --------------------------------------------------------------- |
-| `model`            | `KnownModelIds \| Signal<KnownModelIds>` | Yes      | The model to use for the structured chat resource               |
-| `system`           | `string \| Signal<string>`               | Yes      | The system prompt to use for the structured chat resource       |
+| `model`            | `ReactiveOption<ModelInput>`             | Yes      | The model to use for the structured chat resource               |
+| `system`           | `ReactiveOption<string>`                 | Yes      | The system prompt to use for the structured chat resource       |
 | `schema`           | `s.SchemaOutput`                         | Yes      | The schema to use for the structured chat resource              |
 | `tools`            | `Tools[]`                                | No       | The tools to use for the structured chat resource               |
 | `messages`         | `Chat.Message<Output, Tools>[]`          | No       | The initial messages for the structured chat resource           |
 | `debugName`        | `string`                                 | No       | The debug name for the structured chat resource                 |
 | `debounce`         | `number`                                 | No       | The debounce time for the structured chat resource              |
 | `retries`          | `number`                                 | No       | The number of retries for the structured chat resource          |
-| `apiUrl`           | `string`                                 | No       | The API URL to use for the structured chat resource             |
+| `apiUrl`           | `ReactiveOption<string>`                 | No       | The API URL to use for the structured chat resource             |
+| `threadId`         | `ReactiveOption<string \| undefined>`    | No       | Thread identifier used to load or continue a conversation       |
 | `structuredOutput` | `StructuredOutputOptions`                | No       | Controls how the provider is asked to produce structured output |
 
 ---
@@ -205,16 +206,17 @@ When the user types a scene name, the LLM will predict which lights should be ad
 
 ### `StructuredCompletionResourceOptions`
 
-| Option             | Type                                 | Required | Description                                                     |
-| ------------------ | ------------------------------------ | -------- | --------------------------------------------------------------- |
-| `model`            | `KnownModelIds`                      | Yes      | The model to use for the structured completion resource         |
-| `input`            | `Signal<null \| undefined \| Input>` | Yes      | The input to the structured completion resource                 |
-| `schema`           | `s.SchemaOutput`                     | Yes      | The schema to use for the structured completion resource        |
-| `system`           | `SignalLike<string>`                 | Yes      | The system prompt to use for the structured completion resource |
-| `tools`            | `Chat.AnyTool[]`                     | No       | The tools to use for the structured completion resource         |
-| `debugName`        | `string`                             | No       | The debug name for the structured completion resource           |
-| `apiUrl`           | `string`                             | No       | The API URL to use for the structured completion resource       |
-| `structuredOutput` | `StructuredOutputOptions`            | No       | Controls how the provider is asked to produce structured output |
+| Option             | Type                                      | Required | Description                                                     |
+| ------------------ | ----------------------------------------- | -------- | --------------------------------------------------------------- |
+| `model`            | `ReactiveOption<ModelInput>`              | Yes      | The model to use for the structured completion resource         |
+| `input`            | `Signal<null \| undefined \| Input>`      | Yes      | The input to the structured completion resource                 |
+| `schema`           | `s.SchemaOutput`                          | Yes      | The schema to use for the structured completion resource        |
+| `system`           | `ReactiveOption<string>`                  | Yes      | The system prompt to use for the structured completion resource |
+| `tools`            | `Chat.AnyTool[]`                          | No       | The tools to use for the structured completion resource         |
+| `debugName`        | `string`                                  | No       | The debug name for the structured completion resource           |
+| `apiUrl`           | `ReactiveOption<string>`                  | No       | The API URL to use for the structured completion resource       |
+| `threadId`         | `ReactiveOption<string \| undefined>`     | No       | Thread identifier used to load or continue a conversation       |
+| `structuredOutput` | `StructuredOutputOptions`                 | No       | Controls how the provider is asked to produce structured output |
 
 ---
 

--- a/www/analog/src/app/pages/docs/angular/start/quick.md
+++ b/www/analog/src/app/pages/docs/angular/start/quick.md
@@ -113,13 +113,14 @@ chatResource({
 
 | Option    | Type                                                                   | Required | Description                                                       |
 | --------- | ---------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- |
-| system    | string \| Signal<string>                                               | Yes      | System (assistant) prompt.                                        |
-| model     | KnownModelIds \| Signal<KnownModelIds>                                 | Yes      | Model identifier to use.                                          |
+| system    | ReactiveOption<string>                                                 | Yes      | System (assistant) prompt.                                        |
+| model     | ReactiveOption<ModelInput>                                             | Yes      | Model identifier or model input to use.                           |
 | tools     | Tools[]                                                                | No       | Array of bound tools available to the chat.                       |
 | messages  | Chat.Message<string, Tools>[] \| Signal<Chat.Message<string, Tools>[]> | No       | Initial list of chat messages.                                    |
 | debounce  | number                                                                 | No       | Debounce interval in milliseconds between user inputs.            |
 | debugName | string                                                                 | No       | Name used for debugging in logs and reactive signal labels.       |
-| apiUrl    | string                                                                 | No       | Override for the API base URL (defaults to configured `baseUrl`). |
+| apiUrl    | ReactiveOption<string>                                                 | No       | Override for the API base URL (defaults to configured `baseUrl`). |
+| threadId  | ReactiveOption<string \| undefined>                                    | No       | Thread identifier used to load or continue a conversation.        |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a public Angular `ReactiveOption<T>` type and widen Angular resource options for `model`, `apiUrl`, `system`, and `threadId`.
- Update Angular chat/completion root resources to call `hashbrown.updateOptions(...)` when option signals change while preserving the existing runtime.
- Preserve direct function-valued `ModelInput` factories, wrapper pass-through behavior, and docs for the updated option types.

## Test Plan

- `NX_DAEMON=false FORCE_COLOR=0 npx nx test angular --runInBand`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx lint angular`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build angular`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build-api-report angular`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx build www`
- `NX_DAEMON=false FORCE_COLOR=0 npx nx test www`
- `git diff --check`