### PR TITLE
Clarify chat option order and preserve Angular deep signal identity

### DIFF
--- a/docs/superpowers/plans/2026-07-07-docs-order-angular-referential-equality.md
+++ b/docs/superpowers/plans/2026-07-07-docs-order-angular-referential-equality.md
@@ -1,0 +1,299 @@
+# Docs Order and Angular Referential Equality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document Hashbrown chat order-of-operations behavior and preserve unchanged Angular structured-output references through `toDeepSignal`.
+
+**Architecture:** Documentation changes live in the existing paired React and Angular message history concept pages. Angular referential equality is implemented once in `toDeepSignal`, which is already the shared value exposure path for Angular structured chat and structured completion. Tests pin the identity behavior at the utility boundary.
+
+**Tech Stack:** Nx, TypeScript, Angular signals, Markdown docs, Vitest.
+
+---
+
+## File Structure
+
+- Modify: `www/analog/src/app/pages/docs/react/concept/message-history.md`
+  - Add the React order-of-operations documentation section.
+- Modify: `www/analog/src/app/pages/docs/angular/concept/message-history.md`
+  - Add the Angular order-of-operations documentation section.
+- Modify: `packages/angular/src/utils/deep-signal.spec.ts`
+  - Convert this touched spec file to top-level `test(...)`.
+  - Add identity-preservation tests before implementation.
+- Modify: `packages/angular/src/utils/deep-signal.ts`
+  - Add internal reconciliation for values read through `toDeepSignal`.
+
+## Task 1: Document Order of Operations
+
+**Files:**
+- Modify: `www/analog/src/app/pages/docs/react/concept/message-history.md`
+- Modify: `www/analog/src/app/pages/docs/angular/concept/message-history.md`
+
+- [ ] **Step 1: Add React documentation**
+
+Add a section after "Replace History with `setMessages`" in the React page:
+
+```md
+## Order of Operations
+
+Hashbrown creates one chat instance for the hook and keeps its message history until you intentionally replace it. The `messages` option seeds the initial history only; changing the value you passed to `messages` later does not reset an active chat.
+
+Runtime options such as `model`, `system`, `apiUrl`, `threadId`, tools, transport, retries, and debounce settings are applied to future requests. Updating those options does not append a message, clear history, or resend the conversation by itself.
+
+Use `sendMessage` to add a new turn, `setMessages` to replace history, and `reload` to remove the last assistant message before retrying. For completion hooks, `input` is different from chat history: changing `input` synchronizes the backing single user message for the next completion.
+
+Put durable behavior and constraints in `system`. Put conversational facts, prior turns, summaries, and user-visible conversation state in message history.
+```
+
+- [ ] **Step 2: Add Angular documentation**
+
+Add a matching section after "Replace History with `setMessages`" in the Angular page:
+
+```md
+## Order of Operations
+
+Hashbrown creates one chat instance for the resource and keeps its message history until you intentionally replace it. The `messages` option seeds the initial history only; changing the value you passed to `messages` later does not reset an active chat.
+
+Reactive options such as `model`, `system`, `apiUrl`, `threadId`, tools, and transport are applied to future requests. Updating those options does not append a message, clear history, or resend the conversation by itself.
+
+Use `sendMessage` to add a new turn, `setMessages` to replace history, and `reload` to remove the last assistant message before retrying. For completion resources, `input` is different from chat history: changing `input` synchronizes the backing single user message for the next completion.
+
+Put durable behavior and constraints in `system`. Put conversational facts, prior turns, summaries, and user-visible conversation state in message history.
+```
+
+- [ ] **Step 3: Commit docs**
+
+Run:
+
+```bash
+git add www/analog/src/app/pages/docs/react/concept/message-history.md www/analog/src/app/pages/docs/angular/concept/message-history.md
+git commit -m "docs: clarify chat option order of operations"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Add Failing Angular Identity Tests
+
+**Files:**
+- Modify: `packages/angular/src/utils/deep-signal.spec.ts`
+
+- [ ] **Step 1: Convert the touched spec file to top-level tests**
+
+Remove the outer `describe('toDeepSignal', () => { ... })` wrapper and convert every `it(...)` call in the file to `test(...)`, preserving existing assertions.
+
+- [ ] **Step 2: Add failing tests**
+
+Add these tests near the existing streaming-data tests:
+
+```ts
+test('reuses unchanged nested object references across updates', () => {
+  const state = signal({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'idle',
+  });
+  const deepState = toDeepSignal(state);
+  const firstUser = deepState.user();
+  const firstProfile = deepState.user.profile();
+
+  state.set({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'loading',
+  });
+
+  expect(deepState.user()).toBe(firstUser);
+  expect(deepState.user.profile()).toBe(firstProfile);
+  expect(deepState()).toEqual({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'loading',
+  });
+});
+```
+
+```ts
+test('reuses unchanged nested array references when siblings change', () => {
+  const state = signal({
+    groups: [
+      { id: 'a', items: ['one'] },
+      { id: 'b', items: ['two'] },
+    ],
+  });
+  const deepState = toDeepSignal(state);
+  const firstGroup = deepState().groups[0];
+  const firstItems = deepState().groups[0].items;
+
+  state.set({
+    groups: [
+      { id: 'a', items: ['one'] },
+      { id: 'b', items: ['two', 'three'] },
+    ],
+  });
+
+  expect(deepState().groups[0]).toBe(firstGroup);
+  expect(deepState().groups[0].items).toBe(firstItems);
+  expect(deepState().groups[1]).not.toBe(state().groups[1]);
+});
+```
+
+```ts
+test('reuses the root reference when the next value is structurally equal', () => {
+  const state = signal({ result: { value: 1 } });
+  const deepState = toDeepSignal(state);
+  const firstValue = deepState();
+
+  state.set({ result: { value: 1 } });
+
+  expect(deepState()).toBe(firstValue);
+});
+```
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+Run:
+
+```bash
+npx nx test angular --testFile=packages/angular/src/utils/deep-signal.spec.ts
+```
+
+Expected: the new identity tests fail because unchanged references are not yet reused.
+
+- [ ] **Step 4: Commit failing tests**
+
+Run:
+
+```bash
+git add packages/angular/src/utils/deep-signal.spec.ts
+git commit -m "test: cover angular deep signal identity reuse"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Implement Angular Deep-Signal Reconciliation
+
+**Files:**
+- Modify: `packages/angular/src/utils/deep-signal.ts`
+- Modify if needed: `packages/angular/src/utils/deep-signal.spec.ts`
+
+- [ ] **Step 1: Add a reconciled computed root**
+
+Inside `toDeepSignal`, wrap the incoming signal in a computed signal that remembers the last reconciled value:
+
+```ts
+let previous = untracked(signal);
+const reconciledSignal = computed(() => {
+  const next = signal();
+  previous = reconcileValue(previous, next);
+  return previous;
+});
+```
+
+Use `reconciledSignal` as the proxy target so `deepSig()` returns the stabilized root.
+
+- [ ] **Step 2: Add `reconcileValue` helper**
+
+Add an internal helper below `toDeepSignal`:
+
+```ts
+function reconcileValue<T>(previous: T, next: T): T {
+  if (Object.is(previous, next)) {
+    return previous;
+  }
+
+  if (Array.isArray(previous) && Array.isArray(next)) {
+    if (previous.length !== next.length) {
+      return next.map((value, index) =>
+        reconcileValue(previous[index], value),
+      ) as T;
+    }
+
+    const reconciled = next.map((value, index) =>
+      reconcileValue(previous[index], value),
+    );
+
+    return reconciled.every((value, index) => value === previous[index])
+      ? previous
+      : (reconciled as T);
+  }
+
+  if (isRecord(previous) && isRecord(next)) {
+    const previousKeys = Reflect.ownKeys(previous);
+    const nextKeys = Reflect.ownKeys(next);
+
+    if (
+      previousKeys.length !== nextKeys.length ||
+      nextKeys.some((key) => !previousKeys.includes(key))
+    ) {
+      return buildReconciledRecord(previous, next) as T;
+    }
+
+    const reconciled = buildReconciledRecord(previous, next);
+
+    return nextKeys.every((key) => reconciled[key] === previous[key])
+      ? previous
+      : (reconciled as T);
+  }
+
+  return next;
+}
+```
+
+Add `buildReconciledRecord(previous, next)` to copy own keys from `next` and recursively reconcile each value. Create the result with `Object.create(Object.getPrototypeOf(next))` so changed custom class instances keep the same prototype shape as `next`. Type the helper around `Record<PropertyKey, unknown>` or local `any` casts for `Reflect.ownKeys` access. Keep the helper internal and avoid mutating either input.
+
+- [ ] **Step 3: Run focused tests and verify pass**
+
+Run:
+
+```bash
+npx nx test angular --testFile=packages/angular/src/utils/deep-signal.spec.ts
+```
+
+Expected: all `deep-signal` tests pass.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add packages/angular/src/utils/deep-signal.ts packages/angular/src/utils/deep-signal.spec.ts
+git commit -m "fix: preserve angular deep signal identity"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Verify Affected Packages
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Run Angular test/build/lint**
+
+Run:
+
+```bash
+npx nx test angular
+npx nx build angular
+npx nx lint angular
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run docs build/test**
+
+Run:
+
+```bash
+npx nx build www
+npx nx test www
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Review final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+git diff origin/main...HEAD --stat
+```
+
+Expected: working tree is clean, commits are scoped to the spec, docs, tests, and Angular utility implementation.

--- a/docs/superpowers/specs/2026-07-07-docs-order-angular-referential-equality-design.md
+++ b/docs/superpowers/specs/2026-07-07-docs-order-angular-referential-equality-design.md
@@ -1,0 +1,82 @@
+# Docs Order and Angular Referential Equality Design
+
+## Context
+
+This change covers two GitHub issues in one focused PR:
+
+- Issue #111: document which input and option changes affect chat message history and future requests.
+- Issue #148: preserve referential equality for unchanged Angular structured-output values.
+
+The current React and Angular chat APIs create one Hashbrown instance per hook/resource and update runtime options on subsequent reactive changes. Chat history is initialized from `messages` and then changes through explicit message APIs. Completion APIs derive their single user message from `input`.
+
+Core parser tests already cover resolved-value identity preservation for unchanged parser subtrees. React also stabilizes values at the reactivity bridge with deep equality. Angular structured chat and structured completion both expose values through `toDeepSignal`, making that utility the narrowest Angular fix point.
+
+## Goals
+
+- Document the order of operations for message history, option updates, and completion input changes in both React and Angular docs.
+- Preserve unchanged nested value references in Angular deep signals when streamed structured data produces an equivalent subtree.
+- Keep the public API unchanged.
+- Avoid new dependencies.
+
+## Non-Goals
+
+- Do not change core parser behavior.
+- Do not add resource-level identity reconciliation in every Angular resource.
+- Do not change React behavior.
+- Do not document deferred issues #271, #468, or #466 as part of this PR.
+
+## Documentation Design
+
+Add an "Order of Operations" section to the paired message history concept pages:
+
+- `www/analog/src/app/pages/docs/react/concept/message-history.md`
+- `www/analog/src/app/pages/docs/angular/concept/message-history.md`
+
+The section will explain:
+
+- `messages` seeds the initial history only.
+- `sendMessage`, `setMessages`, and `reload` are the APIs that intentionally mutate chat history.
+- Runtime options such as `model`, `system`, `apiUrl`, `threadId`, tools, and transport are applied to future requests without clearing history or sending a message by themselves.
+- Completion resources differ from chat resources because their `input` option synchronizes the backing single user message.
+- Durable behavior belongs in `system`; conversational state belongs in message history.
+
+This belongs in message history rather than a new concept page because issue #111 is specifically about user expectations around chat history changes.
+
+## Angular Referential Equality Design
+
+Extend `toDeepSignal` in `packages/angular/src/utils/deep-signal.ts` with an internal reconciliation layer.
+
+The reconciler will:
+
+- Keep the previous value inside the deep-signal wrapper.
+- Compare each new value against the previous value.
+- Reuse the previous reference when the whole subtree is structurally equal.
+- Recurse through arrays and values accepted by the existing `isRecord()` predicate so unchanged children keep their identity even when a parent object changes.
+- Return primitives by `Object.is`.
+- Leave non-record object handling consistent with existing `toDeepSignal` behavior.
+- Avoid mutating caller-provided values.
+
+The public `DeepSignal<T>` type and `toDeepSignal<T>()` signature remain unchanged.
+
+## Testing Design
+
+Write failing Angular tests first in `packages/angular/src/utils/deep-signal.spec.ts`:
+
+- Unchanged nested object references are reused across updates.
+- Unchanged nested array references are reused while changed siblings receive new references.
+- The root reference is reused when the entire next value is structurally equal.
+
+Keep tests top-level with `test(...)` and arrange/act/assert spacing.
+
+Verification after implementation:
+
+- `npx nx test angular`
+- `npx nx build angular`
+- `npx nx lint angular`
+- `npx nx build www`
+- `npx nx test www`
+
+## Risks
+
+- Reconciliation adds work on each deep-signal read. The expected values are streamed structured outputs, and the algorithm is scoped to the exposed value path rather than every core parser update.
+- If consumers rely on new object references for equivalent Angular structured-output values, this will reduce unnecessary updates. That matches the issue intent and React behavior.

--- a/packages/angular/src/utils/deep-signal.spec.ts
+++ b/packages/angular/src/utils/deep-signal.spec.ts
@@ -42,6 +42,30 @@ test('creates deep signals for custom class instances', () => {
   expect(deepSig.user.firstName()).toBe('John');
 });
 
+test('preserves custom class prototypes when reconciling changed instances', () => {
+  class User {
+    constructor(readonly firstName: string) {}
+  }
+
+  class UserState {
+    constructor(
+      readonly user: User,
+      readonly version: number,
+    ) {}
+  }
+
+  const sig = signal(new UserState(new User('John'), 1));
+  const deepSig = toDeepSignal(sig);
+  const firstUser = deepSig.user();
+
+  sig.set(new UserState(new User('John'), 2));
+
+  expect(deepSig()).toBeInstanceOf(UserState);
+  expect(deepSig().user).toBeInstanceOf(User);
+  expect(deepSig().user).toBe(firstUser);
+  expect(deepSig().version).toBe(2);
+});
+
 test('allows lazy initialization', () => {
   const sig = signal(undefined as unknown as { m: { s: 't' } });
   const deepSig = toDeepSignal(sig);

--- a/packages/angular/src/utils/deep-signal.spec.ts
+++ b/packages/angular/src/utils/deep-signal.spec.ts
@@ -2,318 +2,366 @@
 import { isSignal, signal } from '@angular/core';
 import { toDeepSignal } from './deep-signal';
 
-describe('toDeepSignal', () => {
-  it('creates deep signals for plain objects', () => {
-    const sig = signal({ m: { s: 't' } });
-    const deepSig = toDeepSignal(sig);
+test('creates deep signals for plain objects', () => {
+  const sig = signal({ m: { s: 't' } });
+  const deepSig = toDeepSignal(sig);
 
-    expect(sig).not.toBe(deepSig);
+  expect(sig).not.toBe(deepSig);
 
-    expect(isSignal(deepSig)).toBe(true);
-    expect(deepSig()).toEqual({ m: { s: 't' } });
+  expect(isSignal(deepSig)).toBe(true);
+  expect(deepSig()).toEqual({ m: { s: 't' } });
 
-    expect(isSignal(deepSig.m)).toBe(true);
-    expect(deepSig.m()).toEqual({ s: 't' });
+  expect(isSignal(deepSig.m)).toBe(true);
+  expect(deepSig.m()).toEqual({ s: 't' });
 
-    expect(isSignal(deepSig.m.s)).toBe(true);
-    expect(deepSig.m.s()).toBe('t');
+  expect(isSignal(deepSig.m.s)).toBe(true);
+  expect(deepSig.m.s()).toBe('t');
+});
+
+test('creates deep signals for custom class instances', () => {
+  class User {
+    constructor(readonly firstName: string) {}
+  }
+
+  class UserState {
+    constructor(readonly user: User) {}
+  }
+
+  const sig = signal(new UserState(new User('John')));
+  const deepSig = toDeepSignal(sig);
+
+  expect(sig).not.toBe(deepSig);
+
+  expect(isSignal(deepSig)).toBe(true);
+  expect(deepSig()).toEqual({ user: { firstName: 'John' } });
+
+  expect(isSignal(deepSig.user)).toBe(true);
+  expect(deepSig.user()).toEqual({ firstName: 'John' });
+
+  expect(isSignal(deepSig.user.firstName)).toBe(true);
+  expect(deepSig.user.firstName()).toBe('John');
+});
+
+test('allows lazy initialization', () => {
+  const sig = signal(undefined as unknown as { m: { s: 't' } });
+  const deepSig = toDeepSignal(sig);
+
+  sig.set({ m: { s: 't' } });
+
+  expect(deepSig()).toEqual({ m: { s: 't' } });
+  expect(deepSig.m()).toEqual({ s: 't' });
+  expect(deepSig.m.s()).toBe('t');
+});
+
+test('creates a deep signal when value is a union of objects', () => {
+  const sig = signal({ m: { s: 't' } } as { s: 'asdf' } | { m: { s: string } });
+  const deepSig = toDeepSignal(sig);
+
+  expect('m' in deepSig).toBe(true);
+  expect('m' in deepSig && deepSig.m()).toEqual({ s: 't' });
+  expect('m' in deepSig && deepSig.m.s()).toBe('t');
+
+  sig.set({ s: 'asdf' });
+
+  expect('m' in deepSig).toBe(false);
+  expect('s' in deepSig).toBe(true);
+  expect('s' in deepSig && deepSig.s()).toBe('asdf');
+
+  sig.set({ m: { s: 'ngrx' } });
+
+  expect('s' in deepSig).toBe(false);
+  expect('m' in deepSig).toBe(true);
+  expect('m' in deepSig && deepSig.m()).toEqual({ s: 'ngrx' });
+  expect('m' in deepSig && deepSig.m.s()).toBe('ngrx');
+});
+
+test('does not affect signals with primitives as values', () => {
+  const num = signal(0);
+  const str = signal('str');
+  const bool = signal(true);
+
+  const deepNum = toDeepSignal(num);
+  const deepStr = toDeepSignal(str);
+  const deepBool = toDeepSignal(bool);
+
+  expect(isSignal(deepNum)).toBe(true);
+  expect(deepNum()).toBe(num());
+
+  expect(isSignal(deepStr)).toBe(true);
+  expect(deepStr()).toBe(str());
+
+  expect(isSignal(deepBool)).toBe(true);
+  expect(deepBool()).toBe(bool());
+});
+
+test('does not affect signals with iterables as values', () => {
+  const array = signal([]);
+  const set = signal(new Set());
+  const map = signal(new Map());
+  const uintArray = signal(new Uint32Array());
+  const floatArray = signal(new Float64Array());
+
+  const deepArray = toDeepSignal(array);
+  const deepSet = toDeepSignal(set);
+  const deepMap = toDeepSignal(map);
+  const deepUintArray = toDeepSignal(uintArray);
+  const deepFloatArray = toDeepSignal(floatArray);
+
+  expect(isSignal(deepArray)).toBe(true);
+  expect(deepArray()).toBe(array());
+
+  expect(isSignal(deepSet)).toBe(true);
+  expect(deepSet()).toBe(set());
+
+  expect(isSignal(deepMap)).toBe(true);
+  expect(deepMap()).toBe(map());
+
+  expect(isSignal(deepUintArray)).toBe(true);
+  expect(deepUintArray()).toBe(uintArray());
+
+  expect(isSignal(deepFloatArray)).toBe(true);
+  expect(deepFloatArray()).toBe(floatArray());
+});
+
+test('does not affect signals with built-in object types as values', () => {
+  const weakSet = signal(new WeakSet());
+  const weakMap = signal(new WeakMap());
+  const promise = signal(Promise.resolve(10));
+  const date = signal(new Date());
+  const error = signal(new Error());
+  const regExp = signal(new RegExp(''));
+  const arrayBuffer = signal(new ArrayBuffer(10));
+  const dataView = signal(new DataView(new ArrayBuffer(10)));
+
+  const deepWeakSet = toDeepSignal(weakSet);
+  const deepWeakMap = toDeepSignal(weakMap);
+  const deepPromise = toDeepSignal(promise);
+  const deepDate = toDeepSignal(date);
+  const deepError = toDeepSignal(error);
+  const deepRegExp = toDeepSignal(regExp);
+  const deepArrayBuffer = toDeepSignal(arrayBuffer);
+  const deepDataView = toDeepSignal(dataView);
+
+  expect(isSignal(deepWeakSet)).toBe(true);
+  expect(deepWeakSet()).toBe(weakSet());
+
+  expect(isSignal(deepWeakMap)).toBe(true);
+  expect(deepWeakMap()).toBe(weakMap());
+
+  expect(isSignal(deepPromise)).toBe(true);
+  expect(deepPromise()).toBe(promise());
+
+  expect(isSignal(deepDate)).toBe(true);
+  expect(deepDate()).toBe(date());
+
+  expect(isSignal(deepError)).toBe(true);
+  expect(deepError()).toBe(error());
+
+  expect(isSignal(deepRegExp)).toBe(true);
+  expect(deepRegExp()).toBe(regExp());
+
+  expect(isSignal(deepArrayBuffer)).toBe(true);
+  expect(deepArrayBuffer()).toBe(arrayBuffer());
+
+  expect(isSignal(deepDataView)).toBe(true);
+  expect(deepDataView()).toBe(dataView());
+});
+
+test('does not affect signals with functions as values', () => {
+  const fn1 = signal(new Function());
+  const fn2 = signal(function () {
+    return;
+  });
+  const fn3 = signal(() => {
+    return;
   });
 
-  it('creates deep signals for custom class instances', () => {
-    class User {
-      constructor(readonly firstName: string) {}
-    }
+  const deepFn1 = toDeepSignal(fn1);
+  const deepFn2 = toDeepSignal(fn2);
+  const deepFn3 = toDeepSignal(fn3);
 
-    class UserState {
-      constructor(readonly user: User) {}
-    }
+  expect(isSignal(deepFn1)).toBe(true);
+  expect(deepFn1()).toBe(fn1());
 
-    const sig = signal(new UserState(new User('John')));
-    const deepSig = toDeepSignal(sig);
+  expect(isSignal(deepFn2)).toBe(true);
+  expect(deepFn2()).toBe(fn2());
 
-    expect(sig).not.toBe(deepSig);
+  expect(isSignal(deepFn3)).toBe(true);
+  expect(deepFn3()).toBe(fn3());
+});
 
-    expect(isSignal(deepSig)).toBe(true);
-    expect(deepSig()).toEqual({ user: { firstName: 'John' } });
+test('does not affect signals with custom class instances that are iterables as values', () => {
+  class CustomArray extends Array {}
 
-    expect(isSignal(deepSig.user)).toBe(true);
-    expect(deepSig.user()).toEqual({ firstName: 'John' });
+  class CustomSet extends Set {}
 
-    expect(isSignal(deepSig.user.firstName)).toBe(true);
-    expect(deepSig.user.firstName()).toBe('John');
+  class CustomFloatArray extends Float32Array {}
+
+  const array = signal(new CustomArray());
+  const floatArray = signal(new CustomFloatArray());
+  const set = signal(new CustomSet());
+
+  const deepArray = toDeepSignal(array);
+  const deepFloatArray = toDeepSignal(floatArray);
+  const deepSet = toDeepSignal(set);
+
+  expect(isSignal(deepArray)).toBe(true);
+  expect(deepArray()).toBe(array());
+
+  expect(isSignal(deepFloatArray)).toBe(true);
+  expect(deepFloatArray()).toBe(floatArray());
+
+  expect(isSignal(deepSet)).toBe(true);
+  expect(deepSet()).toBe(set());
+});
+
+test('does not affect signals with custom class instances that extend built-in object types as values', () => {
+  class CustomWeakMap extends WeakMap {}
+
+  class CustomError extends Error {}
+
+  class CustomArrayBuffer extends ArrayBuffer {}
+
+  const weakMap = signal(new CustomWeakMap());
+  const error = signal(new CustomError());
+  const arrayBuffer = signal(new CustomArrayBuffer(10));
+
+  const deepWeakMap = toDeepSignal(weakMap);
+  const deepError = toDeepSignal(error);
+  const deepArrayBuffer = toDeepSignal(arrayBuffer);
+
+  expect(isSignal(deepWeakMap)).toBe(true);
+  expect(deepWeakMap()).toBe(weakMap());
+
+  expect(isSignal(deepError)).toBe(true);
+  expect(deepError()).toBe(error());
+
+  expect(isSignal(deepArrayBuffer)).toBe(true);
+  expect(deepArrayBuffer()).toBe(arrayBuffer());
+});
+
+// Additional tests for Hashbrown streaming scenarios
+test('works with streaming data scenarios', () => {
+  // Simulate streaming data where properties are gradually populated
+  const state = signal<any>({});
+
+  const deepState = toDeepSignal(state);
+
+  // Initially empty
+  expect(deepState()).toEqual({});
+
+  // First chunk of data arrives
+  state.update(() => ({
+    user: { name: 'John' },
+  }));
+
+  expect(deepState.user()).toEqual({ name: 'John' });
+  expect(deepState.user.name()).toBe('John');
+
+  // More data arrives
+  state.update((s) => ({
+    ...s,
+    user: {
+      ...s.user,
+      age: 30,
+    },
+  }));
+
+  expect(deepState.user()).toEqual({ name: 'John', age: 30 });
+  expect(deepState.user.age()).toBe(30);
+
+  // Additional property added
+  state.update((s) => ({
+    ...s,
+    messages: ['Hello', 'World'],
+  }));
+
+  expect(deepState.messages()).toEqual(['Hello', 'World']);
+});
+
+test('reuses unchanged nested object references across updates', () => {
+  const state = signal({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'idle',
+  });
+  const deepState = toDeepSignal(state);
+  const firstUser = deepState.user();
+  const firstProfile = deepState.user.profile();
+
+  state.set({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'loading',
   });
 
-  it('allows lazy initialization', () => {
-    const sig = signal(undefined as unknown as { m: { s: 't' } });
-    const deepSig = toDeepSignal(sig);
+  expect(deepState.user()).toBe(firstUser);
+  expect(deepState.user.profile()).toBe(firstProfile);
+  expect(deepState()).toEqual({
+    user: { name: 'Ada', profile: { title: 'Engineer' } },
+    status: 'loading',
+  });
+});
 
-    sig.set({ m: { s: 't' } });
+test('reuses unchanged nested array references when siblings change', () => {
+  const state = signal({
+    groups: [
+      { id: 'a', items: ['one'] },
+      { id: 'b', items: ['two'] },
+    ],
+  });
+  const deepState = toDeepSignal(state);
+  const firstGroup = deepState().groups[0];
+  const firstItems = deepState().groups[0].items;
 
-    expect(deepSig()).toEqual({ m: { s: 't' } });
-    expect(deepSig.m()).toEqual({ s: 't' });
-    expect(deepSig.m.s()).toBe('t');
+  state.set({
+    groups: [
+      { id: 'a', items: ['one'] },
+      { id: 'b', items: ['two', 'three'] },
+    ],
   });
 
-  it('creates a deep signal when value is a union of objects', () => {
-    const sig = signal({ m: { s: 't' } } as
-      | { s: 'asdf' }
-      | { m: { s: string } });
-    const deepSig = toDeepSignal(sig);
+  expect(deepState().groups[0]).toBe(firstGroup);
+  expect(deepState().groups[0].items).toBe(firstItems);
+  expect(deepState().groups[1]).not.toBe(state().groups[1]);
+});
 
-    expect('m' in deepSig).toBe(true);
-    expect('m' in deepSig && deepSig.m()).toEqual({ s: 't' });
-    expect('m' in deepSig && deepSig.m.s()).toBe('t');
+test('reuses the root reference when the next value is structurally equal', () => {
+  const state = signal({ result: { value: 1 } });
+  const deepState = toDeepSignal(state);
+  const firstValue = deepState();
 
-    sig.set({ s: 'asdf' });
+  state.set({ result: { value: 1 } });
 
-    expect('m' in deepSig).toBe(false);
-    expect('s' in deepSig).toBe(true);
-    expect('s' in deepSig && deepSig.s()).toBe('asdf');
+  expect(deepState()).toBe(firstValue);
+});
 
-    sig.set({ m: { s: 'ngrx' } });
-
-    expect('s' in deepSig).toBe(false);
-    expect('m' in deepSig).toBe(true);
-    expect('m' in deepSig && deepSig.m()).toEqual({ s: 'ngrx' });
-    expect('m' in deepSig && deepSig.m.s()).toBe('ngrx');
-  });
-
-  it('does not affect signals with primitives as values', () => {
-    const num = signal(0);
-    const str = signal('str');
-    const bool = signal(true);
-
-    const deepNum = toDeepSignal(num);
-    const deepStr = toDeepSignal(str);
-    const deepBool = toDeepSignal(bool);
-
-    expect(isSignal(deepNum)).toBe(true);
-    expect(deepNum()).toBe(num());
-
-    expect(isSignal(deepStr)).toBe(true);
-    expect(deepStr()).toBe(str());
-
-    expect(isSignal(deepBool)).toBe(true);
-    expect(deepBool()).toBe(bool());
-  });
-
-  it('does not affect signals with iterables as values', () => {
-    const array = signal([]);
-    const set = signal(new Set());
-    const map = signal(new Map());
-    const uintArray = signal(new Uint32Array());
-    const floatArray = signal(new Float64Array());
-
-    const deepArray = toDeepSignal(array);
-    const deepSet = toDeepSignal(set);
-    const deepMap = toDeepSignal(map);
-    const deepUintArray = toDeepSignal(uintArray);
-    const deepFloatArray = toDeepSignal(floatArray);
-
-    expect(isSignal(deepArray)).toBe(true);
-    expect(deepArray()).toBe(array());
-
-    expect(isSignal(deepSet)).toBe(true);
-    expect(deepSet()).toBe(set());
-
-    expect(isSignal(deepMap)).toBe(true);
-    expect(deepMap()).toBe(map());
-
-    expect(isSignal(deepUintArray)).toBe(true);
-    expect(deepUintArray()).toBe(uintArray());
-
-    expect(isSignal(deepFloatArray)).toBe(true);
-    expect(deepFloatArray()).toBe(floatArray());
-  });
-
-  it('does not affect signals with built-in object types as values', () => {
-    const weakSet = signal(new WeakSet());
-    const weakMap = signal(new WeakMap());
-    const promise = signal(Promise.resolve(10));
-    const date = signal(new Date());
-    const error = signal(new Error());
-    const regExp = signal(new RegExp(''));
-    const arrayBuffer = signal(new ArrayBuffer(10));
-    const dataView = signal(new DataView(new ArrayBuffer(10)));
-
-    const deepWeakSet = toDeepSignal(weakSet);
-    const deepWeakMap = toDeepSignal(weakMap);
-    const deepPromise = toDeepSignal(promise);
-    const deepDate = toDeepSignal(date);
-    const deepError = toDeepSignal(error);
-    const deepRegExp = toDeepSignal(regExp);
-    const deepArrayBuffer = toDeepSignal(arrayBuffer);
-    const deepDataView = toDeepSignal(dataView);
-
-    expect(isSignal(deepWeakSet)).toBe(true);
-    expect(deepWeakSet()).toBe(weakSet());
-
-    expect(isSignal(deepWeakMap)).toBe(true);
-    expect(deepWeakMap()).toBe(weakMap());
-
-    expect(isSignal(deepPromise)).toBe(true);
-    expect(deepPromise()).toBe(promise());
-
-    expect(isSignal(deepDate)).toBe(true);
-    expect(deepDate()).toBe(date());
-
-    expect(isSignal(deepError)).toBe(true);
-    expect(deepError()).toBe(error());
-
-    expect(isSignal(deepRegExp)).toBe(true);
-    expect(deepRegExp()).toBe(regExp());
-
-    expect(isSignal(deepArrayBuffer)).toBe(true);
-    expect(deepArrayBuffer()).toBe(arrayBuffer());
-
-    expect(isSignal(deepDataView)).toBe(true);
-    expect(deepDataView()).toBe(dataView());
-  });
-
-  it('does not affect signals with functions as values', () => {
-    const fn1 = signal(new Function());
-    const fn2 = signal(function () {
-      return;
-    });
-    const fn3 = signal(() => {
-      return;
-    });
-
-    const deepFn1 = toDeepSignal(fn1);
-    const deepFn2 = toDeepSignal(fn2);
-    const deepFn3 = toDeepSignal(fn3);
-
-    expect(isSignal(deepFn1)).toBe(true);
-    expect(deepFn1()).toBe(fn1());
-
-    expect(isSignal(deepFn2)).toBe(true);
-    expect(deepFn2()).toBe(fn2());
-
-    expect(isSignal(deepFn3)).toBe(true);
-    expect(deepFn3()).toBe(fn3());
-  });
-
-  it('does not affect signals with custom class instances that are iterables as values', () => {
-    class CustomArray extends Array {}
-
-    class CustomSet extends Set {}
-
-    class CustomFloatArray extends Float32Array {}
-
-    const array = signal(new CustomArray());
-    const floatArray = signal(new CustomFloatArray());
-    const set = signal(new CustomSet());
-
-    const deepArray = toDeepSignal(array);
-    const deepFloatArray = toDeepSignal(floatArray);
-    const deepSet = toDeepSignal(set);
-
-    expect(isSignal(deepArray)).toBe(true);
-    expect(deepArray()).toBe(array());
-
-    expect(isSignal(deepFloatArray)).toBe(true);
-    expect(deepFloatArray()).toBe(floatArray());
-
-    expect(isSignal(deepSet)).toBe(true);
-    expect(deepSet()).toBe(set());
-  });
-
-  it('does not affect signals with custom class instances that extend built-in object types as values', () => {
-    class CustomWeakMap extends WeakMap {}
-
-    class CustomError extends Error {}
-
-    class CustomArrayBuffer extends ArrayBuffer {}
-
-    const weakMap = signal(new CustomWeakMap());
-    const error = signal(new CustomError());
-    const arrayBuffer = signal(new CustomArrayBuffer(10));
-
-    const deepWeakMap = toDeepSignal(weakMap);
-    const deepError = toDeepSignal(error);
-    const deepArrayBuffer = toDeepSignal(arrayBuffer);
-
-    expect(isSignal(deepWeakMap)).toBe(true);
-    expect(deepWeakMap()).toBe(weakMap());
-
-    expect(isSignal(deepError)).toBe(true);
-    expect(deepError()).toBe(error());
-
-    expect(isSignal(deepArrayBuffer)).toBe(true);
-    expect(deepArrayBuffer()).toBe(arrayBuffer());
-  });
-
-  // Additional tests for Hashbrown streaming scenarios
-  it('works with streaming data scenarios', () => {
-    // Simulate streaming data where properties are gradually populated
-    const state = signal<any>({});
-
-    const deepState = toDeepSignal(state);
-
-    // Initially empty
-    expect(deepState()).toEqual({});
-
-    // First chunk of data arrives
-    state.update(() => ({
-      user: { name: 'John' },
-    }));
-
-    expect(deepState.user()).toEqual({ name: 'John' });
-    expect(deepState.user.name()).toBe('John');
-
-    // More data arrives
-    state.update((s) => ({
-      ...s,
-      user: {
-        ...s.user,
-        age: 30,
-      },
-    }));
-
-    expect(deepState.user()).toEqual({ name: 'John', age: 30 });
-    expect(deepState.user.age()).toBe(30);
-
-    // Additional property added
-    state.update((s) => ({
-      ...s,
-      messages: ['Hello', 'World'],
-    }));
-
-    expect(deepState.messages()).toEqual(['Hello', 'World']);
-  });
-
-  it('handles nested structured output from LLMs', () => {
-    // Simulate a structured output resource value
-    const messages = signal([
-      {
-        role: 'assistant',
-        content: {
-          result: {
-            prediction: 'positive',
-            confidence: 0.95,
-            details: {
-              categories: ['tech', 'ai'],
-              metadata: {
-                timestamp: '2024-01-01',
-                version: '1.0',
-              },
+test('handles nested structured output from LLMs', () => {
+  // Simulate a structured output resource value
+  const messages = signal([
+    {
+      role: 'assistant',
+      content: {
+        result: {
+          prediction: 'positive',
+          confidence: 0.95,
+          details: {
+            categories: ['tech', 'ai'],
+            metadata: {
+              timestamp: '2024-01-01',
+              version: '1.0',
             },
           },
         },
       },
-    ]);
+    },
+  ]);
 
-    const deepMessages = toDeepSignal(messages);
-    const lastMessage = deepMessages()[0];
+  const deepMessages = toDeepSignal(messages);
+  const lastMessage = deepMessages()[0];
 
-    expect(lastMessage.content.result.prediction).toBe('positive');
-    expect(lastMessage.content.result.confidence).toBe(0.95);
-    expect(lastMessage.content.result.details.categories).toEqual([
-      'tech',
-      'ai',
-    ]);
-    expect(lastMessage.content.result.details.metadata.timestamp).toBe(
-      '2024-01-01',
-    );
-  });
+  expect(lastMessage.content.result.prediction).toBe('positive');
+  expect(lastMessage.content.result.confidence).toBe(0.95);
+  expect(lastMessage.content.result.details.categories).toEqual(['tech', 'ai']);
+  expect(lastMessage.content.result.details.metadata.timestamp).toBe(
+    '2024-01-01',
+  );
 });

--- a/packages/angular/src/utils/deep-signal.ts
+++ b/packages/angular/src/utils/deep-signal.ts
@@ -122,14 +122,20 @@ function reconcileValue<T>(previous: T, next: T): T {
   }
 
   if (isRecord(previous) && isRecord(next)) {
-    const previousKeys = Reflect.ownKeys(previous);
-    const nextKeys = Reflect.ownKeys(next);
-    const reconciled = buildReconciledRecord(previous, next, nextKeys);
+    const previousRecord = previous as Record<PropertyKey, unknown>;
+    const nextRecord = next as Record<PropertyKey, unknown>;
+    const previousKeys = Reflect.ownKeys(previousRecord);
+    const nextKeys = Reflect.ownKeys(nextRecord);
+    const reconciled = buildReconciledRecord(
+      previousRecord,
+      nextRecord,
+      nextKeys,
+    );
 
     return previousKeys.length === nextKeys.length &&
       nextKeys.every(
         (key) =>
-          previousKeys.includes(key) && reconciled[key] === previous[key],
+          previousKeys.includes(key) && reconciled[key] === previousRecord[key],
       )
       ? previous
       : (reconciled as T);

--- a/packages/angular/src/utils/deep-signal.ts
+++ b/packages/angular/src/utils/deep-signal.ts
@@ -70,7 +70,14 @@ export type DeepSignal<T> = Signal<T> &
  * @public
  */
 export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {
-  return new Proxy(signal, {
+  let previous = untracked(signal);
+  const reconciledSignal = computed(() => {
+    const next = signal();
+    previous = reconcileValue(previous, next);
+    return previous;
+  });
+
+  return new Proxy(reconciledSignal, {
     has(target: any, prop) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return !!this.get!(target, prop, undefined);
@@ -96,6 +103,56 @@ export function toDeepSignal<T>(signal: Signal<T>): DeepSignal<T> {
       return toDeepSignal(target[prop]);
     },
   });
+}
+
+function reconcileValue<T>(previous: T, next: T): T {
+  if (Object.is(previous, next)) {
+    return previous;
+  }
+
+  if (Array.isArray(previous) && Array.isArray(next)) {
+    const reconciled = next.map((value, index) =>
+      reconcileValue(previous[index], value),
+    );
+
+    return previous.length === next.length &&
+      reconciled.every((value, index) => value === previous[index])
+      ? previous
+      : (reconciled as T);
+  }
+
+  if (isRecord(previous) && isRecord(next)) {
+    const previousKeys = Reflect.ownKeys(previous);
+    const nextKeys = Reflect.ownKeys(next);
+    const reconciled = buildReconciledRecord(previous, next, nextKeys);
+
+    return previousKeys.length === nextKeys.length &&
+      nextKeys.every(
+        (key) =>
+          previousKeys.includes(key) && reconciled[key] === previous[key],
+      )
+      ? previous
+      : (reconciled as T);
+  }
+
+  return next;
+}
+
+function buildReconciledRecord(
+  previous: Record<PropertyKey, unknown>,
+  next: Record<PropertyKey, unknown>,
+  keys: PropertyKey[],
+): Record<PropertyKey, unknown> {
+  const reconciled = Object.create(Object.getPrototypeOf(next)) as Record<
+    PropertyKey,
+    unknown
+  >;
+
+  for (const key of keys) {
+    reconciled[key] = reconcileValue(previous[key], next[key]);
+  }
+
+  return reconciled;
 }
 
 const nonRecords = [

--- a/www/analog/src/app/pages/docs/angular/concept/message-history.md
+++ b/www/analog/src/app/pages/docs/angular/concept/message-history.md
@@ -113,6 +113,18 @@ This is useful for "clear chat", "delete message", "retry from here", and "trim 
 
 ---
 
+## Order of Operations
+
+Hashbrown creates one chat instance for the resource and keeps its message history until you intentionally replace it. The `messages` option seeds the initial history only; changing the value you passed to `messages` later does not reset an active chat.
+
+Reactive options such as `model`, `system`, `apiUrl`, `threadId`, tools, and transport are applied to future requests. Updating those options does not append a message, clear history, or resend the conversation by itself.
+
+Use `sendMessage` to add a new turn, `setMessages` to replace history, and `reload` to remove the last assistant message before retrying. For completion resources, `input` is different from chat history: changing `input` synchronizes the backing single user message for the next completion.
+
+Put durable behavior and constraints in `system`. Put conversational facts, prior turns, summaries, and user-visible conversation state in message history.
+
+---
+
 ## Summarize Older Turns
 
 For long chats, keep recent messages verbatim and replace older turns with a summary. This preserves context while reducing payload size.

--- a/www/analog/src/app/pages/docs/react/concept/message-history.md
+++ b/www/analog/src/app/pages/docs/react/concept/message-history.md
@@ -104,6 +104,18 @@ This is useful for "clear chat", "delete message", "retry from here", and "trim 
 
 ---
 
+## Order of Operations
+
+Hashbrown creates one chat instance for the hook and keeps its message history until you intentionally replace it. The `messages` option seeds the initial history only; changing the value you passed to `messages` later does not reset an active chat.
+
+Runtime options such as `model`, `system`, `apiUrl`, `threadId`, tools, transport, retries, and debounce settings are applied to future requests. Updating those options does not append a message, clear history, or resend the conversation by itself.
+
+Use `sendMessage` to add a new turn, `setMessages` to replace history, and `reload` to remove the last assistant message before retrying. For completion hooks, `input` is different from chat history: changing `input` synchronizes the backing single user message for the next completion.
+
+Put durable behavior and constraints in `system`. Put conversational facts, prior turns, summaries, and user-visible conversation state in message history.
+
+---
+
 ## Summarize Older Turns
 
 For long chats, keep recent messages verbatim and replace older turns with a summary. This preserves context while reducing payload size.


### PR DESCRIPTION
## Summary

- Document how chat history, runtime option changes, and completion inputs interact in the React and Angular message history docs.
- Preserve referential equality for unchanged Angular deep-signal subtrees, including nested arrays/objects and custom class prototypes.
- Add Angular regression coverage for deep-signal identity reuse.

## Why

Changing runtime options should affect future requests without surprising users by resetting or resending chat history. Angular structured-output consumers also need stable references for unchanged streamed values, matching the identity-preservation behavior already covered in core and React paths.

Closes #111.
Closes #148.

## Test Plan

- [x] `npx nx test angular`
- [x] `npx nx build angular`
- [x] `npx nx lint angular`
- [x] `npx nx build www`
- [x] `npx nx test www`

Note: the builds still emit existing API Extractor/Vite warning noise unrelated to this change.