### PR TITLE
fix(core): recover structured output with trailing JSON

### DIFF
--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -66,6 +66,39 @@ test('parses structured output from content stream', () => {
   expect(state.message?.contentResolved).toBe(firstResolved);
 });
 
+test('recovers structured output from content before trailing JSON', () => {
+  const consoleWarn = jest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+  const responseSchema = s.object('output', {
+    ui: s.array('ui', s.object('component', {})),
+  });
+
+  try {
+    let state = startState(responseSchema, false);
+
+    state = reducer(
+      state,
+      chunkAction({
+        role: 'assistant',
+        content: '{"ui":[{}]}\n{"ui":[{}]}',
+      }),
+    );
+
+    expect(state.error).toBeUndefined();
+    expect(state.message?.contentResolved).toEqual({ ui: [{}] });
+    expect(consoleWarn).not.toHaveBeenCalled();
+
+    state = reducer(state, apiActions.generateMessageFinish());
+
+    expect(state.error).toBeUndefined();
+    expect(state.message?.contentResolved).toEqual({ ui: [{}] });
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleWarn.mockRestore();
+  }
+});
+
 test('parses Standard JSON Schema structured output when complete', () => {
   const responseSchema = {
     '~standard': {
@@ -144,6 +177,57 @@ test('streams output tool arguments like a normal tool in emulated mode', () => 
 
   expect(state.toolCalls[0]?.argumentsResolved).toEqual({ answer: 'ok' });
   expect(state.message?.contentResolved).toBeUndefined();
+});
+
+test('recovers emulated structured output arguments before trailing JSON', () => {
+  const consoleWarn = jest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+  const responseSchema = s.object('output', {
+    ui: s.array('ui', s.object('component', {})),
+  });
+  const toolsByName: Record<string, Chat.Internal.Tool> = {
+    output: {
+      name: 'output',
+      description: '',
+      schema: responseSchema,
+      handler: async () => undefined,
+    },
+  };
+
+  try {
+    let state = startState(responseSchema, true, toolsByName);
+
+    state = reducer(
+      state,
+      chunkAction({
+        role: 'assistant',
+        toolCalls: [
+          {
+            index: 0,
+            id: 'call-output',
+            type: 'function',
+            function: {
+              name: 'output',
+              arguments: '{"ui":[{}]}\n{"ui":[{}]}',
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(state.error).toBeUndefined();
+    expect(state.toolCalls[0]?.argumentsResolved).toEqual({ ui: [{}] });
+    expect(consoleWarn).not.toHaveBeenCalled();
+
+    state = reducer(state, apiActions.generateMessageFinish());
+
+    expect(state.error).toBeUndefined();
+    expect(state.toolCalls[0]?.argumentsResolved).toEqual({ ui: [{}] });
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleWarn.mockRestore();
+  }
 });
 
 test('streams hashbrown tool arguments and preserves identity when unchanged', () => {
@@ -247,6 +331,22 @@ test('non-hashbrown tool arguments resolve only when complete', () => {
   );
 
   expect(state.toolCalls[0]?.argumentsResolved).toEqual({ name: 'alice' });
+});
+
+test('does not recover malformed structured output before the root closes', () => {
+  const responseSchema = s.object('output', {
+    ui: s.array('ui', s.object('component', {})),
+  });
+
+  let state = startState(responseSchema, false);
+
+  state = reducer(
+    state,
+    chunkAction({ role: 'assistant', content: '{"ui":[{}],}' }),
+  );
+
+  expect(state.error).toBeInstanceOf(Error);
+  expect(state.message?.contentResolved).toBeUndefined();
 });
 
 test('defers parser errors until finish', () => {

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -93,22 +93,45 @@ function updateCache(
   return { ...cacheMap, [index]: cache };
 }
 
+function isRecoverableTrailingToken(parserState: ParserState) {
+  if (
+    parserState.error?.message !== 'Unexpected trailing token' ||
+    parserState.rootId === null
+  ) {
+    return false;
+  }
+
+  const rootNode = parserState.nodes[parserState.rootId];
+  return Boolean(rootNode?.closed && rootNode.resolvedValue !== undefined);
+}
+
+function getSchemaParserState(parserState: ParserState) {
+  return isRecoverableTrailingToken(parserState)
+    ? { ...parserState, error: null }
+    : parserState;
+}
+
 function resolveSchemaValue(
   schema: s.HashbrownType,
   parserState: ParserState,
   cache: s.FromJsonAstCache | undefined,
 ) {
-  const output = s.fromJsonAst(schema, parserState, cache);
+  const schemaParserState = getSchemaParserState(parserState);
+  const output = s.fromJsonAst(schema, schemaParserState, cache);
   const value =
     output.result.state === 'match'
       ? (output.result.value as JsonValue)
       : undefined;
+  const recoveredTrailingToken =
+    value !== undefined && isRecoverableTrailingToken(parserState);
   const hasError =
-    output.result.state === 'invalid' || Boolean(parserState.error);
+    output.result.state === 'invalid' ||
+    (Boolean(parserState.error) && !recoveredTrailingToken);
   return {
     cache: output.cache,
     value,
     hasError,
+    recoveredTrailingToken,
   };
 }
 
@@ -118,6 +141,34 @@ function resolveJsonValue(parserState: ParserState) {
   }
 
   return getResolvedValue(parserState);
+}
+
+function warnRecoveredTrailingToken(parsedData: JsonValue, extraData: string) {
+  console.warn(
+    'Hashbrown received extra data after a valid JSON value. The first value was used, but the extra data was ignored.',
+    {
+      parsedData,
+      extraData,
+      tips: [
+        'Add examples of exactly one valid JSON object to your prompt.',
+        'Ask the model not to emit multiple JSON values or split a response across JSON objects.',
+        'If the response is too long, ask the model to summarize while keeping one valid JSON object.',
+      ],
+    },
+  );
+}
+
+function warnRecoveredTrailingTokenFromSource(
+  parserState: ParserState,
+  parsedData: JsonValue,
+  source: string,
+) {
+  const parserError = parserState.error;
+  if (!parserError || !isRecoverableTrailingToken(parserState)) {
+    return;
+  }
+
+  warnRecoveredTrailingToken(parsedData, source.slice(parserError.index));
 }
 
 export const reducer = createReducer(
@@ -412,10 +463,6 @@ export const reducer = createReducer(
 
     if (responseSchema && outputParserState) {
       outputParserState = finalizeJsonParse(outputParserState);
-      if (outputParserState.error && !error) {
-        error = new Error('Invalid structured output');
-      }
-
       const output = resolveSchemaValue(
         responseSchema,
         outputParserState,
@@ -431,14 +478,27 @@ export const reducer = createReducer(
           contentResolved: output.value,
         };
       }
+      if (output.recoveredTrailingToken && output.value !== undefined) {
+        warnRecoveredTrailingTokenFromSource(
+          outputParserState,
+          output.value,
+          message?.content ?? '',
+        );
+      }
     }
 
     const finalizedToolStates: ParserMap = {};
     Object.entries(toolParserStateByIndex).forEach(([key, parserState]) => {
       const index = Number(key);
       const finalized = finalizeJsonParse(parserState);
+      const toolName = getToolCallName(state.rawToolCalls, index);
+      const tool = toolName ? toolsByName[toolName] : undefined;
+      const canRecoverTrailingToken =
+        tool &&
+        s.isHashbrownType(tool.schema) &&
+        isRecoverableTrailingToken(finalized);
       finalizedToolStates[index] = finalized;
-      if (finalized.error && !error) {
+      if (finalized.error && !canRecoverTrailingToken && !error) {
         error = new Error('Invalid tool arguments');
       }
     });
@@ -505,6 +565,13 @@ export const reducer = createReducer(
           );
           if (resolved.value !== undefined) {
             argumentsResolved = resolved.value;
+          }
+          if (resolved.recoveredTrailingToken && resolved.value !== undefined) {
+            warnRecoveredTrailingTokenFromSource(
+              parserState,
+              resolved.value,
+              argumentsString,
+            );
           }
           if (resolved.hasError && !error) {
             error = new Error(`Invalid tool arguments for ${name}`);


### PR DESCRIPTION
## Summary
- recover schema-valid structured output when the model emits extra JSON after the first complete root value
- apply the same recovery path to emulated structured output tool arguments
- warn once on finish with the recovered data, ignored trailing data, and prompt guidance

## Root Cause
The streaming JSON parser preserves the first completed root value after it encounters trailing data, but the reducer treated any parser error as fatal before schema resolution could use that value.

## Test Plan
- npx nx test core --testFile=packages/core/src/reducers/streaming-message.reducer.spec.ts
- npx nx test core
- npx nx lint core
- npx nx build core
- npx nx build-api-report core
- npx nx run-many -t e2e -p openai,anthropic,azure,bedrock,google,ollama,writer,react

Addresses #237
