### PR TITLE
feat(core): experimental WebLLM (@mlc-ai/web-llm) local transport

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,14 @@
   "engines": {
     "node": ">=18"
   },
+  "peerDependencies": {
+    "@mlc-ai/web-llm": "*"
+  },
+  "peerDependenciesMeta": {
+    "@mlc-ai/web-llm": {
+      "optional": true
+    }
+  },
   "keywords": [
     "hashbrown",
     "generative-ui",

--- a/packages/core/src/transport/experimental-local-transport.ts
+++ b/packages/core/src/transport/experimental-local-transport.ts
@@ -8,6 +8,11 @@ import {
   ExperimentalEdgeLocalTransport,
   type ExperimentalEdgeLocalTransportOptions,
 } from './experimental-edge-local-transport';
+import {
+  detectWebLlmSupport,
+  ExperimentalWebLlmLocalTransport,
+  type ExperimentalWebLlmLocalTransportOptions,
+} from './experimental-webllm-local-transport';
 import { type DetectionResult, type ModelSpecFactory } from './model-spec';
 import {
   type Transport,
@@ -21,7 +26,10 @@ import { TransportError } from './transport-error';
  * Supported local prompt adapters.
  * @alpha
  */
-export type LocalPromptAdapterName = 'chrome-local' | 'edge-local';
+export type LocalPromptAdapterName =
+  | 'chrome-local'
+  | 'edge-local'
+  | 'webllm-local';
 
 type ExperimentalLocalTransportEvents =
   ExperimentalChromeLocalTransportOptions['events'];
@@ -33,6 +41,12 @@ type ExperimentalLocalTransportEvents =
 export interface ExperimentalLocalTransportOptions {
   chrome?: ExperimentalChromeLocalTransportOptions;
   edge?: ExperimentalEdgeLocalTransportOptions;
+  /**
+   * WebLLM (`@mlc-ai/web-llm`, WebGPU) adapter options. WebLLM is NOT in the
+   * default selection order because it can trigger a multi-GB model download;
+   * opt in explicitly via `order: ['webllm-local', ...]`.
+   */
+  webllm?: ExperimentalWebLlmLocalTransportOptions;
   events?: ExperimentalLocalTransportEvents;
   order?: LocalPromptAdapterName[];
 }
@@ -188,6 +202,9 @@ function createAdapters(
       if (name === 'edge-local') {
         return createEdgeAdapter(options);
       }
+      if (name === 'webllm-local') {
+        return createWebLlmAdapter(options);
+      }
       return undefined;
     })
     .filter(Boolean) as LocalPromptAdapter[];
@@ -268,6 +285,19 @@ function createEdgeAdapter(
   };
 }
 
+function createWebLlmAdapter(
+  options: ExperimentalLocalTransportOptions,
+): LocalPromptAdapter {
+  const transport = new ExperimentalWebLlmLocalTransport(options.webllm ?? {});
+
+  return {
+    name: 'webllm-local',
+    detect: () => detectWebLlmSupport(),
+    send: (request) => transport.send(request),
+    teardown: () => transport.destroy?.(),
+  };
+}
+
 function mergeEvents(
   shared?: ExperimentalLocalTransportEvents,
   scoped?: ExperimentalLocalTransportEvents,
@@ -295,6 +325,7 @@ function filterLocalOptions(
     events: candidate.events,
     chrome: candidate.chrome,
     edge: candidate.edge,
+    webllm: candidate.webllm,
     order: candidate.order,
   };
 }

--- a/packages/core/src/transport/experimental-webllm-local-transport.spec.ts
+++ b/packages/core/src/transport/experimental-webllm-local-transport.spec.ts
@@ -1,0 +1,177 @@
+import {
+  detectWebLlmSupport,
+  experimental_webllm,
+  ExperimentalWebLlmLocalTransport,
+  type WebLlmCompletionChunk,
+  type WebLlmEngine,
+} from './experimental-webllm-local-transport';
+import { Chat } from '../models';
+import { Frame } from '../frames';
+
+const params: Chat.Api.CompletionCreateParams = {
+  operation: 'generate',
+  model: '' as Chat.Api.CompletionCreateParams['model'],
+  system: 'system',
+  messages: [{ role: 'user', content: 'Hello' }],
+};
+
+function request(signal = new AbortController().signal) {
+  return { params, signal, attempt: 1, maxAttempts: 1, requestId: 'test' };
+}
+
+async function* chunksOf(...contents: string[]): AsyncIterable<WebLlmCompletionChunk> {
+  for (const content of contents) {
+    yield { choices: [{ delta: { role: 'assistant', content }, finish_reason: null }] };
+  }
+}
+
+function fakeEngine(
+  stream: AsyncIterable<WebLlmCompletionChunk>,
+  overrides: Partial<WebLlmEngine> = {},
+): WebLlmEngine & { create: jest.Mock } {
+  const create = jest.fn().mockResolvedValue(stream);
+  return {
+    chat: { completions: { create } },
+    interruptGenerate: jest.fn(),
+    unload: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+    create,
+  } as unknown as WebLlmEngine & { create: jest.Mock };
+}
+
+async function collect(frames: AsyncGenerator<Frame> | undefined): Promise<Frame[]> {
+  const out: Frame[] = [];
+  if (frames) {
+    for await (const frame of frames) out.push(frame);
+  }
+  return out;
+}
+
+test('streams generation-chunk frames then generation-finish from the engine', async () => {
+  const engine = fakeEngine(chunksOf('Hello', ' world'));
+  const transport = new ExperimentalWebLlmLocalTransport({ engine });
+
+  const response = await transport.send(request());
+  const frames = await collect(response.frames);
+
+  expect(engine.create).toHaveBeenCalledTimes(1);
+  const chunkFrames = frames.filter((f) => f.type === 'generation-chunk');
+  expect(chunkFrames).toHaveLength(2);
+  expect(frames.at(-1)?.type).toBe('generation-finish');
+  const first = chunkFrames[0] as Extract<Frame, { type: 'generation-chunk' }>;
+  expect(first.chunk.choices[0].delta.content).toBe('Hello');
+});
+
+test('forwards system + user messages and responseFormat as response_format', async () => {
+  const engine = fakeEngine(chunksOf('ok'));
+  const transport = new ExperimentalWebLlmLocalTransport({ engine });
+
+  await collect(
+    (
+      await transport.send({
+        ...request(),
+        params: { ...params, responseFormat: { title: { type: 'string' } } },
+      })
+    ).frames,
+  );
+
+  const callArgs = engine.create.mock.calls[0][0];
+  expect(callArgs.stream).toBe(true);
+  expect(callArgs.messages[0]).toEqual({ role: 'system', content: 'system' });
+  expect(callArgs.messages[1]).toEqual({ role: 'user', content: 'Hello' });
+  // Bare JSON schema gets wrapped into an OpenAI-compatible json_schema format.
+  expect(callArgs.response_format.type).toBe('json_schema');
+});
+
+test('aborts mid-stream with a WEBLLM_ABORTED TransportError', async () => {
+  const controller = new AbortController();
+  const engine = fakeEngine(
+    (async function* () {
+      yield { choices: [{ delta: { content: 'partial' }, finish_reason: null }] };
+      controller.abort();
+      yield { choices: [{ delta: { content: 'never' }, finish_reason: null }] };
+    })(),
+  );
+  const transport = new ExperimentalWebLlmLocalTransport({ engine });
+  const response = await transport.send(request(controller.signal));
+
+  await expect(collect(response.frames)).rejects.toMatchObject({
+    code: 'WEBLLM_ABORTED',
+  });
+  expect(engine.interruptGenerate).toHaveBeenCalled();
+});
+
+test('surfaces engine errors as a TransportError', async () => {
+  const create = jest.fn().mockRejectedValue(new Error('webgpu exploded'));
+  const engine = { chat: { completions: { create } } } as unknown as WebLlmEngine;
+  const transport = new ExperimentalWebLlmLocalTransport({ engine });
+
+  await expect(collect((await transport.send(request())).frames)).rejects.toMatchObject({
+    code: 'WEBLLM_ENGINE_ERROR',
+  });
+});
+
+test('uses an injected createEngine and reports download progress + state', async () => {
+  const states: string[] = [];
+  const progress: number[] = [];
+  const createEngine = jest.fn(async (_model, opts) => {
+    opts.initProgressCallback?.({ progress: 0.5, text: 'loading' });
+    return fakeEngine(chunksOf('hi'));
+  });
+  const transport = new ExperimentalWebLlmLocalTransport({
+    model: 'Custom-Model-MLC',
+    createEngine,
+    events: {
+      engineState: (s) => states.push(s),
+      downloadProgress: (p) => progress.push(p),
+    },
+  });
+
+  await collect((await transport.send(request())).frames);
+
+  expect(createEngine).toHaveBeenCalledWith('Custom-Model-MLC', expect.any(Object));
+  expect(states).toContain('loading');
+  expect(states).toContain('ready');
+  expect(progress).toContain(50);
+});
+
+describe('detectWebLlmSupport', () => {
+  const originalNavigator = globalThis.navigator;
+  const originalWindow = (globalThis as { window?: unknown }).window;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  test('ok when WebGPU is present', async () => {
+    (globalThis as { window?: unknown }).window = {};
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { gpu: {} },
+      configurable: true,
+    });
+    await expect(detectWebLlmSupport()).resolves.toEqual({ ok: true });
+  });
+
+  test('PLATFORM_UNSUPPORTED when WebGPU is absent', async () => {
+    (globalThis as { window?: unknown }).window = {};
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {},
+      configurable: true,
+    });
+    await expect(detectWebLlmSupport()).resolves.toMatchObject({
+      ok: false,
+      code: 'PLATFORM_UNSUPPORTED',
+    });
+  });
+});
+
+test('experimental_webllm model spec advertises ui + structured, not tools', () => {
+  const spec = experimental_webllm()({});
+  expect(spec.name).toBe('webllm-local');
+  expect(spec.capabilities).toMatchObject({ ui: true, structured: true, tools: false });
+  expect(typeof spec.detect).toBe('function');
+});

--- a/packages/core/src/transport/experimental-webllm-local-transport.ts
+++ b/packages/core/src/transport/experimental-webllm-local-transport.ts
@@ -1,0 +1,451 @@
+import { Frame } from '../frames';
+import {
+  type Transport,
+  type TransportFactory,
+  type TransportRequest,
+  type TransportResponse,
+} from './transport';
+import { type DetectionResult, type ModelSpecFactory } from './model-spec';
+import { TransportError } from './transport-error';
+
+const WEBLLM_SOURCE = 'web-llm';
+
+/**
+ * Default MLC model id. A small, fast, instruction-tuned model that fits the
+ * generative-UI / structured-output use case on consumer GPUs. Override via
+ * {@link ExperimentalWebLlmLocalTransportOptions.model}.
+ * @alpha
+ */
+export const DEFAULT_WEBLLM_MODEL = 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC';
+
+/**
+ * Message shape sent to the WebLLM engine (OpenAI chat-completions compatible).
+ * @alpha
+ */
+export interface WebLlmChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Structured-output / generative-UI constraint forwarded as `response_format`.
+ * @alpha
+ */
+export interface WebLlmResponseFormat {
+  type: 'json_object' | 'json_schema' | 'text' | (string & {});
+  [key: string]: unknown;
+}
+
+/**
+ * One streamed chunk from `engine.chat.completions.create({ stream: true })`.
+ * @alpha
+ */
+export interface WebLlmCompletionChunk {
+  choices?: Array<{
+    delta?: { role?: string; content?: string | null };
+    finish_reason?: string | null;
+  }>;
+}
+
+/**
+ * The subset of the `@mlc-ai/web-llm` MLCEngine this transport depends on.
+ * Kept structural so `@hashbrownai/core` never hard-depends on the (heavy,
+ * WebGPU) web-llm package — apps provide the engine, or it is dynamically
+ * imported at runtime.
+ * @alpha
+ */
+export interface WebLlmEngine {
+  chat: {
+    completions: {
+      create(params: {
+        stream: true;
+        messages: WebLlmChatMessage[];
+        response_format?: WebLlmResponseFormat;
+        temperature?: number;
+      }): Promise<AsyncIterable<WebLlmCompletionChunk>>;
+    };
+  };
+  interruptGenerate?: () => void;
+  unload?: () => Promise<void>;
+}
+
+/**
+ * Progress report emitted while the model weights download / initialize.
+ * @alpha
+ */
+export interface WebLlmInitProgressReport {
+  progress: number;
+  text?: string;
+  timeElapsed?: number;
+}
+
+/**
+ * Factory that creates an MLC engine — matches `@mlc-ai/web-llm`'s
+ * `CreateMLCEngine(model, { initProgressCallback })`.
+ * @alpha
+ */
+export type CreateWebLlmEngine = (
+  model: string,
+  options: {
+    initProgressCallback?: (report: WebLlmInitProgressReport) => void;
+  },
+) => Promise<WebLlmEngine>;
+
+/**
+ * Request produced by {@link ExperimentalWebLlmLocalTransportOptions.transformRequest}.
+ * @alpha
+ */
+export interface WebLlmRequest {
+  messages: WebLlmChatMessage[];
+  responseFormat?: WebLlmResponseFormat;
+  temperature?: number;
+}
+
+/**
+ * Configuration for the experimental WebLLM local transport.
+ * @alpha
+ */
+export interface ExperimentalWebLlmLocalTransportOptions {
+  /** MLC model id to load. Defaults to {@link DEFAULT_WEBLLM_MODEL}. */
+  model?: string;
+  /**
+   * A pre-created engine. Wins over {@link createEngine}. Useful for sharing
+   * one loaded model across transports, and for tests.
+   */
+  engine?: WebLlmEngine;
+  /**
+   * Engine factory. Defaults to dynamically importing `@mlc-ai/web-llm` and
+   * calling `CreateMLCEngine`. Provide your own to preconfigure the engine
+   * (app config, worker engine, cached weights, ...).
+   */
+  createEngine?: CreateWebLlmEngine;
+  /** Map a Hashbrown request into the WebLLM call. Defaults to a faithful passthrough. */
+  transformRequest?: (request: TransportRequest) => WebLlmRequest;
+  /** Sampling temperature forwarded to the engine when the request omits one. */
+  temperature?: number;
+  events?: {
+    /** Weight download / init progress, 0–100. */
+    downloadProgress?: (percent: number) => void;
+    /** Coarse engine lifecycle signal. */
+    engineState?: (state: 'loading' | 'ready' | 'error' | 'destroyed') => void;
+  };
+}
+
+/**
+ * Experimental transport that runs generation fully in the browser via
+ * `@mlc-ai/web-llm` (WebGPU). Mirrors the Chrome/Edge local transports: it
+ * implements {@link Transport} and returns a `frames` async-generator, so it
+ * round-trips through the exact same frame protocol as the HTTP transports.
+ *
+ * Unlike the Chrome Prompt API, WebLLM exposes an OpenAI-compatible surface,
+ * so `responseFormat` (structured output / generative UI) is forwarded as
+ * `response_format` and tool schemas can be layered on later.
+ * @alpha
+ */
+export class ExperimentalWebLlmLocalTransport implements Transport {
+  readonly name = 'ExperimentalWebLlmLocalTransport';
+  private enginePromise?: Promise<WebLlmEngine>;
+
+  constructor(
+    private readonly options: ExperimentalWebLlmLocalTransportOptions = {},
+  ) {}
+
+  async send(request: TransportRequest): Promise<TransportResponse> {
+    const transformRequest =
+      this.options.transformRequest ?? defaultTransformRequest;
+    const webllmRequest = transformRequest(request);
+
+    const engine = await this.getEngine();
+    const frames = this.createFrameGenerator(engine, webllmRequest, request);
+
+    return {
+      frames,
+      metadata: {
+        source: WEBLLM_SOURCE,
+        model: this.options.model ?? DEFAULT_WEBLLM_MODEL,
+        promptMode: 'chatCompletionsStream',
+      },
+      dispose: async () => {
+        try {
+          await engine.unload?.();
+          this.options.events?.engineState?.('destroyed');
+        } finally {
+          this.enginePromise = undefined;
+        }
+      },
+    };
+  }
+
+  async destroy() {
+    const engine = await this.enginePromise?.catch(() => undefined);
+    try {
+      await engine?.unload?.();
+    } finally {
+      this.enginePromise = undefined;
+    }
+  }
+
+  private getEngine(): Promise<WebLlmEngine> {
+    if (this.options.engine) {
+      return Promise.resolve(this.options.engine);
+    }
+    if (this.enginePromise) {
+      return this.enginePromise;
+    }
+
+    const model = this.options.model ?? DEFAULT_WEBLLM_MODEL;
+    const create = this.options.createEngine ?? defaultCreateEngine;
+
+    this.options.events?.engineState?.('loading');
+    this.enginePromise = create(model, {
+      initProgressCallback: (report) => {
+        const percent = Math.round((report.progress ?? 0) * 100);
+        this.options.events?.downloadProgress?.(percent);
+      },
+    })
+      .then((engine) => {
+        this.options.events?.engineState?.('ready');
+        return engine;
+      })
+      .catch((err) => {
+        this.options.events?.engineState?.('error');
+        this.enginePromise = undefined;
+        throw asTransportError(err);
+      });
+
+    return this.enginePromise;
+  }
+
+  private async *createFrameGenerator(
+    engine: WebLlmEngine,
+    webllmRequest: WebLlmRequest,
+    request: TransportRequest,
+  ): AsyncGenerator<Frame> {
+    let stream: AsyncIterable<WebLlmCompletionChunk>;
+    try {
+      stream = await engine.chat.completions.create({
+        stream: true,
+        messages: webllmRequest.messages,
+        response_format: webllmRequest.responseFormat,
+        temperature: webllmRequest.temperature ?? this.options.temperature,
+      });
+    } catch (err) {
+      throw asTransportError(err);
+    }
+
+    try {
+      for await (const chunk of stream) {
+        if (request.signal.aborted) {
+          engine.interruptGenerate?.();
+          throw new TransportError('WebLLM generation aborted', {
+            retryable: false,
+            code: 'WEBLLM_ABORTED',
+          });
+        }
+        const content = chunk.choices?.[0]?.delta?.content;
+        if (typeof content === 'string' && content.length > 0) {
+          yield createChunkFrame(content);
+        }
+      }
+      yield { type: 'generation-finish' };
+    } catch (err) {
+      if (err instanceof TransportError) {
+        throw err;
+      }
+      throw asTransportError(err);
+    }
+  }
+}
+
+/**
+ * Factory for the experimental WebLLM local transport.
+ * @alpha
+ */
+export function createExperimentalWebLlmLocalTransport(
+  options: ExperimentalWebLlmLocalTransportOptions = {},
+): TransportFactory {
+  return () => new ExperimentalWebLlmLocalTransport(options);
+}
+
+/**
+ * Detects whether WebLLM can run — i.e. a browser context exposing WebGPU
+ * (`navigator.gpu`). Cheap and synchronous-ish; no model download.
+ * @alpha
+ */
+export async function detectWebLlmSupport(): Promise<DetectionResult> {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return {
+      ok: false,
+      code: 'PLATFORM_UNSUPPORTED',
+      reason: 'WebLLM requires a browser context.',
+    };
+  }
+  const gpu = (navigator as Navigator & { gpu?: unknown }).gpu;
+  if (!gpu) {
+    return {
+      ok: false,
+      code: 'PLATFORM_UNSUPPORTED',
+      reason: 'WebGPU (navigator.gpu) is unavailable in this browser.',
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Model spec factory for the WebLLM transport. Drop it into a `model: [...]`
+ * fallback array exactly like `experimental_chrome` / `experimental_edge`.
+ *
+ * ```ts
+ * chatResource({
+ *   system: '...',
+ *   model: [experimental_webllm(), experimental_chrome(), 'gpt-4.1'],
+ * });
+ * ```
+ * @alpha
+ */
+export function experimentalWebLlmLocalModelSpec(
+  userOptions: ExperimentalWebLlmLocalTransportOptions = {},
+): ModelSpecFactory {
+  return (inject) => {
+    const mergedOptions: ExperimentalWebLlmLocalTransportOptions = {
+      ...filterWebLlmOptions(inject),
+      ...userOptions,
+    };
+
+    return {
+      name: 'webllm-local',
+      capabilities: {
+        tools: false,
+        structured: true,
+        ui: true,
+        threads: false,
+      },
+      detect: detectWebLlmSupport,
+      transport: () => new ExperimentalWebLlmLocalTransport(mergedOptions),
+    };
+  };
+}
+
+/**
+ * Preferred snake_case helper, consistent with `experimental_chrome` /
+ * `experimental_edge`.
+ * @alpha
+ */
+export const experimental_webllm = experimentalWebLlmLocalModelSpec;
+
+function filterWebLlmOptions(
+  config?: Record<string, unknown>,
+): Partial<ExperimentalWebLlmLocalTransportOptions> {
+  if (!config) {
+    return {};
+  }
+  const candidate =
+    config as unknown as Partial<ExperimentalWebLlmLocalTransportOptions>;
+  return {
+    model: candidate.model,
+    engine: candidate.engine,
+    createEngine: candidate.createEngine,
+    transformRequest: candidate.transformRequest,
+    temperature: candidate.temperature,
+    events: candidate.events,
+  };
+}
+
+function defaultTransformRequest({ params }: TransportRequest): WebLlmRequest {
+  const messages: WebLlmChatMessage[] = [];
+  if (params.system) {
+    messages.push({ role: 'system', content: params.system });
+  }
+  for (const message of params.messages) {
+    if (message.role === 'tool' || message.role === 'error') {
+      continue;
+    }
+    const content =
+      typeof message.content === 'string'
+        ? message.content
+        : JSON.stringify(message.content ?? '');
+    const role = message.role === 'assistant' ? 'assistant' : 'user';
+    messages.push({ role, content });
+  }
+
+  const request: WebLlmRequest = { messages };
+  if (params.responseFormat) {
+    request.responseFormat = toResponseFormat(params.responseFormat);
+  }
+  return request;
+}
+
+/**
+ * Hashbrown carries the structured-output schema as a plain JSON Schema object
+ * on `responseFormat`. WebLLM (OpenAI-compatible) wants
+ * `{ type: 'json_object' | 'json_schema', ... }`. Wrap accordingly.
+ */
+function toResponseFormat(responseFormat: object): WebLlmResponseFormat {
+  if (
+    typeof responseFormat === 'object' &&
+    responseFormat !== null &&
+    'type' in responseFormat
+  ) {
+    return responseFormat as WebLlmResponseFormat;
+  }
+  return {
+    type: 'json_schema',
+    json_schema: { name: 'hashbrown_response', schema: responseFormat },
+  };
+}
+
+async function defaultCreateEngine(
+  model: string,
+  options: { initProgressCallback?: (report: WebLlmInitProgressReport) => void },
+): Promise<WebLlmEngine> {
+  // Non-literal specifier so `@hashbrownai/core` does not statically depend on
+  // the (heavy, WebGPU) web-llm package. Apps that use this transport install
+  // `@mlc-ai/web-llm` themselves (declared as an optional peer dependency).
+  const specifier = '@mlc-ai/web-llm';
+  let mod: { CreateMLCEngine?: CreateWebLlmEngine };
+  try {
+    mod = (await import(/* @vite-ignore */ /* webpackIgnore: true */ specifier)) as {
+      CreateMLCEngine?: CreateWebLlmEngine;
+    };
+  } catch {
+    throw new TransportError(
+      'The WebLLM transport requires the "@mlc-ai/web-llm" package. Install it in your app: npm i @mlc-ai/web-llm',
+      { retryable: false, code: 'PLATFORM_UNSUPPORTED' },
+    );
+  }
+  if (typeof mod.CreateMLCEngine !== 'function') {
+    throw new TransportError(
+      '"@mlc-ai/web-llm" did not export CreateMLCEngine.',
+      { retryable: false, code: 'PLATFORM_UNSUPPORTED' },
+    );
+  }
+  return mod.CreateMLCEngine(model, options);
+}
+
+function asTransportError(err: unknown): TransportError {
+  if (err instanceof TransportError) {
+    return err;
+  }
+  return new TransportError(
+    err instanceof Error ? err.message : 'WebLLM transport failure',
+    { retryable: false, code: 'WEBLLM_ENGINE_ERROR' },
+  );
+}
+
+function createChunkFrame(content: string): Frame {
+  return {
+    type: 'generation-chunk',
+    chunk: {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            content,
+          },
+          finishReason: null,
+        },
+      ],
+    },
+  };
+}

--- a/packages/core/src/transport/index.ts
+++ b/packages/core/src/transport/index.ts
@@ -33,6 +33,22 @@ export {
   type ExperimentalEdgeLocalTransportOptions,
 } from './experimental-edge-local-transport';
 export {
+  ExperimentalWebLlmLocalTransport,
+  createExperimentalWebLlmLocalTransport,
+  detectWebLlmSupport,
+  experimentalWebLlmLocalModelSpec,
+  experimental_webllm,
+  DEFAULT_WEBLLM_MODEL,
+  type ExperimentalWebLlmLocalTransportOptions,
+  type WebLlmEngine,
+  type WebLlmChatMessage,
+  type WebLlmRequest,
+  type WebLlmResponseFormat,
+  type WebLlmCompletionChunk,
+  type WebLlmInitProgressReport,
+  type CreateWebLlmEngine,
+} from './experimental-webllm-local-transport';
+export {
   createDelegatingTransport,
   experimental_local,
   type LocalPromptAdapter,


### PR DESCRIPTION
## What

Adds a fully **in-browser, WebGPU** generation transport to `@hashbrownai/core`, alongside the existing experimental Chrome/Edge local transports. It runs open models on-device via [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm) — no server, no API key, private/offline.

Unlike the Chrome Prompt API, WebLLM exposes an **OpenAI-compatible** surface, so `responseFormat` (structured output / **generative UI**) is forwarded as `response_format` — making on-device generative UI viable.

## API

Drops into a `model: [...]` fallback array exactly like `experimental_chrome` / `experimental_edge`:

```ts
import { experimental_webllm, experimental_chrome } from '@hashbrownai/core';

chatResource({
  system: '…',
  // try on-device WebLLM first, then Chrome Prompt API, then a hosted model
  model: [experimental_webllm({ model: 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC' }), experimental_chrome(), 'gpt-4.1'],
});
```

Also registered as an **opt-in** `'webllm-local'` adapter in the `experimental_local` delegator — deliberately **not** in the default selection order, so it never triggers a surprise multi-GB model download.

## Design notes

- **No hard dependency on `@mlc-ai/web-llm`.** `@hashbrownai/core` stays lean: the engine is described by structural types, provided via an injectable `engine`/`createEngine`, or dynamically imported at runtime (non-literal specifier). Declared as an **optional `peerDependency`**. Apps that use the transport install web-llm themselves.
- Implements `Transport`, returns a `frames` async-generator (`generation-chunk` … `generation-finish`) — round-trips through the same frame protocol as the HTTP transports.
- Honors `AbortSignal` via `interruptGenerate`; maps engine/abort failures to `TransportError` (`WEBLLM_ENGINE_ERROR` / `WEBLLM_ABORTED`).
- Surfaces model-download progress and engine lifecycle via `events`.
- Capabilities: `structured` + `ui` (no `tools` yet — a follow-up can layer tool-calling on WebLLM's function-calling support).

## Tests

8 unit tests with a mock MLC engine (streaming frames, message + `responseFormat` mapping, mid-stream abort, engine-error, progress/lifecycle events, WebGPU detection, model-spec capabilities). **Full `core` suite green (368 tests), `nx build core` green, lint clean** on the new files.

> Note: end-to-end on-device inference needs a WebGPU browser + model download, so it isn't exercised in CI here — the transport logic is covered via the injected-engine tests, matching how the Chrome/Edge locals are unit-tested.

## Scope

`packages/core/src/transport/` only — one new transport + spec, an export line, opt-in delegator registration, and the optional peer-dep declaration. No changes to existing transport behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhULz1TfLAQReBSR9hwsmf