### PR TITLE
fix(sample): wrap smart home react chat errors

### DIFF
--- a/samples/smart-home/react/src/app/shared/Message.tsx
+++ b/samples/smart-home/react/src/app/shared/Message.tsx
@@ -1,11 +1,13 @@
-import { Chat } from '@hashbrownai/react';
+import { Chat } from '@hashbrownai/core';
 
-export const Message = ({ message }: { message: Chat.Message }) => {
+export const Message = ({
+  message,
+}: {
+  message: Chat.Message<string, Chat.AnyTool>;
+}) => {
   const isAssistant = message.role === 'assistant';
-  const isSystem = message.role === 'system';
-  const isTool = message.role === 'tool';
 
-  if (isSystem || isTool || (isAssistant && !message.content)) {
+  if (isAssistant && !message.content) {
     return;
   }
 

--- a/samples/smart-home/react/src/app/shared/RichMessage.spec.tsx
+++ b/samples/smart-home/react/src/app/shared/RichMessage.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { RichMessage } from './RichMessage';
+
+test('wraps long error messages inside a shrinkable text container', () => {
+  const message = {
+    role: 'error' as const,
+    content: `Request failed: ${'x'.repeat(200)}`,
+  };
+
+  render(
+    <RichMessage message={message} onRetry={() => undefined} isLast={true} />,
+  );
+
+  const errorText = screen.getByText(message.content);
+
+  expect(errorText.className).toContain('min-w-0');
+  expect(errorText.className).toContain('break-words');
+  expect(errorText.className).toContain('whitespace-pre-wrap');
+});

--- a/samples/smart-home/react/src/app/shared/RichMessage.tsx
+++ b/samples/smart-home/react/src/app/shared/RichMessage.tsx
@@ -1,3 +1,4 @@
+import { Chat } from '@hashbrownai/core';
 import { UiChatMessage } from '@hashbrownai/react';
 import { Button } from './button';
 import { CircleAlert } from 'lucide-react';
@@ -7,7 +8,7 @@ export const RichMessage = ({
   onRetry,
   isLast,
 }: {
-  message: UiChatMessage<any>;
+  message: UiChatMessage<Chat.AnyTool>;
   onRetry: () => void;
   isLast: boolean;
 }) => {
@@ -32,14 +33,16 @@ export const RichMessage = ({
 
   return (
     <div className={`flex w-full ${onLeft ? 'justify-start' : 'justify-end'}`}>
-      <div className={`p-2 rounded-md ${classNames}`}>
+      <div className={`min-w-0 max-w-full p-2 rounded-md ${classNames}`}>
         {message.role === 'error' && (
-          <div className="flex flex-row items-center gap-2">
-            <CircleAlert />
-            {message.content}
+          <div className="flex min-w-0 flex-row items-start gap-2">
+            <CircleAlert className="mt-0.5 shrink-0" />
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+              {message.content}
+            </span>
             {isLast && (
               <Button
-                className="!pt-0 !pb-0 h-auto"
+                className="!pt-0 !pb-0 h-auto shrink-0"
                 variant="ghost"
                 onClick={onRetry}
               >
@@ -54,7 +57,11 @@ export const RichMessage = ({
         )}
 
         {message.role === 'user' && (
-          <div className="flex flex-col gap-2">{message.content}</div>
+          <div className="flex flex-col gap-2">
+            {typeof message.content === 'string'
+              ? message.content
+              : JSON.stringify(message.content)}
+          </div>
         )}
       </div>
     </div>

--- a/samples/smart-home/react/src/app/shared/utils.ts
+++ b/samples/smart-home/react/src/app/shared/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/samples/smart-home/react/src/app/views/ScheduledScenesView.tsx
+++ b/samples/smart-home/react/src/app/views/ScheduledScenesView.tsx
@@ -26,7 +26,6 @@ export const ScheduledScenesView = () => {
           <ScheduledScene
             key={scheduledScene.id}
             scheduledScene={scheduledScene}
-            onEdit={() => {}}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Wrap long smart-home React chat error messages in a shrinkable text container
- Keep the alert icon and retry button from shrinking while preserving message wrapping
- Add a regression test for long error message wrapping
- Clean up sample type/lint blockers surfaced by verification

Fixes #204

## Verification
- CI=true npx nx test smart-home-react
- npx nx typecheck smart-home-react
- npx nx eslint:lint smart-home-react
- npx nx build smart-home-react