### PR TITLE
test(core): cover CJK streaming output

### DIFF
--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -66,6 +66,33 @@ test('parses structured output from content stream', () => {
   expect(state.message?.contentResolved).toBe(firstResolved);
 });
 
+test('streams Japanese and Chinese structured output from content chunks', () => {
+  const responseSchema = s.object('output', {
+    message: s.streaming.string('message'),
+  });
+
+  let state = startState(responseSchema, false);
+
+  state = reducer(
+    state,
+    chunkAction({ role: 'assistant', content: '{"message":"こん' }),
+  );
+
+  expect(state.message?.contentResolved).toEqual({ message: 'こん' });
+
+  state = reducer(state, chunkAction({ content: 'にちは、你' }));
+
+  expect(state.message?.contentResolved).toEqual({
+    message: 'こんにちは、你',
+  });
+
+  state = reducer(state, chunkAction({ content: '好"}' }));
+
+  expect(state.message?.contentResolved).toEqual({
+    message: 'こんにちは、你好',
+  });
+});
+
 test('recovers structured output from content before trailing JSON', () => {
   const consoleWarn = jest
     .spyOn(console, 'warn')

--- a/packages/core/src/skillet/parser/json-parser.spec.ts
+++ b/packages/core/src/skillet/parser/json-parser.spec.ts
@@ -79,6 +79,32 @@ test('parses across chunk boundaries with unicode escapes and arrays', () => {
   });
 });
 
+test('parses Japanese and Chinese string values across chunks', () => {
+  const state = createParserState();
+
+  const next = parseChunk(state, '{"ja":"こん');
+  const root = getNode(next.nodes, next.rootId);
+
+  expect(next.error).toBeNull();
+  expect(root.resolvedValue).toEqual({ ja: 'こん' });
+
+  const next2 = parseChunk(next, 'にちは","zh":"你');
+  const root2 = getNode(next2.nodes, next2.rootId);
+
+  expect(next2.error).toBeNull();
+  expect(root2.resolvedValue).toEqual({ ja: 'こんにちは', zh: '你' });
+
+  const next3 = parseChunk(next2, '好，世界"}');
+  const done = finalizeJsonParse(next3);
+
+  expect(done.error).toBeNull();
+  expect(done.isComplete).toBe(true);
+  expect(getResolvedValue(done)).toEqual({
+    ja: 'こんにちは',
+    zh: '你好，世界',
+  });
+});
+
 test('parses a string with an escape split across chunks', () => {
   const state = createParserState();
 

--- a/packages/core/src/transport/frames-to-length-prefixed-stream.spec.ts
+++ b/packages/core/src/transport/frames-to-length-prefixed-stream.spec.ts
@@ -1,6 +1,6 @@
 import { framesToLengthPrefixedStream } from './frames-to-length-prefixed-stream';
 import { decodeFrames } from '../frames/decode-frames';
-import { Frame } from '../frames';
+import { encodeFrame, Frame } from '../frames';
 
 test('appends a finish frame when generator completes', async () => {
   const frames = async function* (): AsyncGenerator<Frame> {
@@ -52,4 +52,41 @@ test('propagates generator errors', async () => {
       expect(frame).toBeDefined();
     }
   }).rejects.toThrow('boom');
+});
+
+test('decodes Japanese and Chinese frame content when UTF-8 bytes are split', async () => {
+  const frame: Frame = {
+    type: 'generation-chunk',
+    chunk: {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            content: 'こんにちは、你好',
+          },
+          finishReason: null,
+        },
+      ],
+    },
+  };
+  const encoded = encodeFrame(frame);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const byte of encoded) {
+        controller.enqueue(Uint8Array.of(byte));
+      }
+      controller.close();
+    },
+  });
+  const abortController = new AbortController();
+  const decoded: Frame[] = [];
+
+  for await (const decodedFrame of decodeFrames(stream, {
+    signal: abortController.signal,
+  })) {
+    decoded.push(decodedFrame);
+  }
+
+  expect(decoded).toEqual([frame]);
 });


### PR DESCRIPTION
## Summary
- Add parser coverage for Japanese and Chinese string values streamed across chunks
- Add reducer coverage for structured output resolving CJK text incrementally
- Add frame decoder coverage for CJK content when UTF-8 bytes are split one byte at a time

Current main already handles the reported behavior; this PR captures that as regression coverage.

Closes #87

## Verification
- npx nx test core --testFile=packages/core/src/skillet/parser/json-parser.spec.ts
- npx nx test core --testFile=packages/core/src/reducers/streaming-message.reducer.spec.ts
- npx nx test core --testFile=packages/core/src/transport/frames-to-length-prefixed-stream.spec.ts
- npx nx test core
- npx nx lint core
- npx nx build core
- npx nx build-api-report core