### PR TITLE
docs: refresh homepage for v0.5

### DIFF
--- a/www/analog/src/app/components/Announcement.ts
+++ b/www/analog/src/app/components/Announcement.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { Squircle } from './Squircle';
 import { RouterLink } from '@angular/router';
+import { ConfigService } from '../services/ConfigService';
 
 @Component({
   selector: 'www-announcement',
@@ -8,9 +9,9 @@ import { RouterLink } from '@angular/router';
   template: `
     @if (showAnnouncement) {
       <div class="alert" wwwSquircle="0 0 8 8">
-        <a routerLink="/blog/2025-12-16-hashbrown-v-0-4-0">
-          <strong>New!</strong> Hashbrown v0.4 brings Magic Text, local models,
-          and new adapters
+        <a [routerLink]="uiKitsDocsUrl()">
+          <strong>New!</strong> Hashbrown v0.5 brings UI Kits, a streaming JSON
+          parser, and structured outputs
         </a>
         <button
           class="close"
@@ -135,7 +136,11 @@ import { RouterLink } from '@angular/router';
   `,
 })
 export class Announcement {
-  currentAnnouncementDate = new Date('2025-12-15');
+  private configService = inject(ConfigService);
+  uiKitsDocsUrl = computed(
+    () => `/docs/${this.configService.sdk()}/recipes/ui-kits`,
+  );
+  currentAnnouncementDate = new Date('2026-07-09');
   showAnnouncement = false;
 
   constructor() {

--- a/www/analog/src/app/components/home/Feature.ts
+++ b/www/analog/src/app/components/home/Feature.ts
@@ -18,14 +18,6 @@ import { Squircle } from '../Squircle';
       />
     }
 
-    @if (isNew()) {
-      <img
-        src="/image/landing-page/features/new-in-v04.svg"
-        alt="New in v0.4!"
-        class="is-new"
-      />
-    }
-
     <div class="content">
       <div class="icon">
         <img [src]="imageUrl()" alt="Feature Icon" />
@@ -109,8 +101,7 @@ import { Squircle } from '../Squircle';
       line-height: 140%; /* 18.2px */
     }
 
-    .coming-soon,
-    .is-new {
+    .coming-soon {
       position: absolute;
       top: 0;
       right: 0;
@@ -147,7 +138,6 @@ export class Feature {
   imageUrl = input.required<string>();
   videoUrl = input<SafeResourceUrl>();
   docsPath = input<string[]>();
-  isNew = input<boolean>();
   preview = input<boolean>(false);
   configService = inject(ConfigService);
   docsUrl = computed(() => {

--- a/www/analog/src/app/components/home/Features.ts
+++ b/www/analog/src/app/components/home/Features.ts
@@ -10,7 +10,6 @@ type FeatureListItem = {
   videoUrl?: SafeResourceUrl;
   docsPath?: string[];
   preview?: true;
-  isNew?: true;
   imageUrl: string;
 };
 
@@ -48,7 +47,6 @@ type FeatureListItem = {
             [videoUrl]="feature.videoUrl"
             [docsPath]="feature.docsPath"
             [preview]="feature.preview ?? false"
-            [isNew]="feature.isNew ?? false"
             (watchDemo)="onWatchDemo($event)"
           />
         }
@@ -199,12 +197,19 @@ export class Features {
     {
       title: 'Generative User Interfaces',
       description:
-        "Expose your React or Angular components and let Hashbrown use an LLM to serve dynamic views. You stay in control of the ingredients, deciding exactly what can and can't be generated.",
+        'Expose a set of trusted React or Angular components and let Hashbrown use an LLM to compose dynamic views. You stay in control of the ingredients, deciding exactly which components can and cannot be generated.',
       docsPath: ['concept', 'components'],
       imageUrl: '/image/landing-page/features/generative-user-interfaces.svg',
       videoUrl: this.sanitizer.bypassSecurityTrustResourceUrl(
         'https://www.loom.com/embed/00f9bc82287b400f9ac37714262e4955?sid=78eb2d30-e541-412a-981a-428860ce4665',
       ),
+    },
+    {
+      title: 'UI Kits',
+      description:
+        'Package your trusted components into reusable generative UI building blocks. A UI Kit bundles the schema Hashbrown needs to generate UI with the renderer it needs to turn a resolved value into React or Angular elements, so you can share it across chat, completions, and direct rendering.',
+      docsPath: ['recipes', 'ui-kits'],
+      imageUrl: '/image/landing-page/features/generative-user-interfaces.svg',
     },
     {
       title: 'Client-side Tool Calling',
@@ -216,7 +221,7 @@ export class Features {
     {
       title: 'Structured Data',
       description:
-        'Hashbrown comes with Skillet, a schema language that makes it simple to get structured data from LLMs. It is fully type safe and works for component props, structured outputs, and tool definitions, always served just right.',
+        'Hashbrown comes with Skillet, a schema language that makes it simple to get structured data from LLMs. Its streaming JSON parser turns partial model output into type-safe structured outputs, component props, and tool arguments, always served just right.',
       docsPath: ['concept', 'schema'],
       imageUrl: '/image/landing-page/features/structured-data.svg',
       videoUrl: this.sanitizer.bypassSecurityTrustResourceUrl(
@@ -260,7 +265,6 @@ export class Features {
         "Keep network calls small and lightweight while managing token consumption using Hashbrown's built-in threads support. Cache and recall LLM messages with minimal loading code.",
       docsPath: ['recipes', 'threads'],
       imageUrl: '/image/landing-page/features/threads.svg',
-      isNew: true,
     },
     {
       title: 'Markdown Streaming',
@@ -268,7 +272,6 @@ export class Features {
         "Stream and animate inline markdown with Magic Text, Hashbrown's headless markdown parser. Let LLMs cite their sources with full citation support.",
       docsPath: ['recipes', 'magic-text'],
       imageUrl: '/image/landing-page/features/magic-text.svg',
-      isNew: true,
     },
     {
       title: 'Local Models',
@@ -276,7 +279,6 @@ export class Features {
         'Hashbrown can connect with experimental local small language models in Chrome and Edge to generate completions and power lightweight chat experiences, with no roundtrip to the server.',
       docsPath: ['recipes', 'local-models'],
       imageUrl: '/image/landing-page/features/local-models.svg',
-      isNew: true,
     },
     {
       title: 'Listen To & Generate Speech',


### PR DESCRIPTION
## Summary

Refreshes the homepage and announcement to reflect Hashbrown's current **v0.5** capabilities, completing the last open item on the v0.5 release checklist (#460). Keeps the existing design language and data-driven component structure — no redesign.

### Changes
- **Announcement** ([Announcement.ts](www/analog/src/app/components/Announcement.ts)): replaced the stale v0.4 blog callout with a v0.5 message — _"Hashbrown v0.5 brings UI Kits, a streaming JSON parser, and structured outputs"_ — linking to the SDK-aware UI Kits recipe. Bumped the announcement date so it re-shows for users who previously dismissed the v0.4 notice.
- **Features** ([Features.ts](www/analog/src/app/components/home/Features.ts)): added a **UI Kits** feature card (flagship v0.5 capability, links to the UI Kits recipe), sharpened the _Generative User Interfaces_ copy around **trusted components**, and updated _Structured Data_ to call out **Skillet** + the **streaming JSON parser** and structured outputs. Removed the v0.4-era `isNew` "New!" flags.
- **Feature** ([Feature.ts](www/analog/src/app/components/home/Feature.ts)): removed the "New in v0.4!" badge and its now-unused `isNew` input and `.is-new` styles.

The v0.5 story on the homepage now covers: generative UI with trusted components, Skillet schemas, streaming JSON parser + structured output, UI Kits, Magic Text / streaming Markdown, and provider support.

### Notes
- There is no v0.5 blog post, so the announcement links to the UI Kits recipe docs rather than a release post.
- `new-in-v04.svg` is now orphaned but left in place (deleting a public asset is out of scope for this copy refresh).

## Verification
- `NX_NO_CLOUD=true npx nx build www` — ✅ builds (Angular template compilation validates the new bindings)
- `NX_NO_CLOUD=true npx nx test www` — ✅ passes (no spec files for www)
- `npx prettier --check` on touched files — ✅ clean
- `git diff --check` — ✅ clean
- `npx nx eslint:lint www` — ❌ fails **before** file linting due to a pre-existing ESLint flat-config `extends` issue, unrelated to this change (left as-is per task scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)