### PR TITLE
chore(release): publish 0.5.0

### DIFF
--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -102,3 +102,18 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler pages deploy dist/www/analog/analog/public --project-name="hashbrown-www"
+
+      - name: Smoke test production deployments
+        env:
+          DEPLOY_SAMPLES: ${{ toJSON(inputs.deploy_samples) == 'null' || inputs.deploy_samples }}
+          DEPLOY_WWW: ${{ toJSON(inputs.deploy_www) == 'null' || inputs.deploy_www }}
+        run: |
+          if [[ "$DEPLOY_WWW" == "true" ]]; then
+            node scripts/deploy-smoke.mjs --name docs --url https://hashbrown.dev --expect Hashbrown --retries 12 --retry-delay-ms 5000
+          fi
+
+          if [[ "$DEPLOY_SAMPLES" == "true" ]]; then
+            node scripts/deploy-smoke.mjs --name finance --url https://finance.hashbrown.dev --expect "Finance Sample" --retries 12 --retry-delay-ms 5000
+            node scripts/deploy-smoke.mjs --name smart-home --url https://smart-home.hashbrown.dev --expect "Smart Home" --retries 12 --retry-delay-ms 5000
+            node scripts/deploy-smoke.mjs --name fast-food --url https://fast-food.hashbrown.dev --expect "Fast Food Nutrition Sample" --retries 12 --retry-delay-ms 5000
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: npm-publish
@@ -30,8 +31,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      - name: Configure npm auth token
-        run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+      - name: Install npm 11 for trusted publishing
+        run: npm install -g npm@11
 
       - name: Determine affected base
         uses: nrwl/nx-set-shas@v3
@@ -60,9 +61,13 @@ jobs:
       - name: Lint and test affected projects
         run: npx nx affected -t lint,test --parallel=3
 
+      - name: Verify atomic release versions
+        run: node scripts/verify-release-versions.mjs
+
+      - name: Build release packages
+        run: npx nx run-many -t build -p angular anthropic azure bedrock core google ollama openai react writer --parallel=3
+
       - name: Publish packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx nx release publish --tag=${{ steps.channel.outputs.dist_tag }}
 
       - name: Create GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.5.0 (2026-07-09)
+
+### 🚀 Features
+
+- add Ollama client options ([#476](https://github.com/liveloveapp/hashbrown/pull/476), [#471](https://github.com/liveloveapp/hashbrown/issues/471))
+- support documented message history ([#477](https://github.com/liveloveapp/hashbrown/pull/477), [#329](https://github.com/liveloveapp/hashbrown/issues/329))
+- add structured output modes ([#479](https://github.com/liveloveapp/hashbrown/pull/479), [#467](https://github.com/liveloveapp/hashbrown/issues/467))
+- support reactive Angular resource options ([0ba61ca](https://github.com/liveloveapp/hashbrown/commit/0ba61ca))
+- **google:** add Vertex AI authentication support ([#470](https://github.com/liveloveapp/hashbrown/pull/470), [#469](https://github.com/liveloveapp/hashbrown/issues/469))
+- **vox:** Adds @hashbrownai/vox, an AudioWorklet WASM WebRTC-based VAD for Voice Integration ([#412](https://github.com/liveloveapp/hashbrown/pull/412), [#381](https://github.com/liveloveapp/hashbrown/issues/381))
+
+### 🩹 Fixes
+
+- ship react as dual package ([590f655](https://github.com/liveloveapp/hashbrown/commit/590f655))
+- **core:** recover structured output with trailing JSON ([802a25e](https://github.com/liveloveapp/hashbrown/commit/802a25e))
+- **sample:** wrap smart home react chat errors ([#487](https://github.com/liveloveapp/hashbrown/pull/487), [#204](https://github.com/liveloveapp/hashbrown/issues/204))
+
+### ❤️ Thank You
+
+- Brian Love @blove
+- Michał Kotas @michalkotas
+- U.G. Wilson
+
 ## 0.5.0-beta.4 (2026-02-12)
 
 ### 🚀 Features

--- a/nx.json
+++ b/nx.json
@@ -71,7 +71,7 @@
       "packages/writer"
     ],
     "version": {
-      "preVersionCommand": "npx nx run-many -t build"
+      "preVersionCommand": "npx nx run-many -t build -p angular anthropic azure bedrock core google ollama openai react writer"
     }
   },
   "generators": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@hashbrownai/angular",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Angular bindings for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/angular"
   },
   "peerDependencies": {
     "@angular/core": "^20.0.0 || ^21.0.0",
-    "@hashbrownai/core": "0.5.0-beta.4",
+    "@hashbrownai/core": "0.5.0",
     "@angular/common": "^20.0.0 || ^21.0.0"
   },
   "sideEffects": false,

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/anthropic",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Anthropic provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/anthropic"
   },
   "type": "commonjs",
@@ -13,7 +13,7 @@
   "types": "./src/index.d.ts",
   "dependencies": {
     "tslib": "^2.3.0",
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.24.3"

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/azure",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Azure provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/azure"
   },
   "type": "commonjs",
@@ -15,7 +15,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@hashbrownai/core": "0.5.0-beta.4",
+    "@hashbrownai/core": "0.5.0",
     "openai": "^6.9.0"
   },
   "sideEffects": false,

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/bedrock",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Amazon Bedrock provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/bedrock"
   },
   "type": "commonjs",
@@ -16,7 +16,7 @@
     "@aws-sdk/types": "3.922.0"
   },
   "peerDependencies": {
-    "@hashbrownai/core": "0.5.0-beta.4",
+    "@hashbrownai/core": "0.5.0",
     "@aws-sdk/client-bedrock-runtime": "^3.936.0"
   },
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashbrownai/core",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Runtime helpers for Hashbrown AI",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/google",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Google provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/google"
   },
   "type": "commonjs",
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "@google/genai": "^1.38.0",
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/ollama",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Ollama provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/ollama"
   },
   "type": "commonjs",
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "ollama": "^0.5.16",
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@hashbrownai/openai",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "OpenAI provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/openai"
   },
   "type": "commonjs",
@@ -13,7 +13,7 @@
   "types": "./src/index.d.ts",
   "dependencies": {
     "tslib": "^2.3.0",
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "peerDependencies": {
     "openai": "^6.9.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashbrownai/react",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "React components for Hashbrown AI",
   "license": "MIT",
   "sideEffects": false,
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "react": ">=18 <20",
     "react-dom": ">=18 <20",
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/writer/package.json
+++ b/packages/writer/package.json
@@ -1,18 +1,18 @@
 {
   "name": "@hashbrownai/writer",
-  "version": "0.5.0-beta.4",
+  "version": "0.5.0",
   "description": "Writer provider for Hashbrown AI",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hashbrownai/hashbrown.git",
+    "url": "https://github.com/liveloveapp/hashbrown.git",
     "directory": "packages/writer"
   },
   "type": "commonjs",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "peerDependencies": {
-    "@hashbrownai/core": "0.5.0-beta.4"
+    "@hashbrownai/core": "0.5.0"
   },
   "dependencies": {
     "tslib": "^2.3.0",

--- a/scripts/deploy-smoke.mjs
+++ b/scripts/deploy-smoke.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { resolve } from 'node:path';
+
+const DEFAULT_RETRIES = 0;
+const DEFAULT_RETRY_DELAY_MS = 2000;
+
+const defaultSleep = (delayMs) =>
+  new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, delayMs);
+  });
+
+export function parseDeploySmokeArgs(argv) {
+  const options = {
+    url: 'https://hashbrown.dev',
+    expectedText: 'Hashbrown',
+    name: 'deployment',
+    dryRun: false,
+    retries: DEFAULT_RETRIES,
+    retryDelayMs: DEFAULT_RETRY_DELAY_MS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+
+    if (current === '--url' && argv[index + 1]) {
+      options.url = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (current === '--expect' && argv[index + 1]) {
+      options.expectedText = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (current === '--name' && argv[index + 1]) {
+      options.name = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (current === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (current === '--retries' && argv[index + 1]) {
+      options.retries = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (current === '--retry-delay-ms' && argv[index + 1]) {
+      options.retryDelayMs = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown or incomplete argument: ${current}`);
+  }
+
+  return options;
+}
+
+export async function runDeploySmoke({
+  url,
+  expectedText,
+  name = 'deployment',
+  dryRun = false,
+  retries = DEFAULT_RETRIES,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  fetchImpl = fetch,
+  sleep = defaultSleep,
+}) {
+  if (dryRun) {
+    return `dry-run:${name}:${url}:${expectedText}`;
+  }
+
+  let attemptsRemaining = retries + 1;
+  let lastError = null;
+
+  while (attemptsRemaining > 0) {
+    try {
+      const response = await fetchImpl(url);
+
+      if (!response.ok) {
+        throw new Error(
+          `Deploy smoke failed for ${name} (${url}): ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const html = await response.text();
+      if (!html.includes(expectedText)) {
+        throw new Error(
+          `Deploy smoke failed for ${name} (${url}): missing expected text "${expectedText}"`,
+        );
+      }
+
+      return `pass:${name}:${url}:${expectedText}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      attemptsRemaining -= 1;
+
+      if (attemptsRemaining === 0) {
+        throw lastError;
+      }
+
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw lastError ?? new Error(`Deploy smoke failed for ${name} (${url})`);
+}
+
+if (process.argv[1] === resolve(process.cwd(), 'scripts/deploy-smoke.mjs')) {
+  const options = parseDeploySmokeArgs(process.argv.slice(2));
+
+  runDeploySmoke(options)
+    .then((result) => {
+      process.stdout.write(`${result}\n`);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/deploy-smoke.spec.mjs
+++ b/scripts/deploy-smoke.spec.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseDeploySmokeArgs, runDeploySmoke } from './deploy-smoke.mjs';
+
+test('parses the deploy smoke command line', () => {
+  const options = parseDeploySmokeArgs([
+    '--url',
+    'https://hashbrown.dev',
+    '--expect',
+    'Hashbrown',
+    '--name',
+    'docs',
+    '--dry-run',
+    '--retries',
+    '5',
+    '--retry-delay-ms',
+    '1000',
+  ]);
+
+  assert.deepEqual(options, {
+    url: 'https://hashbrown.dev',
+    expectedText: 'Hashbrown',
+    name: 'docs',
+    dryRun: true,
+    retries: 5,
+    retryDelayMs: 1000,
+  });
+});
+
+test('formats dry-run output without performing a network request', async () => {
+  const result = await runDeploySmoke({
+    url: 'https://hashbrown.dev',
+    expectedText: 'Hashbrown',
+    name: 'docs',
+    dryRun: true,
+    fetchImpl: async () => {
+      throw new Error('fetch should not run');
+    },
+  });
+
+  assert.equal(result, 'dry-run:docs:https://hashbrown.dev:Hashbrown');
+});
+
+test('retries until the deployment responds with expected text', async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (calls.length === 1) {
+      return new Response('missing', {
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+    }
+
+    return new Response('<html><title>Finance Sample</title></html>', {
+      status: 200,
+      statusText: 'OK',
+    });
+  };
+  const sleeps = [];
+  const sleep = async (delayMs) => {
+    sleeps.push(delayMs);
+  };
+
+  const result = await runDeploySmoke({
+    url: 'https://finance.hashbrown.dev',
+    expectedText: 'Finance Sample',
+    name: 'finance',
+    retries: 1,
+    retryDelayMs: 10,
+    fetchImpl,
+    sleep,
+  });
+
+  assert.equal(result, 'pass:finance:https://finance.hashbrown.dev:Finance Sample');
+  assert.equal(calls.length, 2);
+  assert.deepEqual(sleeps, [10]);
+});
+
+test('fails when the response does not contain expected text', async () => {
+  await assert.rejects(
+    runDeploySmoke({
+      url: 'https://fast-food.hashbrown.dev',
+      expectedText: 'Fast Food Nutrition Sample',
+      name: 'fast-food',
+      fetchImpl: async () =>
+        new Response('<html><title>Wrong app</title></html>', {
+          status: 200,
+          statusText: 'OK',
+        }),
+    }),
+    /missing expected text "Fast Food Nutrition Sample"/,
+  );
+});

--- a/scripts/verify-release-versions.mjs
+++ b/scripts/verify-release-versions.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SKIPPED_DIRECTORIES = new Set([
+  '.git',
+  '.nx',
+  'coverage',
+  'dist',
+  'node_modules',
+  'tmp',
+]);
+const TRUSTED_PUBLISHER_REPOSITORY_URL =
+  'https://github.com/liveloveapp/hashbrown.git';
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function* walkProjectJsonFiles(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        yield* walkProjectJsonFiles(join(directory, entry.name));
+      }
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === 'project.json') {
+      yield join(directory, entry.name);
+    }
+  }
+}
+
+async function findProjects(workspaceRoot) {
+  const projects = new Map();
+
+  for await (const projectJsonPath of walkProjectJsonFiles(workspaceRoot)) {
+    const project = await readJson(projectJsonPath);
+    if (typeof project.name === 'string') {
+      projects.set(project.name, {
+        name: project.name,
+        root: projectJsonPath.slice(0, -'/project.json'.length),
+        targets: project.targets ?? {},
+      });
+    }
+  }
+
+  return projects;
+}
+
+async function getPackageForProject(project) {
+  const packageJsonPath = join(project.root, 'package.json');
+  const packageJson = await readJson(packageJsonPath);
+
+  return {
+    packageJson,
+    packageJsonPath,
+    packageName: packageJson.name,
+    projectName: project.name,
+    version: packageJson.version,
+  };
+}
+
+function normalizeTag(tag) {
+  if (!tag) {
+    return undefined;
+  }
+
+  return tag.replace(/^refs\/tags\//, '');
+}
+
+function getInternalDependencies(packageInfo) {
+  const sections = [
+    packageInfo.packageJson.dependencies,
+    packageInfo.packageJson.peerDependencies,
+    packageInfo.packageJson.optionalDependencies,
+    packageInfo.packageJson.devDependencies,
+  ];
+
+  return sections.flatMap((dependencies) =>
+    Object.entries(dependencies ?? {}).filter(([name]) =>
+      name.startsWith('@hashbrownai/'),
+    ),
+  );
+}
+
+function getRepositoryUrl(packageJson) {
+  if (typeof packageJson.repository === 'string') {
+    return packageJson.repository;
+  }
+
+  return packageJson.repository?.url;
+}
+
+export async function verifyReleaseVersions({
+  workspaceRoot = process.cwd(),
+  expectedTag,
+} = {}) {
+  const nxJson = await readJson(join(workspaceRoot, 'nx.json'));
+  const releaseProjects = nxJson.release?.projects;
+
+  if (!Array.isArray(releaseProjects) || releaseProjects.length === 0) {
+    throw new Error('nx.json release.projects must list release package roots.');
+  }
+
+  const projects = await findProjects(workspaceRoot);
+  const releaseProjectRoots = new Set(releaseProjects);
+  const releaseProjectNames = new Set(
+    releaseProjects.map((projectRoot) => projectRoot.replace(/^packages\//, '')),
+  );
+  const omittedPublicPackages = [];
+
+  for (const project of projects.values()) {
+    let packageInfo;
+
+    try {
+      packageInfo = await getPackageForProject(project);
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        continue;
+      }
+      throw error;
+    }
+
+    const isPublicHashbrownPackage =
+      packageInfo.packageJson.private !== true &&
+      typeof packageInfo.packageName === 'string' &&
+      packageInfo.packageName.startsWith('@hashbrownai/');
+
+    if (
+      isPublicHashbrownPackage &&
+      project.targets['nx-release-publish'] &&
+      !releaseProjectNames.has(project.name)
+    ) {
+      omittedPublicPackages.push(packageInfo.packageName);
+    }
+  }
+
+  if (omittedPublicPackages.length > 0) {
+    omittedPublicPackages.sort((a, b) => a.localeCompare(b));
+    throw new Error(
+      omittedPublicPackages
+        .map(
+          (packageName) =>
+            `Public package ${packageName} is not included in nx.json release.projects.`,
+        )
+        .join('\n'),
+    );
+  }
+
+  const packages = [];
+
+  for (const projectRoot of releaseProjectRoots) {
+    const projectName = projectRoot.replace(/^packages\//, '');
+    const project = projects.get(projectName);
+    if (!project) {
+      throw new Error(`Release project "${projectName}" does not have a project.json.`);
+    }
+
+    const packageInfo = await getPackageForProject(project);
+    const expectedPublishRoot = `dist/${projectRoot}`;
+    const publishRoot =
+      project.targets['nx-release-publish']?.options?.packageRoot;
+
+    if (publishRoot !== expectedPublishRoot) {
+      throw new Error(
+        `Release project "${projectName}" must publish from ${expectedPublishRoot}.`,
+      );
+    }
+
+    if (packageInfo.packageJson.private === true) {
+      throw new Error(
+        `Release project "${projectName}" points at private package ${relative(
+          workspaceRoot,
+          packageInfo.packageJsonPath,
+        )}.`,
+      );
+    }
+
+    if (
+      typeof packageInfo.packageName !== 'string' ||
+      typeof packageInfo.version !== 'string'
+    ) {
+      throw new Error(
+        `Release project "${projectName}" must have package name and version in ${relative(
+          workspaceRoot,
+          packageInfo.packageJsonPath,
+        )}.`,
+      );
+    }
+
+    packages.push({
+      packageJsonPath: packageInfo.packageJsonPath,
+      packageName: packageInfo.packageName,
+      projectName: packageInfo.projectName,
+      repositoryUrl: getRepositoryUrl(packageInfo.packageJson),
+      version: packageInfo.version,
+      internalDependencies: getInternalDependencies(packageInfo),
+    });
+  }
+
+  packages.sort((a, b) => a.packageName.localeCompare(b.packageName));
+
+  const versions = new Set(packages.map((pkg) => pkg.version));
+  if (versions.size !== 1) {
+    const packageList = packages
+      .map((pkg) => `  - ${pkg.packageName}: ${pkg.version}`)
+      .join('\n');
+
+    throw new Error(
+      `Hashbrown release packages must share one version.\n${packageList}`,
+    );
+  }
+
+  const [version] = versions;
+  const packageNames = new Set(packages.map((pkg) => pkg.packageName));
+
+  for (const pkg of packages) {
+    if (pkg.repositoryUrl !== TRUSTED_PUBLISHER_REPOSITORY_URL) {
+      throw new Error(
+        `${pkg.packageName} repository URL must be ${TRUSTED_PUBLISHER_REPOSITORY_URL} in ${relative(
+          workspaceRoot,
+          pkg.packageJsonPath,
+        )}.`,
+      );
+    }
+
+    for (const [dependencyName, dependencyVersion] of pkg.internalDependencies) {
+      if (
+        packageNames.has(dependencyName) &&
+        dependencyVersion !== version
+      ) {
+        throw new Error(
+          `${pkg.packageName} depends on ${dependencyName} at ${dependencyVersion}, expected ${version}.`,
+        );
+      }
+    }
+  }
+
+  const tag = normalizeTag(expectedTag);
+  if (tag && tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match package version ${version}.`);
+  }
+
+  return {
+    version,
+    packages: packages.map((pkg) => pkg.packageName),
+  };
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--tag') {
+      options.expectedTag = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const result = await verifyReleaseVersions(parseArgs(process.argv.slice(2)));
+    console.log(
+      `Hashbrown release is atomic at ${result.version}: ${result.packages.join(', ')}`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-release-versions.spec.mjs
+++ b/scripts/verify-release-versions.spec.mjs
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { verifyReleaseVersions } from './verify-release-versions.mjs';
+
+const EXPECTED_REPOSITORY_URL = 'https://github.com/liveloveapp/hashbrown.git';
+
+async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function createWorkspace({
+  releaseProjects = ['packages/core', 'packages/react'],
+  packages = {
+    'packages/core': {
+      name: '@hashbrownai/core',
+      version: '0.5.0',
+      publishRoot: 'dist/packages/core',
+      repository: {
+        type: 'git',
+        url: EXPECTED_REPOSITORY_URL,
+      },
+    },
+    'packages/react': {
+      name: '@hashbrownai/react',
+      version: '0.5.0',
+      publishRoot: 'dist/packages/react',
+      repository: {
+        type: 'git',
+        url: EXPECTED_REPOSITORY_URL,
+      },
+      dependencies: {
+        '@hashbrownai/core': '0.5.0',
+      },
+    },
+  },
+} = {}) {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'hashbrown-release-'));
+
+  await writeJson(join(workspaceRoot, 'nx.json'), {
+    release: {
+      projects: releaseProjects,
+    },
+  });
+
+  for (const [projectRoot, packageInfo] of Object.entries(packages)) {
+    await mkdir(join(workspaceRoot, projectRoot), { recursive: true });
+    await writeJson(join(workspaceRoot, projectRoot, 'project.json'), {
+      name: projectRoot.replace('packages/', ''),
+      targets: packageInfo.publishRoot
+        ? {
+            'nx-release-publish': {
+              options: {
+                packageRoot: packageInfo.publishRoot,
+              },
+            },
+          }
+        : {},
+    });
+    await writeJson(join(workspaceRoot, projectRoot, 'package.json'), {
+      name: packageInfo.name,
+      version: packageInfo.version,
+      private: packageInfo.private,
+      repository: packageInfo.repository ?? {
+        type: 'git',
+        url: EXPECTED_REPOSITORY_URL,
+      },
+      dependencies: packageInfo.dependencies,
+      peerDependencies: packageInfo.peerDependencies,
+    });
+  }
+
+  return workspaceRoot;
+}
+
+test('accepts the fixed Hashbrown release set when every package is versioned together', async () => {
+  const workspaceRoot = await createWorkspace();
+
+  const result = await verifyReleaseVersions({
+    workspaceRoot,
+    expectedTag: 'v0.5.0',
+  });
+
+  assert.deepEqual(result, {
+    version: '0.5.0',
+    packages: ['@hashbrownai/core', '@hashbrownai/react'],
+  });
+});
+
+test('rejects a release tag that does not match the package version', async () => {
+  const workspaceRoot = await createWorkspace();
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot, expectedTag: 'npm/latest' }),
+    /Release tag npm\/latest does not match package version 0\.5\.0/,
+  );
+});
+
+test('rejects mixed versions inside the release set', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.1',
+        publishRoot: 'dist/packages/react',
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /Hashbrown release packages must share one version/,
+  );
+});
+
+test('rejects public publishable packages missing from the release set', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+      },
+      'packages/openai': {
+        name: '@hashbrownai/openai',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/openai',
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /Public package @hashbrownai\/openai is not included in nx\.json release\.projects/,
+  );
+});
+
+test('ignores private Hashbrown packages outside the release set', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+      },
+      'packages/vox': {
+        name: '@hashbrownai/vox',
+        version: '0.0.1',
+        private: true,
+      },
+    },
+  });
+
+  const result = await verifyReleaseVersions({ workspaceRoot });
+
+  assert.deepEqual(result.packages, ['@hashbrownai/core', '@hashbrownai/react']);
+});
+
+test('rejects release packages that publish from a non-dist package root', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'packages/core',
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /Release project "core" must publish from dist\/packages\/core/,
+  );
+});
+
+test('rejects internal Hashbrown dependency versions that are not aligned', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+        dependencies: {
+          '@hashbrownai/core': '0.5.0-beta.4',
+        },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /@hashbrownai\/react depends on @hashbrownai\/core at 0\.5\.0-beta\.4, expected 0\.5\.0/,
+  );
+});
+
+test('rejects release packages whose repository URL does not match the trusted publisher repository', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/hashbrownai/hashbrown.git',
+        },
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+        repository: {
+          type: 'git',
+          url: EXPECTED_REPOSITORY_URL,
+        },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /@hashbrownai\/core repository URL must be https:\/\/github\.com\/liveloveapp\/hashbrown\.git/,
+  );
+});


### PR DESCRIPTION
## Summary
- bump Hashbrown release packages to 0.5.0 and add the changelog entry
- configure npm trusted publishing with OIDC and atomic release verification
- build release package artifacts before npm publish
- add production deployment smoke checks

## Verification
- actionlint .github/workflows/npm-publish.yml .github/workflows/cloudflare-production.yml
- node --test scripts/deploy-smoke.spec.mjs scripts/verify-release-versions.spec.mjs
- node scripts/verify-release-versions.mjs --tag v0.5.0
- npx nx run-many -t build -p angular anthropic azure bedrock core google ollama openai react writer --parallel=3
- npx nx run-many -t test -p angular anthropic azure bedrock core google ollama openai writer --parallel=3
- npx nx run-many -t lint -p angular anthropic azure bedrock core google ollama openai --parallel=3
- npx nx release publish --dry-run

Known lint warnings remain in anthropic and bedrock for @typescript-eslint/no-explicit-any.