### PR TITLE
chore(release): harden publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,15 +46,12 @@ jobs:
           case "${GITHUB_REF_NAME}" in
             npm/preview)
               echo "dist_tag=next" >> "$GITHUB_OUTPUT"
-              echo "create_release=false" >> "$GITHUB_OUTPUT"
               ;;
             npm/latest)
               echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
-              echo "create_release=true" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
-              echo "create_release=false" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
@@ -68,34 +65,10 @@ jobs:
         run: npx nx run-many -t build -p angular anthropic azure bedrock core google ollama openai react writer --parallel=3
 
       - name: Publish packages
-        run: npx nx release publish --tag=${{ steps.channel.outputs.dist_tag }}
+        run: npx nx release publish --tag=${{ steps.channel.outputs.dist_tag }} --access=public --parallel=1
 
-      - name: Create GitHub release
-        if: steps.channel.outputs.create_release == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const tagName = context.ref.replace('refs/tags/', '');
-            const releaseName = `Hashbrown npm latest (${tagName})`;
-
-            try {
-              await github.rest.repos.createRelease({
-                owner,
-                repo,
-                tag_name: tagName,
-                name: releaseName,
-                body: 'Automated npm publish triggered by tag push.',
-                draft: false,
-                prerelease: false,
-              });
-            } catch (error) {
-              if (error.status === 422) {
-                core.warning('Release already exists for this tag; skipping creation.');
-                return;
-              }
-              throw error;
-            }
+      - name: Verify npm release
+        run: node scripts/verify-npm-release.mjs --tag=${{ steps.channel.outputs.dist_tag }}
 
   deploy-cloudflare-production:
     name: Deploy Cloudflare production

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,97 @@
+# Hashbrown Release Runbook
+
+This runbook describes the release process for the fixed Hashbrown npm release
+group.
+
+## Release Package Set
+
+Hashbrown publishes these packages together at one version:
+
+- `@hashbrownai/angular`
+- `@hashbrownai/anthropic`
+- `@hashbrownai/azure`
+- `@hashbrownai/bedrock`
+- `@hashbrownai/core`
+- `@hashbrownai/google`
+- `@hashbrownai/ollama`
+- `@hashbrownai/openai`
+- `@hashbrownai/react`
+- `@hashbrownai/writer`
+
+Each package must have an npm trusted publisher entry with:
+
+- Publisher: GitHub Actions
+- Organization/user: `liveloveapp`
+- Repository: `hashbrown`
+- Workflow filename: `npm-publish.yml`
+- Allowed action: `npm publish`
+- Environment: blank
+
+## Prepare The Release Commit
+
+1. Start from current `main`.
+2. Generate the release version explicitly. Do not rely on semver keywords when
+   old beta tags are not ancestors of `main`.
+3. Generate the changelog for the intended range.
+4. Run local verification:
+
+```sh
+node --test scripts/deploy-smoke.spec.mjs scripts/verify-release-versions.spec.mjs scripts/verify-npm-release.spec.mjs
+node scripts/verify-release-versions.mjs --tag vX.Y.Z
+actionlint .github/workflows/npm-publish.yml .github/workflows/cloudflare-production.yml
+npx nx run-many -t build -p angular anthropic azure bedrock core google ollama openai react writer --parallel=3
+npx nx run-many -t test -p angular anthropic azure bedrock core google ollama openai writer --parallel=3
+npx nx run-many -t lint -p angular anthropic azure bedrock core google ollama openai --parallel=3
+npx nx release publish --dry-run
+```
+
+5. Open and merge the release PR through the protected `main` branch.
+
+## Tag And Publish
+
+After the release commit is on `origin/main`:
+
+```sh
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git tag -a --no-sign vX.Y.Z -m "Hashbrown X.Y.Z" HEAD
+git push origin vX.Y.Z
+```
+
+Create the explicit GitHub release on the version tag:
+
+```sh
+awk '/^## X\\.Y\\.Z /{flag=1; next} /^## /{if (flag) exit} flag {print}' CHANGELOG.md \
+  | gh release create vX.Y.Z --title "Hashbrown X.Y.Z" --notes-file -
+```
+
+Move the npm channel tag to the release commit and push it:
+
+```sh
+git tag -f --no-sign npm/latest HEAD
+git push --force-with-lease origin npm/latest
+```
+
+`npm/latest` is a movable trigger tag. It is not the public release tag.
+
+## Verify The Release
+
+The `NPM Publish` workflow should:
+
+1. Build release packages.
+2. Publish serially with npm trusted publishing.
+3. Verify every package exists on npm with the expected dist tag.
+4. Deploy production Cloudflare Pages.
+5. Smoke test production URLs.
+
+After the workflow succeeds, verify the GitHub release remains attached to the
+version tag:
+
+```sh
+gh release list --limit 5 --json tagName,name,isLatest,isDraft,isPrerelease,publishedAt
+```
+
+If a failed or manual run creates an unwanted `npm/latest` GitHub release, delete
+that release only. Keep the `npm/latest` tag because it records the publish
+trigger.

--- a/scripts/verify-npm-release.mjs
+++ b/scripts/verify-npm-release.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+import { verifyReleaseVersions } from './verify-release-versions.mjs';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+
+async function defaultViewPackage({ packageName, version, registry }) {
+  const { stdout } = await execFileAsync('npm', [
+    'view',
+    `${packageName}@${version}`,
+    'version',
+    'dist-tags',
+    '--json',
+    `--registry=${registry}`,
+  ]);
+
+  return JSON.parse(stdout);
+}
+
+export async function verifyNpmRelease({
+  workspaceRoot = process.cwd(),
+  tag = 'latest',
+  registry = DEFAULT_REGISTRY,
+  viewPackage = defaultViewPackage,
+} = {}) {
+  const release = await verifyReleaseVersions({ workspaceRoot });
+
+  for (const packageName of release.packages) {
+    const packageInfo = await viewPackage({
+      packageName,
+      version: release.version,
+      registry,
+    });
+    const publishedVersion = packageInfo.version;
+    const taggedVersion = packageInfo['dist-tags']?.[tag];
+
+    if (publishedVersion !== release.version) {
+      throw new Error(
+        `${packageName}@${release.version} expected registry version ${release.version}, found ${publishedVersion}.`,
+      );
+    }
+
+    if (taggedVersion !== release.version) {
+      throw new Error(
+        `${packageName}@${release.version} expected ${tag} to point at ${release.version}, found ${taggedVersion}.`,
+      );
+    }
+  }
+
+  return {
+    version: release.version,
+    tag,
+    packages: release.packages,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--tag' && argv[index + 1]) {
+      options.tag = argv[index + 1];
+      index += 1;
+    } else if (arg === '--registry' && argv[index + 1]) {
+      options.registry = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const result = await verifyNpmRelease(parseArgs(process.argv.slice(2)));
+    console.log(
+      `Hashbrown npm release ${result.version} is published on ${result.tag}: ${result.packages.join(', ')}`,
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-npm-release.spec.mjs
+++ b/scripts/verify-npm-release.spec.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { verifyNpmRelease } from './verify-npm-release.mjs';
+
+const EXPECTED_REPOSITORY_URL = 'https://github.com/liveloveapp/hashbrown.git';
+
+async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function createWorkspace() {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'hashbrown-npm-release-'));
+  const packages = {
+    'packages/core': '@hashbrownai/core',
+    'packages/react': '@hashbrownai/react',
+  };
+
+  await writeJson(join(workspaceRoot, 'nx.json'), {
+    release: {
+      projects: Object.keys(packages),
+    },
+  });
+
+  for (const [projectRoot, packageName] of Object.entries(packages)) {
+    await mkdir(join(workspaceRoot, projectRoot), { recursive: true });
+    await writeJson(join(workspaceRoot, projectRoot, 'project.json'), {
+      name: projectRoot.replace('packages/', ''),
+      targets: {
+        'nx-release-publish': {
+          options: {
+            packageRoot: `dist/${projectRoot}`,
+          },
+        },
+      },
+    });
+    await writeJson(join(workspaceRoot, projectRoot, 'package.json'), {
+      name: packageName,
+      version: '0.6.0',
+      repository: {
+        type: 'git',
+        url: EXPECTED_REPOSITORY_URL,
+      },
+      publishConfig: {
+        access: 'public',
+      },
+      dependencies:
+        packageName === '@hashbrownai/react'
+          ? {
+              '@hashbrownai/core': '0.6.0',
+            }
+          : undefined,
+    });
+  }
+
+  return workspaceRoot;
+}
+
+test('accepts packages published at the release version with the requested dist tag', async () => {
+  const workspaceRoot = await createWorkspace();
+  const viewedPackages = [];
+
+  const result = await verifyNpmRelease({
+    workspaceRoot,
+    tag: 'latest',
+    viewPackage: async ({ packageName, version }) => {
+      viewedPackages.push(`${packageName}@${version}`);
+
+      return {
+        version,
+        'dist-tags': {
+          latest: version,
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(result, {
+    version: '0.6.0',
+    tag: 'latest',
+    packages: ['@hashbrownai/core', '@hashbrownai/react'],
+  });
+  assert.deepEqual(viewedPackages, [
+    '@hashbrownai/core@0.6.0',
+    '@hashbrownai/react@0.6.0',
+  ]);
+});
+
+test('rejects packages missing from the npm registry at the release version', async () => {
+  const workspaceRoot = await createWorkspace();
+
+  await assert.rejects(
+    verifyNpmRelease({
+      workspaceRoot,
+      viewPackage: async ({ packageName, version }) => {
+        if (packageName === '@hashbrownai/react') {
+          throw new Error(`${packageName}@${version} was not found`);
+        }
+
+        return {
+          version,
+          'dist-tags': {
+            latest: version,
+          },
+        };
+      },
+    }),
+    /@hashbrownai\/react@0\.6\.0 was not found/,
+  );
+});
+
+test('rejects packages whose dist tag does not point at the release version', async () => {
+  const workspaceRoot = await createWorkspace();
+
+  await assert.rejects(
+    verifyNpmRelease({
+      workspaceRoot,
+      tag: 'latest',
+      viewPackage: async ({ version }) => ({
+        version,
+        'dist-tags': {
+          latest: '0.5.0',
+        },
+      }),
+    }),
+    /expected latest to point at 0\.6\.0, found 0\.5\.0/,
+  );
+});

--- a/scripts/verify-release-versions.mjs
+++ b/scripts/verify-release-versions.mjs
@@ -102,13 +102,17 @@ export async function verifyReleaseVersions({
   const releaseProjects = nxJson.release?.projects;
 
   if (!Array.isArray(releaseProjects) || releaseProjects.length === 0) {
-    throw new Error('nx.json release.projects must list release package roots.');
+    throw new Error(
+      'nx.json release.projects must list release package roots.',
+    );
   }
 
   const projects = await findProjects(workspaceRoot);
   const releaseProjectRoots = new Set(releaseProjects);
   const releaseProjectNames = new Set(
-    releaseProjects.map((projectRoot) => projectRoot.replace(/^packages\//, '')),
+    releaseProjects.map((projectRoot) =>
+      projectRoot.replace(/^packages\//, ''),
+    ),
   );
   const omittedPublicPackages = [];
 
@@ -156,7 +160,9 @@ export async function verifyReleaseVersions({
     const projectName = projectRoot.replace(/^packages\//, '');
     const project = projects.get(projectName);
     if (!project) {
-      throw new Error(`Release project "${projectName}" does not have a project.json.`);
+      throw new Error(
+        `Release project "${projectName}" does not have a project.json.`,
+      );
     }
 
     const packageInfo = await getPackageForProject(project);
@@ -195,6 +201,7 @@ export async function verifyReleaseVersions({
       packageJsonPath: packageInfo.packageJsonPath,
       packageName: packageInfo.packageName,
       projectName: packageInfo.projectName,
+      publishConfigAccess: packageInfo.packageJson.publishConfig?.access,
       repositoryUrl: getRepositoryUrl(packageInfo.packageJson),
       version: packageInfo.version,
       internalDependencies: getInternalDependencies(packageInfo),
@@ -227,11 +234,20 @@ export async function verifyReleaseVersions({
       );
     }
 
-    for (const [dependencyName, dependencyVersion] of pkg.internalDependencies) {
-      if (
-        packageNames.has(dependencyName) &&
-        dependencyVersion !== version
-      ) {
+    if (pkg.publishConfigAccess !== 'public') {
+      throw new Error(
+        `${pkg.packageName} must set publishConfig.access to "public" in ${relative(
+          workspaceRoot,
+          pkg.packageJsonPath,
+        )}.`,
+      );
+    }
+
+    for (const [
+      dependencyName,
+      dependencyVersion,
+    ] of pkg.internalDependencies) {
+      if (packageNames.has(dependencyName) && dependencyVersion !== version) {
         throw new Error(
           `${pkg.packageName} depends on ${dependencyName} at ${dependencyVersion}, expected ${version}.`,
         );
@@ -241,7 +257,9 @@ export async function verifyReleaseVersions({
 
   const tag = normalizeTag(expectedTag);
   if (tag && tag !== `v${version}`) {
-    throw new Error(`Release tag ${tag} does not match package version ${version}.`);
+    throw new Error(
+      `Release tag ${tag} does not match package version ${version}.`,
+    );
   }
 
   return {
@@ -268,7 +286,9 @@ function parseArgs(argv) {
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
-    const result = await verifyReleaseVersions(parseArgs(process.argv.slice(2)));
+    const result = await verifyReleaseVersions(
+      parseArgs(process.argv.slice(2)),
+    );
     console.log(
       `Hashbrown release is atomic at ${result.version}: ${result.packages.join(', ')}`,
     );

--- a/scripts/verify-release-versions.spec.mjs
+++ b/scripts/verify-release-versions.spec.mjs
@@ -68,6 +68,9 @@ async function createWorkspace({
         type: 'git',
         url: EXPECTED_REPOSITORY_URL,
       },
+      publishConfig: packageInfo.publishConfig ?? {
+        access: 'public',
+      },
       dependencies: packageInfo.dependencies,
       peerDependencies: packageInfo.peerDependencies,
     });
@@ -171,7 +174,10 @@ test('ignores private Hashbrown packages outside the release set', async () => {
 
   const result = await verifyReleaseVersions({ workspaceRoot });
 
-  assert.deepEqual(result.packages, ['@hashbrownai/core', '@hashbrownai/react']);
+  assert.deepEqual(result.packages, [
+    '@hashbrownai/core',
+    '@hashbrownai/react',
+  ]);
 });
 
 test('rejects release packages that publish from a non-dist package root', async () => {
@@ -248,5 +254,30 @@ test('rejects release packages whose repository URL does not match the trusted p
   await assert.rejects(
     verifyReleaseVersions({ workspaceRoot }),
     /@hashbrownai\/core repository URL must be https:\/\/github\.com\/liveloveapp\/hashbrown\.git/,
+  );
+});
+
+test('rejects release packages that are not configured for public npm publishing', async () => {
+  const workspaceRoot = await createWorkspace({
+    packages: {
+      'packages/core': {
+        name: '@hashbrownai/core',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/core',
+        publishConfig: {
+          access: 'restricted',
+        },
+      },
+      'packages/react': {
+        name: '@hashbrownai/react',
+        version: '0.5.0',
+        publishRoot: 'dist/packages/react',
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyReleaseVersions({ workspaceRoot }),
+    /@hashbrownai\/core must set publishConfig\.access to "public"/,
   );
 });


### PR DESCRIPTION
## Summary
- remove automatic GitHub release creation from the npm channel tag workflow
- publish npm packages serially with explicit public access and verify the registry before deploy
- enforce release package publishConfig.access and add npm release verification
- document the release runbook and trusted publisher checklist

## Verification
- node --test scripts/deploy-smoke.spec.mjs scripts/verify-release-versions.spec.mjs scripts/verify-npm-release.spec.mjs
- node --check scripts/deploy-smoke.mjs && node --check scripts/verify-release-versions.mjs && node --check scripts/verify-npm-release.mjs
- actionlint .github/workflows/npm-publish.yml .github/workflows/cloudflare-production.yml
- npx prettier --check .github/workflows/npm-publish.yml docs/release-runbook.md scripts/verify-release-versions.mjs scripts/verify-release-versions.spec.mjs scripts/verify-npm-release.mjs scripts/verify-npm-release.spec.mjs
- node scripts/verify-release-versions.mjs --tag v0.5.0
- node scripts/verify-npm-release.mjs --tag latest