### PR TITLE
test(angular): support Angular 22 consumers

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -34,3 +34,27 @@ jobs:
 
       - name: Lint, test, build, and e2e affected projects
         run: npx nx affected -t lint,test,build,e2e --parallel=3
+
+  angular-22-consumer:
+    name: Packed Angular 22 consumer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packed dependencies
+        run: npx nx run-many -t build --projects=core,angular
+
+      - name: Verify clean Angular 22 consumer
+        run: node scripts/verify-angular-22-consumer.mjs

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -9,9 +9,9 @@
     "directory": "packages/angular"
   },
   "peerDependencies": {
-    "@angular/core": "^20.0.0 || ^21.0.0",
+    "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
     "@hashbrownai/core": "0.5.0",
-    "@angular/common": "^20.0.0 || ^21.0.0"
+    "@angular/common": "^20.0.0 || ^21.0.0 || ^22.0.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/angular/src/dummy.spec.ts
+++ b/packages/angular/src/dummy.spec.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-describe('Dummy test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
-  });
+import { expect, test } from 'vitest';
+
+test('package peers support every maintained Angular major', () => {
+  const packageJson = JSON.parse(
+    readFileSync(
+      resolve(process.cwd(), 'packages/angular/package.json'),
+      'utf8',
+    ),
+  ) as { peerDependencies: Record<string, string> };
+
+  expect(packageJson.peerDependencies['@angular/common']).toBe(
+    '^20.0.0 || ^21.0.0 || ^22.0.0',
+  );
+  expect(packageJson.peerDependencies['@angular/core']).toBe(
+    '^20.0.0 || ^21.0.0 || ^22.0.0',
+  );
 });

--- a/scripts/verify-angular-22-consumer.mjs
+++ b/scripts/verify-angular-22-consumer.mjs
@@ -1,0 +1,106 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const workspaceRoot = resolve(import.meta.dirname, '..');
+const consumerRoot = mkdtempSync(join(tmpdir(), 'hashbrown-angular-22-'));
+const packagesRoot = join(consumerRoot, 'packages');
+
+function run(command, args, cwd = workspaceRoot) {
+  execFileSync(command, args, { cwd, stdio: 'inherit' });
+}
+
+function pack(packageRoot) {
+  const output = execFileSync(
+    'npm',
+    ['pack', packageRoot, '--pack-destination', packagesRoot, '--json'],
+    { cwd: workspaceRoot, encoding: 'utf8' },
+  );
+  const result = JSON.parse(output);
+  if (!Array.isArray(result) || typeof result[0]?.filename !== 'string') {
+    throw new Error(
+      `npm pack returned an unexpected result for ${packageRoot}`,
+    );
+  }
+  return join(packagesRoot, result[0].filename);
+}
+
+try {
+  mkdirSync(packagesRoot, { recursive: true });
+  const coreTarball = pack('dist/packages/core');
+  const angularTarball = pack('dist/packages/angular');
+
+  writeFileSync(
+    join(consumerRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'hashbrown-angular-22-consumer',
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@angular/common': '22.0.7',
+          '@angular/core': '22.0.7',
+          '@angular/platform-browser': '22.0.7',
+          '@hashbrownai/angular': `file:${angularTarball}`,
+          '@hashbrownai/core': `file:${coreTarball}`,
+          rxjs: '7.8.2',
+          tslib: '2.8.1',
+        },
+        devDependencies: {
+          typescript: '5.9.3',
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          lib: ['ES2022', 'DOM'],
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          // Hashbrown core exposes QuickJS implementation types from its
+          // declarations; this compatibility check is scoped to Angular's
+          // public provider surface and peer resolution.
+          skipLibCheck: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        files: ['main.ts'],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'main.ts'),
+    `import type { ApplicationConfig } from '@angular/core';\n` +
+      `import { provideHashbrown } from '@hashbrownai/angular';\n\n` +
+      `export const appConfig: ApplicationConfig = {\n` +
+      `  providers: [provideHashbrown({ baseUrl: '/api/chat' })],\n` +
+      `};\n`,
+  );
+
+  run(
+    'npm',
+    [
+      'install',
+      '--strict-peer-deps',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+    ],
+    consumerRoot,
+  );
+  run('npx', ['tsc', '--project', 'tsconfig.json'], consumerRoot);
+  console.log(
+    'Packed @hashbrownai/angular consumer is compatible with Angular 22.',
+  );
+} finally {
+  rmSync(consumerRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- extend the stable Angular package peer range through Angular 22
- replace the dummy test with a maintained-major package contract
- pack local core and Angular artifacts into a clean Angular 22.0.7 / TypeScript 5.9.3 consumer in CI

## Validation

- `npx nx run-many -t build --projects=core,angular`
- `node scripts/verify-angular-22-consumer.mjs`
- `npx nx test angular`
- `npx nx lint angular`
- `npx nx build-api-report angular`
- `actionlint .github/workflows/pr-main.yml`

Supports CopilotKit/CopilotKit#6095; a stable release is required before that consumer can remove its external merge blocker.