### PR TITLE
ci: enable manual Cloudflare production fallback

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -84,7 +84,9 @@ jobs:
 
   cloudflare-production:
     name: Cloudflare Production
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
     needs: ci
     runs-on: ubuntu-latest
     permissions:

--- a/tools/cloudflare/workflow.test.mjs
+++ b/tools/cloudflare/workflow.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const workflowPath = new URL(
+  '../../.github/workflows/pr-main.yml',
+  import.meta.url,
+);
+
+test('allows production deployment from a main push or manual dispatch', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(
+    workflow,
+    /cloudflare-production:[\s\S]*?if: >-\n\s+\(github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\) \|\|\n\s+github\.event_name == 'workflow_dispatch'/,
+  );
+});


### PR DESCRIPTION
## Summary

- allow the unified production job to run for `workflow_dispatch` as well as pushes to `main`
- add a regression test for the workflow trigger contract

## Context

GitHub did not emit a push event for the merge of #500, so no automatic run was created. The unified workflow already declared `workflow_dispatch`, but its production job skipped manual runs. This restores the intended fallback without changing automatic deployment behavior.

## Verification

- `npx nx test cloudflare-deployment` (94 tests)
- `npx nx lint cloudflare-deployment`
- `npx prettier --check .github/workflows/pr-main.yml tools/cloudflare/workflow.test.mjs`
- `actionlint .github/workflows/pr-main.yml`