### PR TITLE
ci: update GitHub actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,13 +11,13 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -56,14 +56,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout pull request head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -93,13 +93,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/docs/security/dependency-audit-2026-08-07.md
+++ b/docs/security/dependency-audit-2026-08-07.md
@@ -19,27 +19,40 @@ Diagnostics used Node.js v24.18.0 and npm 11.16.0.
 | Full       |    99 |   5 |       36 |   57 |        1 |
 | Production |    28 |   2 |        5 |   21 |        0 |
 
-The sole critical finding is Velocity.js 2.1.6. It is development-only through
-Serverless Offline 14.7.4 and is not part of the deployed application runtime.
-It still affects local and CI development surfaces and therefore remains a
-required remediation item.
+`npm audit --omit=dev` follows package metadata and dependency paths; it does
+not prove that a package is reachable in a deployed bundle. Repository use
+provides a more specific exposure classification:
 
-The production audit groups findings through Analog content and router
-packages, the Angular 20.3.25 runtime, Model Context Protocol SDK 1.29.0, Nx and
-Devkit packages, Mermaid 10.9.6, and PostCSS 8.5.16 and its transitive
-dependencies. Some paths are exercised during builds or development-server
-operation, while others can reach deployed runtime code. Build and development
-exposure is distinct from deployed runtime exposure, but neither category is
-dismissed by this triage.
+- **Deployed browser or server runtime:** Angular 20.3.25 runtime packages are
+  used by deployed applications. Analog content and router packages are
+  imported by the `www` app, including its server entry points.
+- **Sample runtime:** Model Context Protocol SDK 1.29.0 is imported by Spotify
+  sample client and server code. Spotify is not one of the four current
+  Cloudflare production deployments.
+- **Build and development tooling:** Nx and Devkit packages and PostCSS 8.5.16
+  paths are used in build or development workflows. The sole critical finding,
+  Velocity.js 2.1.6 through Serverless Offline 14.7.4, is development-only. It
+  still affects local and CI development surfaces and requires remediation.
+- **Removal candidate:** No Mermaid 10.9.6 source import was found in the
+  repository. Its need should be verified and it should be removed if unused,
+  rather than assumed to be deployed.
 
 ## Dependency Tree Caveat
 
 The baseline peer dependency tree is not known to be healthy. A reused install
-contained 17 extraneous nested packages and could allow `npm ls` to pass. A
-clean npm 11 install from the committed lockfile instead reports invalid mixed
-Nx and SWC peer dependencies. Results from the reused installation are
-therefore not evidence that the committed dependency tree can be reproduced
-cleanly.
+contained 17 extraneous nested packages and could allow `npm ls` to pass. The
+reproducible clean baseline check with Node.js 24 and npm 11 is:
+
+```sh
+npm ci
+npm ls --all
+```
+
+This clean-install check from the committed lockfile produced the invalid mixed
+Nx and SWC peer result. No retained artifact from that run is available, so
+future migration pull requests must rerun the check and preserve its result in
+CI. Results from the reused installation are not evidence that the committed
+dependency tree can be reproduced cleanly.
 
 ## Disposable Resolution Experiments
 
@@ -78,9 +91,11 @@ baseline.
 
 ## Remediation Order
 
-1. Align or migrate the entire Nx toolchain first. Nx 23 is the likely target
-   because the applicable advisories require it. Validate every affected lint,
-   test, build, and end-to-end target after the migration.
+1. Align or migrate the entire Nx toolchain first. npm currently proposes
+   Nx 23.1.1 for this mixed manifest, but the migration must evaluate the lowest
+   supported, fully aligned patched Nx release, including patched Nx 22, before
+   choosing Nx 22 or Nx 23. Validate every affected lint, test, build, and
+   end-to-end target after the migration.
 2. Update the Angular runtime to 20.3.27 and align the Angular build tooling.
 3. Refresh Model Context Protocol SDK 1.30, Mermaid 10.9.8, PostCSS 8.5.26,
    Serverless Offline 14.8 with Velocity.js 2.1.7, and Verdaccio 6.9.2, then

--- a/docs/security/dependency-audit-2026-08-07.md
+++ b/docs/security/dependency-audit-2026-08-07.md
@@ -1,0 +1,99 @@
+# Dependency Audit Triage: 2026-08-07
+
+## Decision
+
+The current dependency findings do not block the GitHub Actions v7 maintenance
+pull request. That pull request changes the runtime used by GitHub-owned actions
+and does not change application dependencies or npm release behavior.
+
+Dependency remediation must begin with alignment of the complete Nx toolchain.
+An audit CI gate should not be added until the baseline has been intentionally
+reduced and the resulting dependency tree is valid and reproducible.
+
+## Current Committed Lockfile
+
+Diagnostics used Node.js v24.18.0 and npm 11.16.0.
+
+| Scope      | Total | Low | Moderate | High | Critical |
+| ---------- | ----: | --: | -------: | ---: | -------: |
+| Full       |    99 |   5 |       36 |   57 |        1 |
+| Production |    28 |   2 |        5 |   21 |        0 |
+
+The sole critical finding is Velocity.js 2.1.6. It is development-only through
+Serverless Offline 14.7.4 and is not part of the deployed application runtime.
+It still affects local and CI development surfaces and therefore remains a
+required remediation item.
+
+The production audit groups findings through Analog content and router
+packages, the Angular 20.3.25 runtime, Model Context Protocol SDK 1.29.0, Nx and
+Devkit packages, Mermaid 10.9.6, and PostCSS 8.5.16 and its transitive
+dependencies. Some paths are exercised during builds or development-server
+operation, while others can reach deployed runtime code. Build and development
+exposure is distinct from deployed runtime exposure, but neither category is
+dismissed by this triage.
+
+## Dependency Tree Caveat
+
+The baseline peer dependency tree is not known to be healthy. A reused install
+contained 17 extraneous nested packages and could allow `npm ls` to pass. A
+clean npm 11 install from the committed lockfile instead reports invalid mixed
+Nx and SWC peer dependencies. Results from the reused installation are
+therefore not evidence that the committed dependency tree can be reproduced
+cleanly.
+
+## Disposable Resolution Experiments
+
+Two experiments were used to evaluate remediation boundaries. Both were
+disposable: all manifest and lockfile changes were discarded. No force,
+`legacy-peer-deps`, override, dependency downgrade, or package change was
+retained.
+
+### Full clean lock regeneration
+
+A clean regeneration reduced the full audit to 59 findings: 2 low, 27 moderate,
+30 high, and 0 critical. The production audit fell to 3 findings, all high.
+
+The resulting tree was invalid. `npm ls` reported invalid `chokidar`,
+`@nx/eslint`, `@swc-node/register`, and `@swc/core` packages, plus an extraneous
+`@swc/wasm` package. The audit improvement therefore could not be retained as a
+valid dependency update.
+
+### Non-forcing audit fix
+
+`npm audit fix --package-lock-only --ignore-scripts` reduced the full audit to
+73 findings: 3 low, 26 moderate, 44 high, and 0 critical. The production audit
+fell to 14 findings: 0 low, 1 moderate, 13 high, and 0 critical.
+
+This result was also invalid. npm deduplicated `@nx/vite` 22.7.8 into the
+Nx 21-era `@nx/eslint` and SWC package set, after which `npm ls` failed. The
+non-forcing audit fix was not suitable for the current mixed-major manifest.
+
+## Root Cause
+
+The root manifest mixes Nx 21.5 and 21.6 packages with `@nx/vite` `^22.7.6`.
+The current lockfile preserves nested copies that mask parts of this mismatch.
+npm 11 re-resolution and deduplication expose the invalid Nx and SWC peer
+relationships, so a security-only lockfile refresh cannot safely resolve the
+baseline.
+
+## Remediation Order
+
+1. Align or migrate the entire Nx toolchain first. Nx 23 is the likely target
+   because the applicable advisories require it. Validate every affected lint,
+   test, build, and end-to-end target after the migration.
+2. Update the Angular runtime to 20.3.27 and align the Angular build tooling.
+3. Refresh Model Context Protocol SDK 1.30, Mermaid 10.9.8, PostCSS 8.5.26,
+   Serverless Offline 14.8 with Velocity.js 2.1.7, and Verdaccio 6.9.2, then
+   re-run full and production audits.
+4. Handle compatibility work separately for React Router 7, SWC CLI 0.8.1,
+   esbuild 0.28.1, Analog and its platform dependencies, exact-pinned Wrangler,
+   and the Serverless downgrade advisory.
+
+These steps must produce both lower audit totals and a clean dependency-tree
+validation from a fresh install. Audit totals alone are not sufficient.
+
+## Release Boundary
+
+npm publishing remains independent of the GitHub Actions and dependency
+triage work. This document changes no release trigger, permission, package, or
+publishing behavior.

--- a/docs/security/dependency-audit-2026-08-07.md
+++ b/docs/security/dependency-audit-2026-08-07.md
@@ -24,8 +24,12 @@ not prove that a package is reachable in a deployed bundle. Repository use
 provides a more specific exposure classification:
 
 - **Deployed browser or server runtime:** Angular 20.3.25 runtime packages are
-  used by deployed applications. Analog content and router packages are
-  imported by the `www` app, including its server entry points.
+  used by deployed applications.
+- **Deployed application with unverified vulnerable-path reachability:** Analog
+  content and router packages are used by the deployed `www` application,
+  including its server entry points, but the audit advisory path runs through
+  `sharp`. Whether that vulnerable `sharp` path is reachable in the deployed
+  application remains unverified pending bundle and runtime-path inspection.
 - **Sample runtime:** Model Context Protocol SDK 1.29.0 is imported by Spotify
   sample client and server code. Spotify is not one of the four current
   Cloudflare production deployments.
@@ -97,9 +101,10 @@ baseline.
    choosing Nx 22 or Nx 23. Validate every affected lint, test, build, and
    end-to-end target after the migration.
 2. Update the Angular runtime to 20.3.27 and align the Angular build tooling.
-3. Refresh Model Context Protocol SDK 1.30, Mermaid 10.9.8, PostCSS 8.5.26,
-   Serverless Offline 14.8 with Velocity.js 2.1.7, and Verdaccio 6.9.2, then
-   re-run full and production audits.
+3. Refresh Model Context Protocol SDK 1.30, PostCSS 8.5.26, Serverless Offline
+   14.8 with Velocity.js 2.1.7, and Verdaccio 6.9.2. Remove Mermaid if confirmed
+   unused; otherwise upgrade it to 10.9.8. Then re-run full and production
+   audits.
 4. Handle compatibility work separately for React Router 7, SWC CLI 0.8.1,
    esbuild 0.28.1, Analog and its platform dependencies, exact-pinned Wrangler,
    and the Serverless downgrade advisory.

--- a/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
+++ b/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
@@ -1,0 +1,265 @@
+# GitHub Actions and Dependency Security Maintenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove GitHub Actions runtime deprecation warnings and reduce npm audit findings with compatible dependency updates.
+
+**Architecture:** Preserve the unified deployment and independent npm publishing workflows while moving GitHub-owned actions to their Node 24-based v7 releases. Refresh only dependencies already allowed by `package.json`, then record residual findings by the migration required to fix them.
+
+**Tech Stack:** GitHub Actions YAML, Node.js 24, npm lockfiles and audit, Nx, Node test runner
+
+---
+
+## File Map
+
+- Modify `.github/workflows/pr-main.yml`: use current checkout and Node setup action majors.
+- Modify `.github/workflows/npm-publish.yml`: use the same action majors without changing trusted publishing.
+- Modify `.github/workflows/nightly.yml`: use the same action majors.
+- Modify `tools/cloudflare/workflow.test.mjs`: prevent workflow action versions from regressing.
+- Modify `package.json`: raise vulnerable dependency minimums within compatible release lines.
+- Modify `package-lock.json`: regenerate the dependency graph with Node 24 and npm 11.
+- Create `docs/security/dependency-audit-2026-08-07.md`: record audit improvement and remaining migration groups.
+
+### Task 1: Protect the workflow runtime versions
+
+**Files:**
+- Modify: `tools/cloudflare/workflow.test.mjs`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add all three workflow paths and this top-level test:
+
+```js
+test('uses Node 24-based GitHub actions in every workflow', async () => {
+  const workflows = await Promise.all(
+    workflowPaths.map(async (workflowPath) => ({
+      workflowPath,
+      contents: await readFile(workflowPath, 'utf8'),
+    })),
+  );
+
+  for (const { workflowPath, contents } of workflows) {
+    const actionReferences = [
+      ...contents.matchAll(/actions\/(checkout|setup-node)@(\S+)/g),
+    ];
+
+    assert.ok(actionReferences.length > 0);
+
+    for (const [, action, version] of actionReferences) {
+      assert.equal(
+        version,
+        'v7',
+        `${workflowPath.pathname} uses actions/${action}@${version}`,
+      );
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `node --test tools/cloudflare/workflow.test.mjs`
+
+Expected: FAIL because the workflows still reference v4.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tools/cloudflare/workflow.test.mjs
+git commit -m "test: require Node 24 GitHub actions"
+```
+
+### Task 2: Upgrade GitHub-owned actions
+
+**Files:**
+- Modify: `.github/workflows/pr-main.yml`
+- Modify: `.github/workflows/npm-publish.yml`
+- Modify: `.github/workflows/nightly.yml`
+
+- [ ] **Step 1: Apply the minimal workflow changes**
+
+Replace every `actions/checkout@v4` and `actions/setup-node@v4` reference with
+`@v7`. Do not change triggers, permissions, inputs, jobs, or deployment commands.
+
+- [ ] **Step 2: Run the focused test and verify it passes**
+
+Run: `node --test tools/cloudflare/workflow.test.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 3: Validate workflow formatting and syntax**
+
+Run: `npx prettier --check .github/workflows/pr-main.yml .github/workflows/npm-publish.yml .github/workflows/nightly.yml tools/cloudflare/workflow.test.mjs`
+
+Run when installed: `actionlint .github/workflows/pr-main.yml .github/workflows/npm-publish.yml .github/workflows/nightly.yml`
+
+Expected: PASS. If `actionlint` is unavailable, report that and rely on repository tests plus GitHub validation.
+
+- [ ] **Step 4: Commit the workflow update**
+
+```bash
+git add .github/workflows/pr-main.yml .github/workflows/npm-publish.yml .github/workflows/nightly.yml
+git commit -m "ci: update GitHub actions to Node 24 runtimes"
+```
+
+### Task 3: Refresh compatible vulnerable dependencies
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Capture the baseline**
+
+Run: `npm audit --json`
+
+Expected baseline: 99 total findings: 5 low, 36 moderate, 57 high, and 1 critical. Production-only baseline: 28 total findings: 2 low, 5 moderate, 21 high, and 0 critical.
+
+- [ ] **Step 2: Confirm the lockfile toolchain**
+
+Run: `node --version`
+
+Expected: `v24.18.0`, matching `.nvmrc`.
+
+Run: `npm --version`
+
+Expected: npm 11.
+
+- [ ] **Step 3: Raise compatible dependency minimums**
+
+Update the manifest to these minimums without changing major release lines:
+
+- Angular runtime packages and `@angular/compiler-cli`: `^20.3.27`
+- `@modelcontextprotocol/sdk`: `^1.30.0`
+- `mermaid`: `^10.9.8`
+- `postcss`: `^8.5.26`
+- `serverless-offline`: `^14.8.0`
+- `verdaccio`: `^6.9.2`
+
+- [ ] **Step 4: Regenerate the lockfile with the CI toolchain**
+
+Back up the existing lockfile outside the worktree, remove the worktree copy,
+then run:
+
+`npm install --package-lock-only --ignore-scripts`
+
+Expected: PASS and a new lockfile. This procedure is required because npm 11's
+targeted `npm update --package-lock-only` leaves the locked dependency graph
+unchanged in this repository.
+
+Expected resolved targets include Angular 20.3.27, MCP SDK 1.30.x,
+Mermaid 10.9.8, PostCSS 8.5.26, Serverless Offline 14.8.x, Verdaccio 6.9.2,
+and Velocity.js 2.1.7 transitively.
+
+- [ ] **Step 5: Review lockfile scope**
+
+Run: `git diff --stat package-lock.json`
+
+Run: `git diff -- package-lock.json`
+
+Expected: dependency resolution changes only; no dependency crosses a declared
+release line and no forced downgrade or override is introduced. A full npm 11
+regeneration is expected to remove stale transitive entries.
+
+- [ ] **Step 6: Reinstall exactly from the lockfile**
+
+Run: `npm ci`
+
+Expected: PASS.
+
+- [ ] **Step 7: Validate peer dependencies**
+
+Run: `npm ls --all`
+
+Expected: PASS with no invalid or missing peer dependency.
+
+- [ ] **Step 8: Re-run full and production audits**
+
+Run: `npm audit --json`
+
+Run: `npm audit --omit=dev --json`
+
+Expected from the disposable Node 24/npm 11 regeneration: 59 full findings
+(2 low, 27 moderate, 30 high, 0 critical) and 3 production findings (all high,
+from the deferred Nx migration). The critical Velocity.js and patched Angular
+findings must be removed. Do not force fixes for residual findings.
+
+- [ ] **Step 9: Commit the compatible refresh**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: refresh compatible security fixes"
+```
+
+### Task 4: Document residual audit findings
+
+**Files:**
+- Create: `docs/security/dependency-audit-2026-08-07.md`
+
+- [ ] **Step 1: Write the audit record**
+
+Record:
+
+- baseline and final full/production severity totals;
+- compatible packages refreshed in this pull request;
+- residual groups requiring separate work: Nx 23, React Router 7, Analog/sharp,
+  Wrangler and Serverless downgrade advisories, and remaining build-only tooling;
+- why `npm audit fix --force`, dependency overrides, and unsafe downgrades were not used.
+
+- [ ] **Step 2: Verify the record against the current audit**
+
+Run both audit commands again and compare every documented total.
+
+- [ ] **Step 3: Commit the audit record**
+
+```bash
+git add docs/security/dependency-audit-2026-08-07.md
+git commit -m "docs: triage residual dependency advisories"
+```
+
+### Task 5: Verify and publish the maintenance pull request
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run repository-specific deployment tests**
+
+Run: `npx nx test cloudflare-deployment`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run affected validation**
+
+Run: `npx nx affected -t lint,test,build,e2e --base=origin/main --head=HEAD --parallel=3`
+
+Expected: PASS for every affected target.
+
+- [ ] **Step 3: Verify publishing remains independent**
+
+Inspect `.github/workflows/npm-publish.yml` and confirm it still triggers only on
+`npm/preview` and `npm/latest`, retains `id-token: write`, and has no Cloudflare
+job or dependency.
+
+- [ ] **Step 4: Run final hygiene checks**
+
+Run: `git diff --check origin/main...HEAD`
+
+Run: `git status --short --branch`
+
+Expected: no whitespace errors and a clean branch.
+
+- [ ] **Step 5: Push and open the pull request**
+
+Push `blove/actions-security-maintenance` and open a ready pull request against
+`main` with the audit before/after totals in its description.
+
+- [ ] **Step 6: Merge only after required validation is green**
+
+Confirm `PR / Main CI / PR Gate` succeeds, then squash-merge. Do not merge while
+validation or previews are failing.
+
+- [ ] **Step 7: Remove the obsolete worktree**
+
+From `/Users/blove/repos/hashbrown`, verify
+`/Users/blove/repos/hashbrown/.worktrees/cloudflare-deployment-implementation`
+is clean, remove that worktree, and verify it no longer appears in
+`git worktree list`.

--- a/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
+++ b/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
@@ -1,5 +1,21 @@
 # GitHub Actions and Dependency Security Maintenance Implementation Plan
 
+## Execution Outcome (Authoritative)
+
+> **Completed with dependency refresh discarded.** The GitHub Actions v7 and
+> audit-triage work was completed. The planned `package.json` and
+> `package-lock.json` refresh was attempted only in disposable, restorable
+> diagnostics; those attempts introduced or revealed invalid mixed Nx/SWC peer
+> dependency trees, so every dependency change was discarded. `package.json`
+> and `package-lock.json` remain unchanged. All dependency-edit steps in this
+> plan are superseded and must not be executed. The authoritative follow-up is
+> `docs/security/dependency-audit-2026-08-07.md`, beginning with a fully aligned
+> patched Nx migration.
+
+This plan is retained only as historical execution context. It is not an
+active runbook; in particular, Task 3 and every instruction to modify or
+regenerate dependency files are superseded by the outcome above.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Remove GitHub Actions runtime deprecation warnings and reduce npm audit findings with compatible dependency updates.
@@ -104,7 +120,13 @@ git add .github/workflows/pr-main.yml .github/workflows/npm-publish.yml .github/
 git commit -m "ci: update GitHub actions to Node 24 runtimes"
 ```
 
-### Task 3: Refresh compatible vulnerable dependencies
+### Task 3: Refresh compatible vulnerable dependencies (Superseded - Do Not Execute)
+
+> **Historical record only:** Do not execute any step in Task 3. Disposable,
+> restorable diagnostics found invalid mixed Nx/SWC peer dependency trees, all
+> resulting dependency changes were discarded, and `package.json` and
+> `package-lock.json` remain unchanged. Follow
+> `docs/security/dependency-audit-2026-08-07.md` instead.
 
 **Files:**
 

--- a/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
+++ b/docs/superpowers/plans/2026-08-07-actions-security-maintenance.md
@@ -23,6 +23,7 @@
 ### Task 1: Protect the workflow runtime versions
 
 **Files:**
+
 - Modify: `tools/cloudflare/workflow.test.mjs`
 
 - [ ] **Step 1: Write the failing regression test**
@@ -72,6 +73,7 @@ git commit -m "test: require Node 24 GitHub actions"
 ### Task 2: Upgrade GitHub-owned actions
 
 **Files:**
+
 - Modify: `.github/workflows/pr-main.yml`
 - Modify: `.github/workflows/npm-publish.yml`
 - Modify: `.github/workflows/nightly.yml`
@@ -105,6 +107,7 @@ git commit -m "ci: update GitHub actions to Node 24 runtimes"
 ### Task 3: Refresh compatible vulnerable dependencies
 
 **Files:**
+
 - Modify: `package.json`
 - Modify: `package-lock.json`
 
@@ -193,6 +196,7 @@ git commit -m "chore: refresh compatible security fixes"
 ### Task 4: Document residual audit findings
 
 **Files:**
+
 - Create: `docs/security/dependency-audit-2026-08-07.md`
 
 - [ ] **Step 1: Write the audit record**
@@ -219,6 +223,7 @@ git commit -m "docs: triage residual dependency advisories"
 ### Task 5: Verify and publish the maintenance pull request
 
 **Files:**
+
 - Verify all changed files.
 
 - [ ] **Step 1: Run repository-specific deployment tests**

--- a/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
+++ b/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
@@ -1,5 +1,21 @@
 # GitHub Actions and Dependency Security Maintenance
 
+## Execution Outcome (Authoritative)
+
+> **Completed with dependency refresh discarded.** The GitHub Actions v7 and
+> audit-triage work was completed. The planned `package.json` and
+> `package-lock.json` refresh was attempted only in disposable, restorable
+> diagnostics; those attempts introduced or revealed invalid mixed Nx/SWC peer
+> dependency trees, so every dependency change was discarded. `package.json`
+> and `package-lock.json` remain unchanged. All dependency-edit steps described
+> below are superseded and must not be executed. The authoritative follow-up is
+> `docs/security/dependency-audit-2026-08-07.md`, beginning with a fully aligned
+> patched Nx migration.
+
+The remainder of this document is retained only as historical design and
+execution context. Where it proposes dependency edits, the outcome above takes
+precedence.
+
 ## Goal
 
 Remove the GitHub Actions Node 20 runtime warnings and reduce the current npm

--- a/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
+++ b/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
@@ -31,14 +31,16 @@ The pull request will not:
 
 ## Implementation
 
-All three workflows will use the current official major versions of GitHub's
-checkout and Node setup actions. Existing workflow regression tests will be
-extended only if they currently assert action versions or deployment behavior.
+All three workflows will use v7 of GitHub's checkout and Node setup actions.
+Existing workflow regression tests will verify every reference, rather than
+only checking that each workflow contains at least one current reference.
 
-The dependency lockfile will be refreshed from the existing manifest. Each
-resulting direct dependency change will be reviewed before it is kept. Changes
-that cross a declared range or introduce an incompatible peer dependency will
-be reverted from this pull request and listed as follow-up work instead.
+Compatible direct dependency minimums will be raised within their existing
+major release lines, then the dependency lockfile will be regenerated with the
+Node and npm versions used by CI. Each resulting direct dependency change will
+be reviewed before it is kept. Changes that cross a compatible release line or
+introduce an incompatible peer dependency will be reverted from this pull
+request and listed as follow-up work instead.
 
 ## Validation
 
@@ -58,6 +60,10 @@ clean-state check.
 
 ## Follow-Up Boundary
 
-Residual findings will be grouped by upgrade boundary, especially Nx, React
-Router, Analog, and build-only tooling. Those migrations should be handled in
-separate pull requests with their own compatibility testing.
+Residual findings will be recorded in
+`docs/security/dependency-audit-2026-08-07.md` and grouped by upgrade boundary,
+especially Nx, React Router, Analog, and build-only tooling. Those migrations
+should be handled in separate pull requests with their own compatibility
+testing. After merge, only
+`/Users/blove/repos/hashbrown/.worktrees/cloudflare-deployment-implementation`
+will be removed.

--- a/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
+++ b/docs/superpowers/specs/2026-08-07-actions-security-maintenance-design.md
@@ -1,0 +1,63 @@
+# GitHub Actions and Dependency Security Maintenance
+
+## Goal
+
+Remove the GitHub Actions Node 20 runtime warnings and reduce the current npm
+audit findings without coupling deployment maintenance to major framework
+migrations.
+
+## Scope
+
+The maintenance pull request will:
+
+- update every `actions/checkout` and `actions/setup-node` reference to the
+  current Node 24-based major release;
+- preserve the existing Node version, npm caching, permissions, release tags,
+  and Cloudflare deployment behavior;
+- refresh dependencies only within the version ranges already declared in
+  `package.json`;
+- accept direct patch or minor upgrades when their existing test coverage and
+  affected-project validation pass;
+- record unresolved findings that require a major migration or a risky
+  downgrade as follow-up work.
+
+The pull request will not:
+
+- run `npm audit fix --force`;
+- downgrade packages to versions suggested by npm when doing so would undo the
+  current application architecture;
+- combine Nx 23 or React Router 7 migrations with deployment maintenance;
+- change npm publishing or Cloudflare deployment triggers.
+
+## Implementation
+
+All three workflows will use the current official major versions of GitHub's
+checkout and Node setup actions. Existing workflow regression tests will be
+extended only if they currently assert action versions or deployment behavior.
+
+The dependency lockfile will be refreshed from the existing manifest. Each
+resulting direct dependency change will be reviewed before it is kept. Changes
+that cross a declared range or introduce an incompatible peer dependency will
+be reverted from this pull request and listed as follow-up work instead.
+
+## Validation
+
+Before opening the pull request:
+
+1. Validate workflow YAML and repository-specific deployment tests.
+2. Run `npm ci` from the updated lockfile.
+3. Run the audit again and compare severity totals with the baseline of 99
+   findings: 5 low, 36 moderate, 57 high, and 1 critical.
+4. Run Nx affected lint, test, build, and e2e targets.
+5. Confirm the npm publishing workflow remains tag-driven and independent from
+   Cloudflare deployment.
+
+The pull request will be squash-merged only after `PR / Main CI / PR Gate` is
+green. The obsolete Cloudflare cutover worktree will then be removed after a
+clean-state check.
+
+## Follow-Up Boundary
+
+Residual findings will be grouped by upgrade boundary, especially Nx, React
+Router, Analog, and build-only tooling. Those migrations should be handled in
+separate pull requests with their own compatibility testing.

--- a/tools/cloudflare/workflow.test.mjs
+++ b/tools/cloudflare/workflow.test.mjs
@@ -6,6 +6,11 @@ const workflowPath = new URL(
   '../../.github/workflows/pr-main.yml',
   import.meta.url,
 );
+const workflowPaths = [
+  workflowPath,
+  new URL('../../.github/workflows/npm-publish.yml', import.meta.url),
+  new URL('../../.github/workflows/nightly.yml', import.meta.url),
+];
 
 test('allows production deployment from a main push or manual dispatch', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
@@ -14,4 +19,28 @@ test('allows production deployment from a main push or manual dispatch', async (
     workflow,
     /cloudflare-production:[\s\S]*?if: >-\n\s+\(github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\) \|\|\n\s+github\.event_name == 'workflow_dispatch'/,
   );
+});
+
+test('uses Node 24 action runtimes in every workflow', async () => {
+  const workflows = await Promise.all(
+    workflowPaths.map(async (path) => ({
+      path,
+      contents: await readFile(path, 'utf8'),
+    })),
+  );
+
+  const actionReferences = workflows.flatMap(({ path, contents }) =>
+    [...contents.matchAll(/actions\/(checkout|setup-node)@([^\s#]+)/g)].map(
+      ([reference, action, version]) => ({ path, reference, action, version }),
+    ),
+  );
+
+  assert.ok(actionReferences.length > 0);
+  for (const { path, reference, action, version } of actionReferences) {
+    assert.equal(
+      version,
+      'v7',
+      `${path.pathname}: ${reference} must use actions/${action}@v7`,
+    );
+  }
 });

--- a/tools/cloudflare/workflow.test.mjs
+++ b/tools/cloudflare/workflow.test.mjs
@@ -1,16 +1,56 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 const workflowPath = new URL(
   '../../.github/workflows/pr-main.yml',
   import.meta.url,
 );
-const workflowPaths = [
-  workflowPath,
-  new URL('../../.github/workflows/npm-publish.yml', import.meta.url),
-  new URL('../../.github/workflows/nightly.yml', import.meta.url),
-];
+const workflowDirectoryPath = new URL(
+  '../../.github/workflows/',
+  import.meta.url,
+);
+const actionUsePattern =
+  /^\s*(?:-\s*)?uses:\s*(['"]?)(actions\/(?:checkout|setup-node))@([^\s#'"]+)\1\s*(?:#.*)?$/i;
+const blockScalarPattern =
+  /^\s*(?:-\s*)?[^#\s][^:]*:\s*[>|](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?$/;
+
+function findActionReferences(path, contents) {
+  const references = [];
+  let blockScalarIndent;
+
+  for (const [index, line] of contents.split(/\r?\n/).entries()) {
+    const indentation = line.length - line.trimStart().length;
+
+    if (blockScalarIndent !== undefined) {
+      if (line.trim() === '' || indentation > blockScalarIndent) {
+        continue;
+      }
+
+      blockScalarIndent = undefined;
+    }
+
+    if (blockScalarPattern.test(line)) {
+      blockScalarIndent = indentation;
+      continue;
+    }
+
+    const match = actionUsePattern.exec(line);
+    if (match) {
+      const [, , matchedAction, version] = match;
+
+      references.push({
+        path,
+        lineNumber: index + 1,
+        reference: `${matchedAction}@${version}`,
+        action: matchedAction.toLowerCase(),
+        version,
+      });
+    }
+  }
+
+  return references;
+}
 
 test('allows production deployment from a main push or manual dispatch', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
@@ -21,7 +61,14 @@ test('allows production deployment from a main push or manual dispatch', async (
   );
 });
 
-test('uses Node 24 action runtimes in every workflow', async () => {
+test('requires actions/checkout and actions/setup-node references to use v7', async () => {
+  const workflowEntries = await readdir(workflowDirectoryPath, {
+    withFileTypes: true,
+  });
+  const workflowPaths = workflowEntries
+    .filter((entry) => entry.isFile() && /\.ya?ml$/i.test(entry.name))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => new URL(entry.name, workflowDirectoryPath));
   const workflows = await Promise.all(
     workflowPaths.map(async (path) => ({
       path,
@@ -30,17 +77,24 @@ test('uses Node 24 action runtimes in every workflow', async () => {
   );
 
   const actionReferences = workflows.flatMap(({ path, contents }) =>
-    [...contents.matchAll(/actions\/(checkout|setup-node)@([^\s#]+)/g)].map(
-      ([reference, action, version]) => ({ path, reference, action, version }),
-    ),
+    findActionReferences(path, contents),
   );
 
-  assert.ok(actionReferences.length > 0);
-  for (const { path, reference, action, version } of actionReferences) {
+  assert.ok(
+    actionReferences.length > 0,
+    'expected at least one actions/checkout or actions/setup-node reference',
+  );
+  for (const {
+    path,
+    lineNumber,
+    reference,
+    action,
+    version,
+  } of actionReferences) {
     assert.equal(
       version,
       'v7',
-      `${path.pathname}: ${reference} must use actions/${action}@v7`,
+      `${path.pathname}:${lineNumber}: ${reference} must use ${action}@v7`,
     );
   }
 });


### PR DESCRIPTION
## Summary

- update every `actions/checkout` and `actions/setup-node` reference to the Node 24-based v7 releases
- add regression coverage across all repository workflows so those action versions cannot silently regress
- document the current dependency audit baseline, discarded unsafe remediation experiments, and the required Nx-first migration order

## Impact

This removes GitHub Actions Node 20 runtime deprecation warnings without changing workflow triggers, permissions, Cloudflare deployment behavior, nightly behavior, or npm trusted publishing.

No `package.json` or `package-lock.json` changes are included. The dependency audit found that the manifest mixes Nx 21 and Nx 22 packages; both a clean lock regeneration and a non-forcing audit fix produced invalid Nx/SWC peer trees. Those experiments were discarded and the follow-up is documented in `docs/security/dependency-audit-2026-08-07.md`.

## Verification

- `npm ci` with Node 24 and npm 11
- workflow regression tests: 2 passed
- Cloudflare deployment tooling: 95 tests passed
- `actionlint` for all workflows
- Prettier for all changed files
- Nx affected lint, test, build, and e2e validation passed; lint and test targets were scheduled
- `git diff --check origin/main...HEAD`
- npm publishing remains tag-driven, OIDC-enabled, and independent from Cloudflare

## Known Baseline

- full npm audit: 99 findings (5 low, 36 moderate, 57 high, 1 critical)
- production-scoped npm audit: 28 findings (2 low, 5 moderate, 21 high)
- clean-install dependency validation exposes three pre-existing mixed Nx/SWC peer issues; this branch does not change the dependency graph
