### PR TITLE
feat(core): add AG-UI event boundary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@ag-ui/core": "0.0.58",
         "@analogjs/content": "3.0.0-alpha.64",
         "@analogjs/router": "3.0.0-alpha.64",
         "@angular/animations": "22.1.1",
@@ -213,6 +214,15 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.58.tgz",
+      "integrity": "sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     ]
   },
   "dependencies": {
+    "@ag-ui/core": "0.0.58",
     "@analogjs/content": "3.0.0-alpha.64",
     "@analogjs/router": "3.0.0-alpha.64",
     "@angular/animations": "22.1.1",

--- a/packages/core/e2e/package-shape.e2e.spec.ts
+++ b/packages/core/e2e/package-shape.e2e.spec.ts
@@ -82,6 +82,9 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
             '@hashbrownai/core/package.json',
           );
           const packageJson = require(packageJsonPath);
+          if (packageJson.dependencies?.['@ag-ui/core'] !== '0.0.58') {
+            throw new Error('Core must declare an exact @ag-ui/core dependency');
+          }
           const cjs = require('@hashbrownai/core');
           const cjsPartialJson = require('@cacheplane/partial-json');
           const esm = await import(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ag-ui/core": "0.0.58",
     "@cacheplane/partial-json": "0.2.2"
   },
   "engines": {

--- a/packages/core/src/actions/api.actions.ts
+++ b/packages/core/src/actions/api.actions.ts
@@ -1,3 +1,4 @@
+import type { AGUIEvent } from '@ag-ui/core';
 import { createActionGroup, emptyProps, props } from '../utils/micro-ngrx';
 import { Chat } from '../models';
 import { s } from '../schema';
@@ -8,8 +9,7 @@ export default createActionGroup('api', {
     emulateStructuredOutput: boolean;
     toolsByName: Record<string, Chat.Internal.Tool>;
   }>(),
-  generateMessageChunk: props<Chat.Api.CompletionChunk>(),
-  generateMessageFinish: emptyProps(),
+  generateMessageEvent: props<AGUIEvent>(),
   generateMessageSuccess: props<{
     message: Chat.Internal.AssistantMessage;
     toolCalls: Chat.Internal.ToolCall[];

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1,3 +1,4 @@
+import { EventType } from '@ag-ui/core';
 import { Chat } from '../models';
 import { s } from '../schema';
 import { apiActions, devActions } from '../actions';
@@ -639,204 +640,435 @@ function mockSuccessfulSelection() {
   return send;
 }
 
-describe('generateMessage effect', () => {
-  const ModelResolverMock = jest.mocked(ModelResolver);
-  const decodeFramesMock = jest.mocked(decodeFrames);
+const ModelResolverMock = jest.mocked(ModelResolver);
+const decodeFramesMock = jest.mocked(decodeFrames);
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+type MockTransportResponse = {
+  frames?: AsyncIterable<unknown>;
+  stream?: AsyncIterable<unknown>;
+  dispose?: jest.Mock;
+  metadata?: unknown;
+};
 
-  type MockTransportResponse = {
-    frames?: AsyncIterable<unknown>;
-    stream?: AsyncIterable<unknown>;
-    dispose?: jest.Mock;
-    metadata?: unknown;
+function makeSelection(
+  transportResponseFactory: (request: {
+    signal: AbortSignal;
+  }) => Promise<MockTransportResponse>,
+) {
+  const send = jest.fn().mockImplementation(transportResponseFactory);
+  const selection = {
+    spec: { name: 'selected-model' },
+    transport: { send },
+    metadata: { chosenSpec: 'selected-model', skippedSpecs: [] },
+  };
+  ModelResolverMock.mockImplementation(
+    () =>
+      ({
+        select: jest.fn(async () => selection),
+        skipFromError: jest.fn(),
+        getMetadata: jest.fn(() => selection.metadata),
+      }) as unknown as ModelResolver,
+  );
+  return { send, selection };
+}
+
+test('dispatches AG-UI lifecycle events and success on happy path', async () => {
+  jest.clearAllMocks();
+  const messageChunk: Chat.Api.CompletionChunk = {
+    choices: [
+      {
+        index: 0,
+        delta: { role: 'assistant', content: 'Hello' },
+        finishReason: 'stop',
+      },
+    ],
   };
 
-  function makeSelection(
-    transportResponseFactory: () => Promise<MockTransportResponse>,
-  ) {
-    const send = jest.fn().mockImplementation(transportResponseFactory);
-    const selection = {
-      spec: { name: 'selected-model' },
-      transport: { send },
-      metadata: { chosenSpec: 'selected-model', skippedSpecs: [] },
-    };
-    ModelResolverMock.mockImplementation(
-      () =>
-        ({
-          select: jest.fn(async () => selection),
-          skipFromError: jest.fn(),
-          getMetadata: jest.fn(() => selection.metadata),
-        }) as unknown as ModelResolver,
-    );
-    return { send, selection };
-  }
+  const frames = async function* () {
+    yield { type: 'generation-start' as const };
+    yield { type: 'generation-chunk' as const, chunk: messageChunk };
+    yield { type: 'generation-finish' as const };
+  };
 
-  it('dispatches start, chunk, success, and finalize on happy path', async () => {
-    const messageChunk: Chat.Api.CompletionChunk = {
-      choices: [
+  const dispose = jest.fn();
+  const { send } = makeSelection(async () => ({
+    frames: frames(),
+    dispose,
+  }));
+
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [
+        selectRawStreamingMessage,
         {
-          index: 0,
-          delta: { role: 'assistant', content: 'Hello' },
-          finishReason: 'stop',
+          role: 'assistant',
+          content: 'Hello',
+          toolCallIds: [],
         },
       ],
-    };
+    ]),
+  );
+  const teardown = generateMessage(store);
 
-    const frames = async function* () {
-      yield { type: 'generation-start' as const };
-      yield { type: 'generation-chunk' as const, chunk: messageChunk };
-      yield { type: 'generation-finish' as const };
-    };
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
 
-    const dispose = jest.fn();
-    const { send } = makeSelection(async () => ({
-      frames: frames(),
-      dispose,
-    }));
-
-    const store = createTestStore(
-      new Map<SelectorKey, unknown>([
-        [
-          selectRawStreamingMessage,
-          {
-            role: 'assistant',
-            content: 'Hello',
-            toolCallIds: [],
-          },
-        ],
-      ]),
-    );
-    const teardown = generateMessage(store);
-
-    await store.trigger(
-      devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
-    );
-
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(decodeFramesMock).toHaveBeenCalled();
-    expect(store.actions.map((a) => a.type)).toEqual([
-      apiActions.generateMessageStart.type,
-      apiActions.generateMessageChunk.type,
-      apiActions.generateMessageFinish.type,
-      apiActions.generateMessageSuccess.type,
-      apiActions.assistantTurnFinalized.type,
-    ]);
-    expect(store.actions[1].payload).toMatchObject({
-      choices: [
-        {
-          delta: expect.objectContaining({
-            content: 'Hello',
-            role: 'assistant',
-          }),
-        },
-      ],
-    });
-    expect(store.actions[3].payload).toMatchObject({
-      message: {
-        role: 'assistant',
-        content: 'Hello',
-      },
-      toolCalls: [],
-    });
-    expect(dispose).toHaveBeenCalledTimes(1);
-
-    teardown?.();
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(decodeFramesMock).toHaveBeenCalled();
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageSuccess.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(store.actions[1].payload).toMatchObject({
+    type: EventType.RUN_STARTED,
+    threadId: expect.any(String),
+    runId: expect.any(String),
   });
+  expect(store.actions[2].payload).toMatchObject({
+    type: EventType.TEXT_MESSAGE_START,
+    messageId: expect.any(String),
+    role: 'assistant',
+  });
+  const runStarted = store.actions[1]?.payload as {
+    threadId: string;
+    runId: string;
+  };
+  const textStarted = store.actions[2]?.payload as { messageId: string };
+  expect(store.actions[3].payload).toMatchObject({
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId: textStarted.messageId,
+    delta: 'Hello',
+  });
+  expect(store.actions[4].payload).toMatchObject({
+    type: EventType.TEXT_MESSAGE_END,
+    messageId: textStarted.messageId,
+  });
+  expect(store.actions[5].payload).toMatchObject({
+    type: EventType.RUN_FINISHED,
+    threadId: runStarted.threadId,
+    runId: runStarted.runId,
+  });
+  expect(store.actions[6].payload).toMatchObject({
+    message: {
+      role: 'assistant',
+      content: 'Hello',
+    },
+    toolCalls: [],
+  });
+  expect(dispose).toHaveBeenCalledTimes(1);
 
-  it('retries on retryable transport errors and eventually succeeds', async () => {
-    const retries = 1;
+  teardown?.();
+});
 
-    let attempt = 0;
-    const messageChunk: Chat.Api.CompletionChunk = {
-      choices: [
-        {
-          index: 0,
-          delta: { role: 'assistant', content: 'Hi after retry' },
-          finishReason: 'stop',
-        },
-      ],
-    };
+test('retries on retryable transport errors and eventually succeeds', async () => {
+  jest.clearAllMocks();
+  const retries = 1;
 
-    const { send } = makeSelection(async () => {
-      attempt++;
-      if (attempt === 1) {
-        throw new TransportError('temporary boom', { retryable: true });
-      }
+  let attempt = 0;
+  const messageChunk: Chat.Api.CompletionChunk = {
+    choices: [
+      {
+        index: 0,
+        delta: { role: 'assistant', content: 'Hi after retry' },
+        finishReason: 'stop',
+      },
+    ],
+  };
+
+  const { send } = makeSelection(async () => {
+    attempt++;
+    if (attempt === 1) {
       return {
         frames: (async function* () {
           yield { type: 'generation-start' as const };
-          yield { type: 'generation-chunk' as const, chunk: messageChunk };
-          yield { type: 'generation-finish' as const };
+          throw new TransportError('temporary boom', { retryable: true });
         })(),
         dispose: jest.fn(),
       };
-    });
-
-    const store = createTestStore(
-      new Map<SelectorKey, unknown>([
-        [selectRetries, retries],
-        [
-          selectRawStreamingMessage,
-          {
-            role: 'assistant',
-            content: 'Hi after retry',
-            toolCallIds: [],
-          },
-        ],
-      ]),
-    );
-    const teardown = generateMessage(store);
-
-    await store.trigger(
-      devActions.sendMessage({
-        message: { role: 'user', content: 'retry me' },
-      }),
-    );
-
-    expect(send).toHaveBeenCalledTimes(2);
-    expect(store.actions.map((a) => a.type)).toEqual([
-      apiActions.generateMessageError.type,
-      apiActions.generateMessageStart.type,
-      apiActions.generateMessageChunk.type,
-      apiActions.generateMessageFinish.type,
-      apiActions.generateMessageSuccess.type,
-      apiActions.assistantTurnFinalized.type,
-      apiActions.generateMessageExhaustedRetries.type,
-    ]);
-    const chunkPayload = (store.actions[2].payload ??
-      {}) as Chat.Api.CompletionChunk;
-    expect(chunkPayload.choices[0]?.delta?.content).toBe('Hi after retry');
-
-    teardown?.();
+    }
+    return {
+      frames: (async function* () {
+        yield { type: 'generation-start' as const };
+        yield { type: 'generation-chunk' as const, chunk: messageChunk };
+        yield { type: 'generation-finish' as const };
+      })(),
+      dispose: jest.fn(),
+    };
   });
 
-  it('dispatches exhausted retries after max retryable failures', async () => {
-    const retries = 1;
-    const error = new Error('still broken');
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, retries],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Hi after retry',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
 
-    makeSelection(async () => {
-      throw error;
-    });
+  await store.trigger(
+    devActions.sendMessage({
+      message: { role: 'user', content: 'retry me' },
+    }),
+  );
 
-    const store = createTestStore(
-      new Map<SelectorKey, unknown>([[selectRetries, retries]]),
-    );
-    const teardown = generateMessage(store);
-
-    await store.trigger(
-      devActions.sendMessage({ message: { role: 'user', content: 'fail' } }),
-    );
-
-    expect(store.actions.map((a) => a.type)).toEqual([
-      apiActions.generateMessageError.type,
-      apiActions.generateMessageError.type,
-      apiActions.assistantTurnFinalized.type,
-      apiActions.generateMessageExhaustedRetries.type,
-    ]);
-
-    teardown?.();
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageError.type,
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageSuccess.type,
+    apiActions.assistantTurnFinalized.type,
+    apiActions.generateMessageExhaustedRetries.type,
+  ]);
+  expect(store.actions[2].payload).toMatchObject({
+    type: EventType.RUN_ERROR,
+    message: 'temporary boom',
   });
+  expect(store.actions[7].payload).toMatchObject({
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    delta: 'Hi after retry',
+  });
+
+  teardown?.();
+});
+
+test('dispatches exhausted retries after max retryable failures', async () => {
+  jest.clearAllMocks();
+  const retries = 1;
+  const error = new Error('still broken');
+
+  makeSelection(async () => {
+    throw error;
+  });
+
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, retries]]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'fail' } }),
+  );
+
+  expect(store.actions.map((a) => a.type)).toEqual([
+    apiActions.generateMessageError.type,
+    apiActions.generateMessageError.type,
+    apiActions.assistantTurnFinalized.type,
+    apiActions.generateMessageExhaustedRetries.type,
+  ]);
+
+  teardown?.();
+});
+
+test('converts generation error frames to AG-UI run errors', async () => {
+  jest.clearAllMocks();
+  const frames = async function* () {
+    yield { type: 'generation-start' as const };
+    yield {
+      type: 'generation-error' as const,
+      error: 'provider failed',
+    };
+  };
+  makeSelection(async () => ({ frames: frames() }));
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageError.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(store.actions[2].payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'provider failed',
+  });
+
+  teardown?.();
+});
+
+test('converts decode failures after run start to one AG-UI run error', async () => {
+  jest.clearAllMocks();
+  const frames = async function* () {
+    yield { type: 'generation-start' as const };
+    throw new Error('decode failed');
+  };
+  makeSelection(async () => ({ frames: frames() }));
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageError.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(store.actions[2].payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'decode failed',
+  });
+
+  teardown?.();
+});
+
+test('converts premature stream completion to an AG-UI run error', async () => {
+  jest.clearAllMocks();
+  const frames = async function* () {
+    yield { type: 'generation-start' as const };
+  };
+  makeSelection(async () => ({ frames: frames() }));
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageError.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(store.actions[2].payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Generation stream ended before generation-finish',
+  });
+
+  teardown?.();
+});
+
+test('terminates an active AG-UI run when generation is cancelled', async () => {
+  jest.clearAllMocks();
+  let notifyStarted: () => void = () => undefined;
+  const started = new Promise<void>((resolve) => {
+    notifyStarted = resolve;
+  });
+  makeSelection(async ({ signal }) => ({
+    frames: (async function* () {
+      notifyStarted();
+      yield { type: 'generation-start' as const };
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+    })(),
+  }));
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  const generation = store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  await started;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await store.trigger(devActions.stopMessageGeneration(true));
+  await generation;
+
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  const runStarted = store.actions[1]?.payload as {
+    threadId: string;
+    runId: string;
+  };
+  expect(store.actions[2].payload).toMatchObject({
+    type: EventType.RUN_ERROR,
+    message: 'Generation cancelled',
+  });
+  expect(runStarted).toMatchObject({
+    threadId: expect.any(String),
+    runId: expect.any(String),
+  });
+
+  teardown?.();
+});
+
+test('does not retry when decoding throws after generation is cancelled', async () => {
+  jest.clearAllMocks();
+  let notifyStarted: () => void = () => undefined;
+  const started = new Promise<void>((resolve) => {
+    notifyStarted = resolve;
+  });
+  const { send } = makeSelection(async ({ signal }) => ({
+    frames: (async function* () {
+      notifyStarted();
+      yield { type: 'generation-start' as const };
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener('abort', () => resolve(), {
+          once: true,
+        });
+      });
+      throw new Error('Stream ended with 3 leftover bytes');
+    })(),
+  }));
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, 1]]),
+  );
+  const teardown = generateMessage(store);
+
+  const generation = store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  await started;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await store.trigger(devActions.stopMessageGeneration(true));
+  await generation;
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.generateMessageEvent.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(store.actions[2].payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Generation cancelled',
+  });
+
+  teardown?.();
 });

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -1,9 +1,11 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { s } from '../schema';
 import { sleep, switchAsync } from '../utils/async';
 import { createEffect } from '../utils/micro-ngrx';
 import { apiActions, devActions, internalActions } from '../actions';
 import { decodeFrames } from '../frames/decode-frames';
 import { Chat } from '../models';
+import { createCompletionChunkEventAdapter } from '../transport/completion-chunk-to-agui-events';
 import { updateAssistantMessage } from '../utils/assistant-message';
 import {
   selectApiMessages,
@@ -144,6 +146,21 @@ export const generateMessage = createEffect((store) => {
           }
 
           let transportResponse: TransportResponse | undefined;
+          let activeRun:
+            { threadId: string; runId: string; terminal: boolean } | undefined;
+          const dispatchRunError = (message: string) => {
+            if (!activeRun || activeRun.terminal) {
+              return;
+            }
+
+            activeRun = { ...activeRun, terminal: true };
+            store.dispatch(
+              apiActions.generateMessageEvent({
+                type: EventType.RUN_ERROR,
+                message,
+              }),
+            );
+          };
 
           try {
             attempt++;
@@ -158,13 +175,18 @@ export const generateMessage = createEffect((store) => {
               ...params,
               model: selection.spec.name,
             };
+            const requestId = _createRequestId();
+            const runId = requestId;
+            const aguiThreadId = threadId ?? requestId;
+            const completionChunkAdapter =
+              createCompletionChunkEventAdapter(requestId);
 
             transportResponse = await selection.transport.send({
               params: paramsWithModel,
               signal: requestAbortSignal,
               attempt,
               maxAttempts: retries + 1,
-              requestId: _createRequestId(),
+              requestId,
             });
 
             if (cancelAbortController.signal.aborted) {
@@ -225,6 +247,11 @@ export const generateMessage = createEffect((store) => {
                   throw new Error(frame.error);
                 }
                 case 'generation-start': {
+                  activeRun = {
+                    threadId: aguiThreadId,
+                    runId,
+                    terminal: false,
+                  };
                   store.dispatch(
                     apiActions.generateMessageStart({
                       responseSchema,
@@ -244,10 +271,21 @@ export const generateMessage = createEffect((store) => {
                           : toolsByName,
                     }),
                   );
+                  store.dispatch(
+                    apiActions.generateMessageEvent({
+                      type: EventType.RUN_STARTED,
+                      threadId: aguiThreadId,
+                      runId,
+                    }),
+                  );
                   break;
                 }
                 case 'generation-chunk': {
-                  store.dispatch(apiActions.generateMessageChunk(frame.chunk));
+                  for (const event of completionChunkAdapter.push(
+                    frame.chunk,
+                  )) {
+                    store.dispatch(apiActions.generateMessageEvent(event));
+                  }
                   break;
                 }
                 case 'thread-save-success': {
@@ -270,13 +308,27 @@ export const generateMessage = createEffect((store) => {
                   break;
                 }
                 case 'generation-error': {
+                  dispatchRunError(frame.error);
                   // Assumption: a 'finish' will follow the 'error', but we know we need to retry
                   // as soon as we see the error.  Therefore, throw an exception to break out
                   // of the for loop.
                   throw new Error(frame.error);
                 }
                 case 'generation-finish': {
-                  store.dispatch(apiActions.generateMessageFinish());
+                  if (activeRun) {
+                    activeRun = { ...activeRun, terminal: true };
+                  }
+                  const events: AGUIEvent[] = [
+                    ...completionChunkAdapter.finish(),
+                    {
+                      type: EventType.RUN_FINISHED,
+                      threadId: aguiThreadId,
+                      runId,
+                    },
+                  ];
+                  for (const event of events) {
+                    store.dispatch(apiActions.generateMessageEvent(event));
+                  }
 
                   const streamingError = store.read(
                     selectStreamingMessageError,
@@ -313,9 +365,35 @@ export const generateMessage = createEffect((store) => {
                 }
               }
             }
+
+            if (activeRun && !activeRun.terminal) {
+              const cancelled =
+                effectAbortController.signal.aborted ||
+                switchSignal.aborted ||
+                cancelAbortController.signal.aborted;
+              if (cancelled) {
+                dispatchRunError('Generation cancelled');
+                return;
+              }
+
+              throw new TransportError(
+                'Generation stream ended before generation-finish',
+                { retryable: true },
+              );
+            }
           } catch (e) {
+            const cancelled =
+              effectAbortController.signal.aborted ||
+              switchSignal.aborted ||
+              cancelAbortController.signal.aborted;
+            if (cancelled) {
+              dispatchRunError('Generation cancelled');
+              return;
+            }
+
             const error =
               e instanceof Error ? e : new Error('Unknown transport error');
+            dispatchRunError(error.message);
             store.dispatch(apiActions.generateMessageError(error));
 
             const retryable =

--- a/packages/core/src/reducers/index.spec.ts
+++ b/packages/core/src/reducers/index.spec.ts
@@ -1,3 +1,4 @@
+import { EventType } from '@ag-ui/core';
 import { apiActions, devActions } from '../actions';
 import { Chat } from '../models';
 import { s } from '../schema';
@@ -111,44 +112,29 @@ test('selectViewMessages uses streaming output tool arguments', () => {
 
   state = reduceAll(
     state,
-    apiActions.generateMessageChunk({
-      choices: [
-        {
-          index: 0,
-          delta: {
-            role: 'assistant',
-            toolCalls: [
-              {
-                index: 0,
-                id: 'call-output',
-                type: 'function',
-                function: { name: 'output', arguments: '{"text":"he' },
-              },
-            ],
-          },
-          finishReason: null,
-        },
-      ],
+    apiActions.generateMessageEvent({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-output',
+      toolCallName: 'output',
+      parentMessageId: 'message-1',
     }),
   );
 
   state = reduceAll(
     state,
-    apiActions.generateMessageChunk({
-      choices: [
-        {
-          index: 0,
-          delta: {
-            toolCalls: [
-              {
-                index: 0,
-                function: { arguments: 'llo"}' },
-              },
-            ],
-          },
-          finishReason: null,
-        },
-      ],
+    apiActions.generateMessageEvent({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-output',
+      delta: '{"text":"he',
+    }),
+  );
+
+  state = reduceAll(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-output',
+      delta: 'llo"}',
     }),
   );
 

--- a/packages/core/src/reducers/status.reducer.spec.ts
+++ b/packages/core/src/reducers/status.reducer.spec.ts
@@ -1,0 +1,65 @@
+import { EventType } from '@ag-ui/core';
+import { apiActions } from '../actions';
+import { initialStatusState, reducer } from './status.reducer';
+
+test('marks generation active from an AG-UI run start event', () => {
+  const state = {
+    ...initialStatusState,
+    isSending: true,
+    generatingError: new Error('previous failure'),
+  };
+
+  const next = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    }),
+  );
+
+  expect(next).toEqual({
+    ...state,
+    isSending: false,
+    isReceiving: true,
+    isGenerating: true,
+    generatingError: undefined,
+  });
+});
+
+test('marks generation active from AG-UI chunk events', () => {
+  const state = {
+    ...initialStatusState,
+    isReceiving: false,
+    isGenerating: false,
+  };
+
+  const next = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.TEXT_MESSAGE_CHUNK,
+      messageId: 'message-1',
+      delta: 'hello',
+    }),
+  );
+
+  expect(next).toEqual({
+    ...state,
+    isReceiving: true,
+    isGenerating: true,
+  });
+});
+
+test('ignores AG-UI events unrelated to generation status', () => {
+  const state = initialStatusState;
+
+  const next = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { ignored: true },
+    }),
+  );
+
+  expect(next).toBe(state);
+});

--- a/packages/core/src/reducers/status.reducer.ts
+++ b/packages/core/src/reducers/status.reducer.ts
@@ -1,3 +1,4 @@
+import { EventType } from '@ag-ui/core';
 import { createReducer, on } from '../utils/micro-ngrx';
 import { apiActions, devActions, internalActions } from '../actions';
 
@@ -48,21 +49,30 @@ export const reducer = createReducer(
       };
     },
   ),
-  on(apiActions.generateMessageStart, (state) => {
-    return {
-      ...state,
-      isSending: false,
-      isReceiving: true,
-      isGenerating: true,
-      generatingError: undefined,
-    };
-  }),
-  on(apiActions.generateMessageChunk, (state) => {
-    return {
-      ...state,
-      isReceiving: true,
-      isGenerating: true,
-    };
+  on(apiActions.generateMessageEvent, (state, action) => {
+    switch (action.payload.type) {
+      case EventType.RUN_STARTED:
+        return {
+          ...state,
+          isSending: false,
+          isReceiving: true,
+          isGenerating: true,
+          generatingError: undefined,
+        };
+      case EventType.TEXT_MESSAGE_START:
+      case EventType.TEXT_MESSAGE_CONTENT:
+      case EventType.TEXT_MESSAGE_CHUNK:
+      case EventType.TOOL_CALL_START:
+      case EventType.TOOL_CALL_ARGS:
+      case EventType.TOOL_CALL_CHUNK:
+        return {
+          ...state,
+          isReceiving: true,
+          isGenerating: true,
+        };
+      default:
+        return state;
+    }
   }),
   on(apiActions.generateMessageSuccess, (state) => {
     return {

--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -1,7 +1,12 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { apiActions } from '../actions';
 import { Chat } from '../models';
 import { s } from '../schema';
-import { initialState, reducer } from './streaming-message.reducer';
+import {
+  initialState,
+  reducer,
+  type StreamingMessageState,
+} from './streaming-message.reducer';
 
 function startState(
   responseSchema?: s.SchemaOutput,
@@ -18,82 +23,142 @@ function startState(
   );
 }
 
-function chunkAction(delta: Chat.Api.CompletionChunk['choices'][0]['delta']) {
-  const chunk: Chat.Api.CompletionChunk = {
-    choices: [
-      {
-        index: 0,
-        delta,
-        finishReason: null,
-      },
-    ],
-  };
-
-  return apiActions.generateMessageChunk(chunk);
+function reduceEvents(
+  state: StreamingMessageState,
+  events: AGUIEvent[],
+): StreamingMessageState {
+  return events.reduce(
+    (current, event) =>
+      reducer(current, apiActions.generateMessageEvent(event)),
+    state,
+  );
 }
 
-test('parses structured output from content stream', () => {
+function textEvents(delta: string, messageId = 'message-1'): AGUIEvent[] {
+  return [
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId,
+      delta,
+    },
+  ];
+}
+
+function textContent(delta: string, messageId = 'message-1'): AGUIEvent {
+  return {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId,
+    delta,
+  };
+}
+
+function toolEvents(
+  toolCallId: string,
+  toolCallName: string,
+  delta: string,
+): AGUIEvent[] {
+  return [
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId,
+      toolCallName,
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId,
+      delta,
+    },
+  ];
+}
+
+function toolArgs(toolCallId: string, delta: string): AGUIEvent {
+  return {
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId,
+    delta,
+  };
+}
+
+function runFinished(): AGUIEvent {
+  return {
+    type: EventType.RUN_FINISHED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  };
+}
+
+test('parses structured output from AG-UI text events', () => {
   const responseSchema = s.object('output', {
     message: s.streaming.string('message'),
   });
-
   let state = startState(responseSchema, false);
 
-  state = reducer(
-    state,
-    chunkAction({ role: 'assistant', content: '{"message":"he' }),
-  );
+  state = reduceEvents(state, textEvents('{"message":"he'));
 
   expect(state.message?.contentResolved).toEqual({ message: 'he' });
   const firstResolved = state.message?.contentResolved as {
     message: string;
   };
 
-  state = reducer(
-    state,
-    chunkAction({
-      toolCalls: [
-        {
-          index: 0,
-          id: 'call-1',
-          type: 'function',
-          function: { name: 'noop', arguments: '{}' },
-        },
-      ],
-    }),
-  );
+  state = reduceEvents(state, toolEvents('call-1', 'noop', '{}'));
 
   expect(state.message?.contentResolved).toBe(firstResolved);
 });
 
-test('streams Japanese and Chinese structured output from content chunks', () => {
+test('streams Japanese and Chinese structured output from AG-UI text events', () => {
   const responseSchema = s.object('output', {
     message: s.streaming.string('message'),
   });
-
   let state = startState(responseSchema, false);
 
-  state = reducer(
-    state,
-    chunkAction({ role: 'assistant', content: '{"message":"こん' }),
-  );
+  state = reduceEvents(state, textEvents('{"message":"こん'));
 
   expect(state.message?.contentResolved).toEqual({ message: 'こん' });
 
-  state = reducer(state, chunkAction({ content: 'にちは、你' }));
+  state = reduceEvents(state, [textContent('にちは、你')]);
 
   expect(state.message?.contentResolved).toEqual({
     message: 'こんにちは、你',
   });
 
-  state = reducer(state, chunkAction({ content: '好"}' }));
+  state = reduceEvents(state, [textContent('好"}')]);
 
   expect(state.message?.contentResolved).toEqual({
     message: 'こんにちは、你好',
   });
 });
 
-test('recovers structured output from content before trailing JSON', () => {
+test('streams structured output from AG-UI text chunk shorthand', () => {
+  const responseSchema = s.object('output', {
+    message: s.streaming.string('message'),
+  });
+  let state = startState(responseSchema, false);
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TEXT_MESSAGE_CHUNK,
+      messageId: 'message-1',
+      role: 'assistant',
+      delta: '{"message":"he',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CHUNK,
+      delta: 'llo"}',
+    },
+    runFinished(),
+  ]);
+
+  expect(state.message?.content).toBe('{"message":"hello"}');
+  expect(state.message?.contentResolved).toEqual({ message: 'hello' });
+});
+
+test('recovers structured output from AG-UI text before trailing JSON', () => {
   const consoleWarn = jest
     .spyOn(console, 'warn')
     .mockImplementation(() => undefined);
@@ -104,19 +169,13 @@ test('recovers structured output from content before trailing JSON', () => {
   try {
     let state = startState(responseSchema, false);
 
-    state = reducer(
-      state,
-      chunkAction({
-        role: 'assistant',
-        content: '{"ui":[{}]}\n{"ui":[{}]}',
-      }),
-    );
+    state = reduceEvents(state, textEvents('{"ui":[{}]}\n{"ui":[{}]}'));
 
     expect(state.error).toBeUndefined();
     expect(state.message?.contentResolved).toEqual({ ui: [{}] });
     expect(consoleWarn).not.toHaveBeenCalled();
 
-    state = reducer(state, apiActions.generateMessageFinish());
+    state = reduceEvents(state, [runFinished()]);
 
     expect(state.error).toBeUndefined();
     expect(state.message?.contentResolved).toEqual({ ui: [{}] });
@@ -144,18 +203,14 @@ test('parses Standard JSON Schema structured output when complete', () => {
       },
     },
   } as const satisfies s.StandardJSONSchemaV1<unknown, { message: string }>;
-
   let state = startState(responseSchema, false);
 
-  state = reducer(
-    state,
-    chunkAction({ role: 'assistant', content: '{"message":"hello"}' }),
-  );
+  state = reduceEvents(state, textEvents('{"message":"hello"}'));
 
   expect(state.message?.contentResolved).toEqual({ message: 'hello' });
 });
 
-test('streams output tool arguments like a normal tool in emulated mode', () => {
+test('streams output tool arguments from AG-UI events in emulated mode', () => {
   const responseSchema = s.object('output', {
     answer: s.streaming.string('answer'),
   });
@@ -167,22 +222,11 @@ test('streams output tool arguments like a normal tool in emulated mode', () => 
       handler: async () => undefined,
     },
   };
-
   let state = startState(responseSchema, true, toolsByName);
 
-  state = reducer(
+  state = reduceEvents(
     state,
-    chunkAction({
-      role: 'assistant',
-      toolCalls: [
-        {
-          index: 0,
-          id: 'call-output',
-          type: 'function',
-          function: { name: 'output', arguments: '{"answer":"o' },
-        },
-      ],
-    }),
+    toolEvents('call-output', 'output', '{"answer":"o'),
   );
 
   expect(state.toolCalls).toHaveLength(1);
@@ -190,23 +234,13 @@ test('streams output tool arguments like a normal tool in emulated mode', () => 
   expect(state.toolCalls[0]?.argumentsResolved).toEqual({ answer: 'o' });
   expect(state.message?.contentResolved).toBeUndefined();
 
-  state = reducer(
-    state,
-    chunkAction({
-      toolCalls: [
-        {
-          index: 0,
-          function: { arguments: 'k"}' },
-        },
-      ],
-    }),
-  );
+  state = reduceEvents(state, [toolArgs('call-output', 'k"}')]);
 
   expect(state.toolCalls[0]?.argumentsResolved).toEqual({ answer: 'ok' });
   expect(state.message?.contentResolved).toBeUndefined();
 });
 
-test('recovers emulated structured output arguments before trailing JSON', () => {
+test('recovers AG-UI tool arguments before trailing JSON', () => {
   const consoleWarn = jest
     .spyOn(console, 'warn')
     .mockImplementation(() => undefined);
@@ -225,29 +259,16 @@ test('recovers emulated structured output arguments before trailing JSON', () =>
   try {
     let state = startState(responseSchema, true, toolsByName);
 
-    state = reducer(
+    state = reduceEvents(
       state,
-      chunkAction({
-        role: 'assistant',
-        toolCalls: [
-          {
-            index: 0,
-            id: 'call-output',
-            type: 'function',
-            function: {
-              name: 'output',
-              arguments: '{"ui":[{}]}\n{"ui":[{}]}',
-            },
-          },
-        ],
-      }),
+      toolEvents('call-output', 'output', '{"ui":[{}]}\n{"ui":[{}]}'),
     );
 
     expect(state.error).toBeUndefined();
     expect(state.toolCalls[0]?.argumentsResolved).toEqual({ ui: [{}] });
     expect(consoleWarn).not.toHaveBeenCalled();
 
-    state = reducer(state, apiActions.generateMessageFinish());
+    state = reduceEvents(state, [runFinished()]);
 
     expect(state.error).toBeUndefined();
     expect(state.toolCalls[0]?.argumentsResolved).toEqual({ ui: [{}] });
@@ -257,7 +278,73 @@ test('recovers emulated structured output arguments before trailing JSON', () =>
   }
 });
 
-test('streams hashbrown tool arguments and preserves identity when unchanged', () => {
+test('finalizes AG-UI tool arguments only once across tool and run completion', () => {
+  const consoleWarn = jest
+    .spyOn(console, 'warn')
+    .mockImplementation(() => undefined);
+  const toolsByName: Record<string, Chat.Internal.Tool> = {
+    submit: {
+      name: 'submit',
+      description: '',
+      schema: s.object('args', { value: s.number('value') }),
+      handler: async () => undefined,
+    },
+  };
+
+  try {
+    let state = startState(undefined, false, toolsByName);
+    state = reduceEvents(
+      state,
+      toolEvents('call-submit', 'submit', '{"value":1}\n{"value":2}'),
+    );
+
+    state = reduceEvents(state, [
+      { type: EventType.TOOL_CALL_END, toolCallId: 'call-submit' },
+      runFinished(),
+    ]);
+
+    expect(state.error).toBeUndefined();
+    expect(state.toolCalls[0]?.argumentsResolved).toEqual({ value: 1 });
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleWarn.mockRestore();
+  }
+});
+
+test('preserves Hashbrown tool metadata from later AG-UI tool events', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-1',
+      toolCallName: 'search',
+      parentMessageId: 'message-1',
+      rawEvent: {
+        hashbrown: {
+          metadata: { initial: 'preserved' },
+        },
+      },
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-1',
+      delta: '',
+      rawEvent: {
+        hashbrown: {
+          metadata: { signature: 'opaque' },
+        },
+      },
+    },
+  ]);
+
+  expect(state.toolCalls[0]?.metadata).toEqual({
+    initial: 'preserved',
+    signature: 'opaque',
+  });
+});
+
+test('streams multiple AG-UI tool calls keyed by toolCallId', () => {
   const toolsByName: Record<string, Chat.Internal.Tool> = {
     weather: {
       name: 'weather',
@@ -272,48 +359,119 @@ test('streams hashbrown tool arguments and preserves identity when unchanged', (
       handler: async () => undefined,
     },
   };
-
   let state = startState(undefined, false, toolsByName);
 
-  state = reducer(
+  state = reduceEvents(
     state,
-    chunkAction({
-      role: 'assistant',
-      toolCalls: [
-        {
-          index: 0,
-          id: 'call-weather',
-          type: 'function',
-          function: { name: 'weather', arguments: '{"city":"p' },
-        },
-      ],
-    }),
+    toolEvents('call-weather', 'weather', '{"city":"p'),
   );
-
   const firstArgs = state.toolCalls[0]?.argumentsResolved as {
     city: string;
   };
 
   expect(firstArgs).toEqual({ city: 'p' });
 
-  state = reducer(
-    state,
-    chunkAction({
-      toolCalls: [
-        {
-          index: 1,
-          id: 'call-noop',
-          type: 'function',
-          function: { name: 'noop', arguments: '{}' },
-        },
-      ],
-    }),
-  );
+  state = reduceEvents(state, toolEvents('call-noop', 'noop', '{}'));
 
   expect(state.toolCalls[0]?.argumentsResolved).toBe(firstArgs);
+  expect(state.toolCalls.map((toolCall) => toolCall.id)).toEqual([
+    'call-weather',
+    'call-noop',
+  ]);
 });
 
-test('non-hashbrown tool arguments resolve only when complete', () => {
+test('streams interleaved AG-UI tool call chunk shorthand', () => {
+  const toolsByName: Record<string, Chat.Internal.Tool> = {
+    weather: {
+      name: 'weather',
+      description: '',
+      schema: s.object('args', { city: s.streaming.string('city') }),
+      handler: async () => undefined,
+    },
+    time: {
+      name: 'time',
+      description: '',
+      schema: s.object('args', { zone: s.streaming.string('zone') }),
+      handler: async () => undefined,
+    },
+  };
+  let state = startState(undefined, false, toolsByName);
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-weather',
+      toolCallName: 'weather',
+      parentMessageId: 'message-1',
+      delta: '{"city":"',
+    },
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-time',
+      toolCallName: 'time',
+      parentMessageId: 'message-1',
+      delta: '{"zone":"',
+    },
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-weather',
+      delta: 'Paris"}',
+    },
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-time',
+      delta: 'UTC"}',
+    },
+    runFinished(),
+  ]);
+
+  expect(state.toolCalls).toEqual([
+    expect.objectContaining({
+      id: 'call-weather',
+      argumentsResolved: { city: 'Paris' },
+    }),
+    expect.objectContaining({
+      id: 'call-time',
+      argumentsResolved: { zone: 'UTC' },
+    }),
+  ]);
+});
+
+test('uses the active tool call for AG-UI tool chunks with omitted ids', () => {
+  const toolsByName: Record<string, Chat.Internal.Tool> = {
+    weather: {
+      name: 'weather',
+      description: '',
+      schema: s.object('args', { city: s.streaming.string('city') }),
+      handler: async () => undefined,
+    },
+  };
+  let state = startState(undefined, false, toolsByName);
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-weather',
+      toolCallName: 'weather',
+      delta: '{"city":"Par',
+    },
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      delta: 'is"}',
+    },
+    runFinished(),
+  ]);
+
+  expect(state.toolCalls[0]).toEqual(
+    expect.objectContaining({
+      id: 'call-weather',
+      arguments: '{"city":"Paris"}',
+      argumentsResolved: { city: 'Paris' },
+    }),
+  );
+});
+
+test('non-hashbrown AG-UI tool arguments resolve only when complete', () => {
   const toolsByName: Record<string, Chat.Internal.Tool> = {
     legacy: {
       name: 'legacy',
@@ -325,37 +483,16 @@ test('non-hashbrown tool arguments resolve only when complete', () => {
       handler: async () => undefined,
     },
   };
-
   let state = startState(undefined, false, toolsByName);
 
-  state = reducer(
+  state = reduceEvents(
     state,
-    chunkAction({
-      role: 'assistant',
-      toolCalls: [
-        {
-          index: 0,
-          id: 'call-legacy',
-          type: 'function',
-          function: { name: 'legacy', arguments: '{"name":"al' },
-        },
-      ],
-    }),
+    toolEvents('call-legacy', 'legacy', '{"name":"al'),
   );
 
   expect(state.toolCalls[0]?.argumentsResolved).toBeUndefined();
 
-  state = reducer(
-    state,
-    chunkAction({
-      toolCalls: [
-        {
-          index: 0,
-          function: { arguments: 'ice"}' },
-        },
-      ],
-    }),
-  );
+  state = reduceEvents(state, [toolArgs('call-legacy', 'ice"}')]);
 
   expect(state.toolCalls[0]?.argumentsResolved).toEqual({ name: 'alice' });
 });
@@ -364,31 +501,52 @@ test('does not recover malformed structured output before the root closes', () =
   const responseSchema = s.object('output', {
     ui: s.array('ui', s.object('component', {})),
   });
-
   let state = startState(responseSchema, false);
 
-  state = reducer(
-    state,
-    chunkAction({ role: 'assistant', content: '{"ui":[{}],}' }),
-  );
+  state = reduceEvents(state, textEvents('{"ui":[{}],}'));
 
   expect(state.error).toBeInstanceOf(Error);
   expect(state.message?.contentResolved).toBeUndefined();
 });
 
-test('defers parser errors until finish', () => {
+test('defers AG-UI parser errors until the run finishes', () => {
   const responseSchema = s.object('output', { message: s.string('message') });
-
   let state = startState(responseSchema, false);
 
-  state = reducer(
-    state,
-    chunkAction({ role: 'assistant', content: '{"message":"oops' }),
-  );
+  state = reduceEvents(state, textEvents('{"message":"oops'));
 
   expect(state.error).toBeUndefined();
 
-  state = reducer(state, apiActions.generateMessageFinish());
+  state = reduceEvents(state, [runFinished()]);
 
   expect(state.error).toBeInstanceOf(Error);
+});
+
+test('stores AG-UI run errors without discarding the partial message', () => {
+  let state = startState();
+  state = reduceEvents(state, textEvents('partial'));
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.RUN_ERROR,
+      message: 'provider failed',
+      code: 'provider_error',
+    },
+  ]);
+
+  expect(state.message?.content).toBe('partial');
+  expect(state.error).toEqual(new Error('provider failed'));
+});
+
+test('ignores unsupported AG-UI events without mutating state', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [
+    {
+      type: EventType.STATE_SNAPSHOT,
+      snapshot: { ignored: true },
+    },
+  ]);
+
+  expect(next).toBe(state);
 });

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -1,9 +1,4 @@
-import { createReducer, on, select } from '../utils/micro-ngrx';
-import { Chat } from '../models';
-import { apiActions, devActions } from '../actions';
-import { mergeToolCalls } from '../utils/assistant-message';
-import { JsonValue } from '../utils';
-import { s } from '../schema';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import {
   create,
   finish,
@@ -11,20 +6,25 @@ import {
   resolve,
   type StreamState,
 } from '@cacheplane/partial-json';
+import { apiActions, devActions } from '../actions';
+import { Chat } from '../models';
+import { s } from '../schema';
+import { JsonValue } from '../utils';
+import { createReducer, on, select } from '../utils/micro-ngrx';
 
-type ParserMap = Record<number, StreamState>;
-type CacheMap = Record<number, s.FromJsonAstCache>;
-type ToolCallIndexMap = Record<string, number>;
+type ParserMap = Record<string, StreamState>;
+type CacheMap = Record<string, s.FromJsonAstCache>;
 
 export interface StreamingMessageState {
   message: Chat.Internal.AssistantMessage | null;
+  messageId?: string;
+  activeToolCallId?: string;
   toolCalls: Chat.Internal.ToolCall[];
-  rawToolCalls: Chat.Api.ToolCall[];
   outputParserState?: StreamState;
   outputCache?: s.FromJsonAstCache;
-  toolParserStateByIndex: ParserMap;
-  toolCacheByIndex: CacheMap;
-  toolCallIndexById: ToolCallIndexMap;
+  toolParserStateById: ParserMap;
+  toolCacheById: CacheMap;
+  finalizedToolCallIds: Record<string, true>;
   configSnapshot?: {
     responseSchema?: s.HashbrownType;
     emulateStructuredOutput: boolean;
@@ -35,62 +35,20 @@ export interface StreamingMessageState {
 
 export const initialState: StreamingMessageState = {
   message: null,
+  messageId: undefined,
+  activeToolCallId: undefined,
   toolCalls: [],
-  rawToolCalls: [],
   outputParserState: undefined,
   outputCache: undefined,
-  toolParserStateByIndex: {},
-  toolCacheByIndex: {},
-  toolCallIndexById: {},
+  toolParserStateById: {},
+  toolCacheById: {},
+  finalizedToolCallIds: {},
   configSnapshot: undefined,
   error: undefined,
 };
 
 function ensureParserState(state: StreamState | undefined) {
   return state ?? create();
-}
-
-function getToolCallName(
-  mergedToolCalls: Chat.Api.ToolCall[],
-  index: number | undefined,
-  fallback?: string,
-) {
-  if (fallback) {
-    return fallback;
-  }
-
-  if (index === undefined) {
-    return undefined;
-  }
-
-  const existing = mergedToolCalls.find((call) => call.index === index);
-  return existing?.function?.name;
-}
-
-function updateToolParserState(
-  parserStates: ParserMap,
-  index: number,
-  delta: string,
-) {
-  const current = ensureParserState(parserStates[index]);
-  const next = push(current, delta);
-  if (next === current) {
-    return parserStates;
-  }
-
-  return { ...parserStates, [index]: next };
-}
-
-function updateCache(
-  cacheMap: CacheMap,
-  index: number,
-  cache: s.FromJsonAstCache,
-) {
-  if (cacheMap[index] === cache) {
-    return cacheMap;
-  }
-
-  return { ...cacheMap, [index]: cache };
 }
 
 function isRecoverableTrailingToken(parserState: StreamState) {
@@ -173,6 +131,458 @@ function warnRecoveredTrailingTokenFromSource(
   warnRecoveredTrailingToken(parsedData, source.slice(parserError.index));
 }
 
+function getToolCallMetadata(rawEvent: unknown) {
+  if (!rawEvent || typeof rawEvent !== 'object' || Array.isArray(rawEvent)) {
+    return undefined;
+  }
+
+  const hashbrown = (rawEvent as Record<string, unknown>)['hashbrown'];
+  if (!hashbrown || typeof hashbrown !== 'object' || Array.isArray(hashbrown)) {
+    return undefined;
+  }
+
+  const metadata = (hashbrown as Record<string, unknown>)['metadata'];
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
+  }
+
+  return metadata as Record<string, unknown>;
+}
+
+function startTextMessage(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TEXT_MESSAGE_START }>,
+): StreamingMessageState {
+  if (event.role !== 'assistant') {
+    return state;
+  }
+
+  if (state.message && state.messageId === event.messageId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    messageId: event.messageId,
+    message: state.message ?? {
+      role: 'assistant',
+      content: '',
+      toolCallIds: state.toolCalls.map((toolCall) => toolCall.id),
+    },
+  };
+}
+
+function appendTextContent(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TEXT_MESSAGE_CONTENT }>,
+): StreamingMessageState {
+  if (
+    !state.message ||
+    state.messageId !== event.messageId ||
+    event.delta.length === 0
+  ) {
+    return state;
+  }
+
+  const responseSchema = state.configSnapshot?.responseSchema;
+  const content = (state.message.content ?? '') + event.delta;
+  let message: Chat.Internal.AssistantMessage = {
+    ...state.message,
+    content,
+  };
+  let outputParserState = state.outputParserState;
+  let outputCache = state.outputCache;
+  let error = state.error;
+
+  if (responseSchema) {
+    outputParserState = push(ensureParserState(outputParserState), event.delta);
+    const output = resolveSchemaValue(
+      responseSchema,
+      outputParserState,
+      outputCache,
+    );
+    outputCache = output.cache;
+    if (output.hasError && !error) {
+      error = new Error('Invalid structured output');
+    }
+    if (output.value !== undefined) {
+      message = {
+        ...message,
+        contentResolved: output.value,
+      };
+    }
+  }
+
+  return {
+    ...state,
+    message,
+    outputParserState,
+    outputCache,
+    error,
+  };
+}
+
+function startToolCall(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TOOL_CALL_START }>,
+): StreamingMessageState {
+  if (state.toolCalls.some((toolCall) => toolCall.id === event.toolCallId)) {
+    return state.activeToolCallId === event.toolCallId
+      ? state
+      : { ...state, activeToolCallId: event.toolCallId };
+  }
+
+  const toolCalls = [
+    ...state.toolCalls,
+    {
+      id: event.toolCallId,
+      name: event.toolCallName,
+      arguments: '',
+      status: 'pending' as const,
+      metadata: getToolCallMetadata(event.rawEvent),
+    },
+  ];
+  const message = state.message ?? {
+    role: 'assistant' as const,
+    content: '',
+    toolCallIds: [],
+  };
+
+  return {
+    ...state,
+    messageId: state.messageId ?? event.parentMessageId,
+    activeToolCallId: event.toolCallId,
+    message: {
+      ...message,
+      toolCallIds: toolCalls.map((toolCall) => toolCall.id),
+    },
+    toolCalls,
+  };
+}
+
+function appendToolArguments(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TOOL_CALL_ARGS }>,
+): StreamingMessageState {
+  const toolCallIndex = state.toolCalls.findIndex(
+    (toolCall) => toolCall.id === event.toolCallId,
+  );
+  if (toolCallIndex === -1) {
+    return state;
+  }
+
+  const toolCall = state.toolCalls[toolCallIndex];
+  if (!toolCall) {
+    return state;
+  }
+
+  const incomingMetadata = getToolCallMetadata(event.rawEvent);
+  if (event.delta.length === 0 && !incomingMetadata) {
+    return state;
+  }
+
+  const argumentsString = toolCall.arguments + event.delta;
+  const metadata = incomingMetadata
+    ? { ...(toolCall.metadata ?? {}), ...incomingMetadata }
+    : toolCall.metadata;
+  const tool = state.configSnapshot?.toolsByName[toolCall.name];
+  let argumentsResolved = toolCall.argumentsResolved;
+  let toolParserStateById = state.toolParserStateById;
+  let toolCacheById = state.toolCacheById;
+  let error = state.error;
+
+  if (tool && event.delta.length > 0) {
+    const parserState = push(
+      ensureParserState(toolParserStateById[event.toolCallId]),
+      event.delta,
+    );
+    toolParserStateById = {
+      ...toolParserStateById,
+      [event.toolCallId]: parserState,
+    };
+
+    if (s.isHashbrownType(tool.schema)) {
+      const resolved = resolveSchemaValue(
+        tool.schema,
+        parserState,
+        toolCacheById[event.toolCallId],
+      );
+      toolCacheById = {
+        ...toolCacheById,
+        [event.toolCallId]: resolved.cache,
+      };
+      if (resolved.value !== undefined) {
+        argumentsResolved = resolved.value;
+      }
+      if (resolved.hasError && !error) {
+        error = new Error(`Invalid tool arguments for ${toolCall.name}`);
+      }
+    } else if (parserState.error && !error) {
+      error = new Error(`Invalid tool arguments for ${toolCall.name}`);
+    } else {
+      const resolvedValue = resolveJsonValue(parserState);
+      if (resolvedValue !== undefined) {
+        argumentsResolved = resolvedValue;
+      }
+    }
+  }
+
+  const toolCalls = state.toolCalls.map((current, index) =>
+    index === toolCallIndex
+      ? {
+          ...current,
+          arguments: argumentsString,
+          argumentsResolved,
+          metadata,
+        }
+      : current,
+  );
+
+  return {
+    ...state,
+    activeToolCallId: event.toolCallId,
+    toolCalls,
+    toolParserStateById,
+    toolCacheById,
+    error,
+  };
+}
+
+function applyTextMessageChunk(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TEXT_MESSAGE_CHUNK }>,
+): StreamingMessageState {
+  const messageId = event.messageId ?? state.messageId;
+  if (!messageId) {
+    return state;
+  }
+
+  let next = state;
+  if (!state.message || state.messageId !== messageId) {
+    next = startTextMessage(state, {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: event.role ?? 'assistant',
+      name: event.name,
+      rawEvent: event.rawEvent,
+      timestamp: event.timestamp,
+    });
+  }
+
+  if (event.delta === undefined) {
+    return next;
+  }
+
+  return appendTextContent(next, {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId,
+    delta: event.delta,
+    rawEvent: event.rawEvent,
+    timestamp: event.timestamp,
+  });
+}
+
+function applyToolCallChunk(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TOOL_CALL_CHUNK }>,
+): StreamingMessageState {
+  const toolCallId = event.toolCallId ?? state.activeToolCallId;
+  if (!toolCallId) {
+    return state;
+  }
+
+  let next = state;
+  const existing = state.toolCalls.some(
+    (toolCall) => toolCall.id === toolCallId,
+  );
+  if (!existing) {
+    if (!event.toolCallName) {
+      return state;
+    }
+    next = startToolCall(state, {
+      type: EventType.TOOL_CALL_START,
+      toolCallId,
+      toolCallName: event.toolCallName,
+      parentMessageId: event.parentMessageId,
+      rawEvent: event.rawEvent,
+      timestamp: event.timestamp,
+    });
+  } else if (state.activeToolCallId !== toolCallId) {
+    next = { ...state, activeToolCallId: toolCallId };
+  }
+
+  if (event.delta === undefined && event.rawEvent === undefined) {
+    return next;
+  }
+
+  return appendToolArguments(next, {
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId,
+    delta: event.delta ?? '',
+    rawEvent: event.rawEvent,
+    timestamp: event.timestamp,
+  });
+}
+
+function finalizeOutput(state: StreamingMessageState): StreamingMessageState {
+  const responseSchema = state.configSnapshot?.responseSchema;
+  if (!responseSchema || !state.outputParserState) {
+    return state;
+  }
+
+  const outputParserState = finish(state.outputParserState);
+  const output = resolveSchemaValue(
+    responseSchema,
+    outputParserState,
+    state.outputCache,
+  );
+  let message = state.message;
+  let error = state.error;
+
+  if (output.hasError && !error) {
+    error = new Error('Invalid structured output');
+  }
+  if (output.value !== undefined && message) {
+    message = {
+      ...message,
+      contentResolved: output.value,
+    };
+  }
+  if (output.recoveredTrailingToken && output.value !== undefined) {
+    warnRecoveredTrailingTokenFromSource(
+      outputParserState,
+      output.value,
+      message?.content ?? '',
+    );
+  }
+
+  return {
+    ...state,
+    message,
+    outputParserState,
+    outputCache: output.cache,
+    error,
+  };
+}
+
+function finalizeToolCalls(
+  state: StreamingMessageState,
+  toolCallIds?: ReadonlySet<string>,
+): StreamingMessageState {
+  const toolsByName = state.configSnapshot?.toolsByName ?? {};
+  let toolParserStateById = state.toolParserStateById;
+  let toolCacheById = state.toolCacheById;
+  let finalizedToolCallIds = state.finalizedToolCallIds;
+  let error = state.error;
+
+  const toolCalls = state.toolCalls.map((toolCall) => {
+    if (
+      (toolCallIds && !toolCallIds.has(toolCall.id)) ||
+      finalizedToolCallIds[toolCall.id]
+    ) {
+      return toolCall;
+    }
+
+    const parserState = toolParserStateById[toolCall.id];
+    const tool = toolsByName[toolCall.name];
+    if (!parserState || !tool) {
+      return toolCall;
+    }
+
+    const finalized = finish(parserState);
+    toolParserStateById = {
+      ...toolParserStateById,
+      [toolCall.id]: finalized,
+    };
+    finalizedToolCallIds = {
+      ...finalizedToolCallIds,
+      [toolCall.id]: true,
+    };
+    let argumentsResolved = toolCall.argumentsResolved;
+
+    if (s.isHashbrownType(tool.schema)) {
+      const resolved = resolveSchemaValue(
+        tool.schema,
+        finalized,
+        toolCacheById[toolCall.id],
+      );
+      toolCacheById = {
+        ...toolCacheById,
+        [toolCall.id]: resolved.cache,
+      };
+      if (resolved.value !== undefined) {
+        argumentsResolved = resolved.value;
+      }
+      if (resolved.recoveredTrailingToken && resolved.value !== undefined) {
+        warnRecoveredTrailingTokenFromSource(
+          finalized,
+          resolved.value,
+          toolCall.arguments,
+        );
+      }
+      if (resolved.hasError && !error) {
+        error = new Error(`Invalid tool arguments for ${toolCall.name}`);
+      }
+    } else {
+      const resolvedValue = resolveJsonValue(finalized);
+      if (resolvedValue !== undefined) {
+        argumentsResolved = resolvedValue;
+      }
+      if (finalized.error && !error) {
+        error = new Error(`Invalid tool arguments for ${toolCall.name}`);
+      }
+    }
+
+    return argumentsResolved === toolCall.argumentsResolved
+      ? toolCall
+      : { ...toolCall, argumentsResolved };
+  });
+
+  return {
+    ...state,
+    toolCalls,
+    toolParserStateById,
+    toolCacheById,
+    finalizedToolCallIds,
+    error,
+  };
+}
+
+function finishRun(state: StreamingMessageState): StreamingMessageState {
+  return finalizeToolCalls(finalizeOutput(state));
+}
+
+function reduceEvent(
+  state: StreamingMessageState,
+  event: AGUIEvent,
+): StreamingMessageState {
+  switch (event.type) {
+    case EventType.TEXT_MESSAGE_START:
+      return startTextMessage(state, event);
+    case EventType.TEXT_MESSAGE_CONTENT:
+      return appendTextContent(state, event);
+    case EventType.TEXT_MESSAGE_CHUNK:
+      return applyTextMessageChunk(state, event);
+    case EventType.TOOL_CALL_START:
+      return startToolCall(state, event);
+    case EventType.TOOL_CALL_ARGS:
+      return appendToolArguments(state, event);
+    case EventType.TOOL_CALL_CHUNK:
+      return applyToolCallChunk(state, event);
+    case EventType.TOOL_CALL_END:
+      return finalizeToolCalls(state, new Set([event.toolCallId]));
+    case EventType.RUN_FINISHED:
+      return finishRun(state);
+    case EventType.RUN_ERROR:
+      return {
+        ...state,
+        error: state.error ?? new Error(event.message),
+      };
+    default:
+      return state;
+  }
+}
+
 export const reducer = createReducer(
   initialState,
   on(
@@ -191,437 +601,14 @@ export const reducer = createReducer(
       };
     },
   ),
-  on(
-    apiActions.generateMessageChunk,
-    (state, action): StreamingMessageState => {
-      const choice = action.payload.choices[0];
-      if (!choice) {
-        return state;
-      }
-
-      const config = state.configSnapshot;
-      const responseSchema = config?.responseSchema;
-      const toolsByName = config?.toolsByName ?? {};
-
-      const delta = choice.delta;
-      const deltaContent = delta.content ?? '';
-      const deltaToolCalls = delta.toolCalls ?? [];
-
-      let message = state.message;
-      if (!message) {
-        if (delta.role !== 'assistant') {
-          return state;
-        }
-        message = {
-          role: 'assistant',
-          content: '',
-          toolCallIds: [],
-        };
-      }
-      const baseMessage: Chat.Internal.AssistantMessage = message ?? {
-        role: 'assistant',
-        content: '',
-        toolCallIds: [],
-      };
-      message = baseMessage;
-
-      const mergedRawToolCalls = mergeToolCalls(
-        state.rawToolCalls,
-        deltaToolCalls,
-      );
-
-      let outputParserState = state.outputParserState;
-      let outputCache = state.outputCache;
-      let toolParserStateByIndex = state.toolParserStateByIndex;
-      let toolCacheByIndex = state.toolCacheByIndex;
-      let toolCallIndexById = state.toolCallIndexById;
-      let error = state.error;
-      const updatedToolIds = new Set<string>();
-      const updatedToolIndices = new Set<number>();
-      const resolvedArgsByIndex = new Map<number, JsonValue | undefined>();
-
-      for (const toolCallDelta of deltaToolCalls) {
-        const index =
-          toolCallDelta.index ??
-          (toolCallDelta.id ? toolCallIndexById[toolCallDelta.id] : undefined);
-        const deltaArgs = toolCallDelta.function?.arguments;
-        const isStringArgs = typeof deltaArgs === 'string';
-        const hasArgs =
-          deltaArgs !== undefined &&
-          deltaArgs !== null &&
-          (!isStringArgs || deltaArgs.length > 0);
-
-        if (toolCallDelta.id && toolCallDelta.index !== undefined) {
-          toolCallIndexById = {
-            ...toolCallIndexById,
-            [toolCallDelta.id]: toolCallDelta.index,
-          };
-        }
-
-        if (index === undefined) {
-          continue;
-        }
-        updatedToolIndices.add(index);
-
-        const name = getToolCallName(
-          mergedRawToolCalls,
-          index,
-          toolCallDelta.function?.name,
-        );
-
-        if (!hasArgs) {
-          continue;
-        }
-
-        if (!name) {
-          continue;
-        }
-
-        const tool = toolsByName[name];
-        if (!tool) {
-          continue;
-        }
-
-        if (isStringArgs) {
-          toolParserStateByIndex = updateToolParserState(
-            toolParserStateByIndex,
-            index,
-            deltaArgs,
-          );
-
-          const toolState = toolParserStateByIndex[index];
-          if (!toolState) {
-            continue;
-          }
-
-          if (s.isHashbrownType(tool.schema)) {
-            const resolved = resolveSchemaValue(
-              tool.schema,
-              toolState,
-              toolCacheByIndex[index],
-            );
-            toolCacheByIndex = updateCache(
-              toolCacheByIndex,
-              index,
-              resolved.cache,
-            );
-            if (resolved.value !== undefined) {
-              resolvedArgsByIndex.set(index, resolved.value);
-            }
-
-            if (resolved.hasError && !error) {
-              error = new Error(`Invalid tool arguments for ${name}`);
-            }
-          } else if (toolState.error && !error) {
-            error = new Error(`Invalid tool arguments for ${name}`);
-          } else {
-            const resolvedValue = resolveJsonValue(toolState);
-            if (resolvedValue !== undefined) {
-              resolvedArgsByIndex.set(index, resolvedValue);
-            }
-          }
-        } else {
-          resolvedArgsByIndex.set(index, deltaArgs as JsonValue);
-        }
-
-        if (toolCallDelta.id) {
-          updatedToolIds.add(toolCallDelta.id);
-        }
-      }
-
-      let nextContent = message.content ?? '';
-      nextContent += deltaContent;
-
-      if (responseSchema && deltaContent) {
-        const nextOutputState = push(
-          ensureParserState(outputParserState),
-          deltaContent,
-        );
-        outputParserState = nextOutputState;
-        const output = resolveSchemaValue(
-          responseSchema,
-          nextOutputState,
-          outputCache,
-        );
-        outputCache = output.cache;
-        if (output.hasError && !error) {
-          error = new Error('Invalid structured output');
-        }
-        if (output.value !== undefined) {
-          message = {
-            ...message,
-            contentResolved: output.value,
-          };
-        }
-      }
-
-      const existingToolCalls = state.toolCalls;
-      const existingById = existingToolCalls.reduce(
-        (acc, toolCall) => {
-          acc[toolCall.id] = toolCall;
-          return acc;
-        },
-        {} as Record<string, Chat.Internal.ToolCall>,
-      );
-
-      const nextToolCalls = mergedRawToolCalls.flatMap((toolCall) => {
-        const name = toolCall.function?.name;
-        if (!name) {
-          return [];
-        }
-
-        const toolCallId =
-          toolCall.id ??
-          (toolCall.index !== undefined
-            ? `tool-call-${toolCall.index}`
-            : undefined);
-        if (!toolCallId) {
-          return [];
-        }
-
-        const existing = existingById[toolCallId];
-        if (
-          existing &&
-          !updatedToolIds.has(toolCallId) &&
-          !updatedToolIndices.has(toolCall.index ?? -1)
-        ) {
-          return [existing];
-        }
-
-        const base: Chat.Internal.ToolCall = existing ?? {
-          id: toolCallId,
-          name,
-          arguments: '',
-          status: 'pending',
-        };
-
-        const rawArguments = toolCall.function?.arguments;
-        const argumentsString =
-          typeof rawArguments === 'string'
-            ? rawArguments
-            : rawArguments != null
-              ? JSON.stringify(rawArguments)
-              : '';
-
-        const tool = toolsByName[name];
-        const toolIndex =
-          toolCall.index ??
-          (toolCall.id ? toolCallIndexById[toolCall.id] : undefined);
-        const parserState =
-          tool && toolIndex !== undefined
-            ? toolParserStateByIndex[toolIndex]
-            : undefined;
-        let argumentsResolved = base.argumentsResolved;
-
-        if (tool && parserState && toolIndex !== undefined) {
-          const resolved = resolvedArgsByIndex.get(toolIndex);
-          if (resolved !== undefined) {
-            argumentsResolved = resolved;
-          }
-        }
-
-        return [
-          {
-            ...base,
-            name,
-            arguments: argumentsString,
-            argumentsResolved,
-          },
-        ];
-      });
-
-      const nextMessage: Chat.Internal.AssistantMessage = {
-        ...message,
-        content: nextContent,
-        toolCallIds: nextToolCalls.map((toolCall) => toolCall.id),
-      };
-
-      return {
-        ...state,
-        message: nextMessage,
-        toolCalls: nextToolCalls,
-        rawToolCalls: mergedRawToolCalls,
-        outputParserState,
-        outputCache,
-        toolParserStateByIndex,
-        toolCacheByIndex,
-        toolCallIndexById,
-        error,
-      };
-    },
+  on(apiActions.generateMessageEvent, (state, action): StreamingMessageState =>
+    reduceEvent(state, action.payload),
   ),
-  on(apiActions.generateMessageFinish, (state): StreamingMessageState => {
-    const config = state.configSnapshot;
-    const responseSchema = config?.responseSchema;
-    const toolsByName = config?.toolsByName ?? {};
-
-    let outputParserState = state.outputParserState;
-    let outputCache = state.outputCache;
-    let toolParserStateByIndex = state.toolParserStateByIndex;
-    let toolCacheByIndex = state.toolCacheByIndex;
-    const toolCallIndexById = state.toolCallIndexById;
-    let error = state.error;
-    let message = state.message;
-
-    if (responseSchema && outputParserState) {
-      outputParserState = finish(outputParserState);
-      const output = resolveSchemaValue(
-        responseSchema,
-        outputParserState,
-        outputCache,
-      );
-      outputCache = output.cache;
-      if (output.hasError && !error) {
-        error = new Error('Invalid structured output');
-      }
-      if (output.value !== undefined && message) {
-        message = {
-          ...message,
-          contentResolved: output.value,
-        };
-      }
-      if (output.recoveredTrailingToken && output.value !== undefined) {
-        warnRecoveredTrailingTokenFromSource(
-          outputParserState,
-          output.value,
-          message?.content ?? '',
-        );
-      }
-    }
-
-    const finalizedToolStates: ParserMap = {};
-    Object.entries(toolParserStateByIndex).forEach(([key, parserState]) => {
-      const index = Number(key);
-      const finalized = finish(parserState);
-      const toolName = getToolCallName(state.rawToolCalls, index);
-      const tool = toolName ? toolsByName[toolName] : undefined;
-      const canRecoverTrailingToken =
-        tool &&
-        s.isHashbrownType(tool.schema) &&
-        isRecoverableTrailingToken(finalized);
-      finalizedToolStates[index] = finalized;
-      if (finalized.error && !canRecoverTrailingToken && !error) {
-        error = new Error('Invalid tool arguments');
-      }
-    });
-    toolParserStateByIndex = finalizedToolStates;
-
-    const existingById = state.toolCalls.reduce(
-      (acc, toolCall) => {
-        acc[toolCall.id] = toolCall;
-        return acc;
-      },
-      {} as Record<string, Chat.Internal.ToolCall>,
-    );
-
-    const nextToolCalls = state.rawToolCalls.flatMap((toolCall) => {
-      const name = toolCall.function?.name;
-      if (!name) {
-        return [];
-      }
-
-      const toolCallId =
-        toolCall.id ??
-        (toolCall.index !== undefined
-          ? `tool-call-${toolCall.index}`
-          : undefined);
-      if (!toolCallId) {
-        return [];
-      }
-
-      const existing = existingById[toolCallId];
-      const base: Chat.Internal.ToolCall = existing ?? {
-        id: toolCallId,
-        name,
-        arguments: '',
-        status: 'pending',
-        metadata: toolCall.metadata,
-      };
-
-      const rawArguments = toolCall.function?.arguments;
-      const argumentsString =
-        typeof rawArguments === 'string'
-          ? rawArguments
-          : rawArguments != null
-            ? JSON.stringify(rawArguments)
-            : '';
-
-      const tool = toolsByName[name];
-      const toolIndex =
-        toolCall.index ??
-        (toolCall.id ? toolCallIndexById[toolCall.id] : undefined);
-      const parserState = tool ? toolParserStateByIndex[toolIndex] : undefined;
-      let argumentsResolved = base.argumentsResolved;
-
-      if (tool && parserState && toolIndex !== undefined) {
-        if (s.isHashbrownType(tool.schema)) {
-          const resolved = resolveSchemaValue(
-            tool.schema,
-            parserState,
-            toolCacheByIndex[toolIndex],
-          );
-          toolCacheByIndex = updateCache(
-            toolCacheByIndex,
-            toolIndex,
-            resolved.cache,
-          );
-          if (resolved.value !== undefined) {
-            argumentsResolved = resolved.value;
-          }
-          if (resolved.recoveredTrailingToken && resolved.value !== undefined) {
-            warnRecoveredTrailingTokenFromSource(
-              parserState,
-              resolved.value,
-              argumentsString,
-            );
-          }
-          if (resolved.hasError && !error) {
-            error = new Error(`Invalid tool arguments for ${name}`);
-          }
-        } else {
-          const resolvedValue = resolveJsonValue(parserState);
-          if (resolvedValue !== undefined) {
-            argumentsResolved = resolvedValue;
-          }
-        }
-      }
-
-      return [
-        {
-          ...base,
-          name,
-          arguments: argumentsString,
-          argumentsResolved,
-          metadata: toolCall.metadata ?? base.metadata,
-        },
-      ];
-    });
-
-    if (message) {
-      message = {
-        ...message,
-        toolCallIds: nextToolCalls.map((toolCall) => toolCall.id),
-      };
-    }
-
-    return {
-      ...state,
-      message,
-      toolCalls: nextToolCalls,
-      outputParserState,
-      outputCache,
-      toolParserStateByIndex,
-      toolCacheByIndex,
-      error,
-    };
-  }),
   on(
     apiActions.generateMessageSuccess,
     apiActions.generateMessageError,
     devActions.stopMessageGeneration,
-    () => {
-      return initialState;
-    },
+    () => initialState,
   ),
 );
 

--- a/packages/core/src/transport/completion-chunk-to-agui-events.spec.ts
+++ b/packages/core/src/transport/completion-chunk-to-agui-events.spec.ts
@@ -1,0 +1,291 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { Chat } from '../models';
+import { createCompletionChunkEventAdapter } from './completion-chunk-to-agui-events';
+
+function chunk(
+  delta: Chat.Api.CompletionChunk['choices'][number]['delta'],
+): Chat.Api.CompletionChunk {
+  return {
+    choices: [{ index: 0, delta, finishReason: null }],
+  };
+}
+
+test('converts legacy text chunks into AG-UI text events', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const first = adapter.push(chunk({ role: 'assistant', content: 'Hello' }));
+  const second = adapter.push(chunk({ content: ' world' }));
+  const finished = adapter.finish();
+
+  expect([...first, ...second, ...finished]).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-1',
+      delta: 'Hello',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-1',
+      delta: ' world',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'message-1',
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('converts interleaved legacy tool deltas into AG-UI tool events', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const first = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-weather',
+          type: 'function',
+          function: { name: 'weather', arguments: '{"city":' },
+        },
+        {
+          index: 1,
+          id: 'call-time',
+          type: 'function',
+          function: { name: 'time', arguments: '{"zone":' },
+        },
+      ],
+    }),
+  );
+  const second = adapter.push(
+    chunk({
+      toolCalls: [
+        { index: 1, function: { arguments: '"UTC"}' } },
+        { index: 0, function: { arguments: '"Paris"}' } },
+      ],
+    }),
+  );
+  const finished = adapter.finish();
+
+  expect([...first, ...second, ...finished]).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-weather',
+      toolCallName: 'weather',
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-weather',
+      delta: '{"city":',
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-time',
+      toolCallName: 'time',
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-time',
+      delta: '{"zone":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-time',
+      delta: '"UTC"}',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-weather',
+      delta: '"Paris"}',
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: 'call-weather',
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: 'call-time',
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('buffers tool arguments until legacy chunks provide an id and name', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const buffered = adapter.push(
+    chunk({
+      toolCalls: [{ index: 0, function: { arguments: '{"value":' } }],
+    }),
+  );
+  const identified = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-1',
+          function: { name: 'submit', arguments: '1}' },
+        },
+      ],
+    }),
+  );
+
+  expect(buffered).toEqual([]);
+  expect(identified).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-1',
+      toolCallName: 'submit',
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-1',
+      delta: '{"value":1}',
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('serializes object-valued legacy tool arguments into AG-UI deltas', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const events = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-weather',
+          type: 'function',
+          function: {
+            name: 'weather',
+            arguments: { city: 'Paris' } as unknown as string,
+          },
+        },
+      ],
+    }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-weather',
+      toolCallName: 'weather',
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-weather',
+      delta: '{"city":"Paris"}',
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('preserves tool metadata and resolves indexless deltas by id', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const started = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'submit', arguments: '{"value":' },
+        },
+      ],
+    }),
+  );
+  const continued = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          id: 'call-1',
+          function: { arguments: '1}' },
+          metadata: { signature: 'opaque' },
+        },
+      ],
+    }),
+  );
+
+  expect([...started, ...continued]).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-1',
+      toolCallName: 'submit',
+      parentMessageId: 'message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-1',
+      delta: '{"value":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-1',
+      delta: '1}',
+      rawEvent: {
+        hashbrown: {
+          metadata: { signature: 'opaque' },
+        },
+      },
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('emits metadata-only legacy deltas after a tool call starts', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+  adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'submit', arguments: '{}' },
+        },
+      ],
+    }),
+  );
+
+  const events = adapter.push(
+    chunk({
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-1',
+          metadata: { google: { thoughtSignature: 'opaque' } },
+        },
+      ],
+    }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-1',
+      delta: '',
+      rawEvent: {
+        hashbrown: {
+          metadata: { google: { thoughtSignature: 'opaque' } },
+        },
+      },
+    },
+  ] satisfies AGUIEvent[]);
+});
+
+test('ignores empty legacy chunks and finishes idempotently', () => {
+  const adapter = createCompletionChunkEventAdapter('message-1');
+
+  const empty = adapter.push({ choices: [] });
+  const firstFinish = adapter.finish();
+  const secondFinish = adapter.finish();
+
+  expect(empty).toEqual([]);
+  expect(firstFinish).toEqual([]);
+  expect(secondFinish).toEqual([]);
+});

--- a/packages/core/src/transport/completion-chunk-to-agui-events.ts
+++ b/packages/core/src/transport/completion-chunk-to-agui-events.ts
@@ -1,0 +1,188 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { Chat } from '../models';
+
+type LegacyToolCall = {
+  id?: string;
+  name?: string;
+  arguments: string;
+  metadata?: Record<string, unknown>;
+  started: boolean;
+};
+
+function serializeArguments(value: unknown) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Stateful adapter for the legacy completion chunks still emitted by frame transports.
+ *
+ * This adapter exists only at the legacy ingress boundary. Hashbrown reducers consume
+ * the returned AG-UI events and do not depend on provider-shaped completion chunks.
+ *
+ * @internal
+ */
+export interface CompletionChunkEventAdapter {
+  push(chunk: Chat.Api.CompletionChunk): AGUIEvent[];
+  finish(): AGUIEvent[];
+}
+
+/**
+ * Creates an adapter that converts legacy completion chunks into AG-UI message events.
+ *
+ * @param messageId - Stable AG-UI ID assigned to the assistant message for the run.
+ * @returns A stateful completion chunk adapter.
+ * @internal
+ */
+export function createCompletionChunkEventAdapter(
+  messageId: string,
+): CompletionChunkEventAdapter {
+  const toolCalls = new Map<number, LegacyToolCall>();
+  const toolCallIndexById = new Map<string, number>();
+  let textStarted = false;
+  let finished = false;
+
+  return {
+    push(chunk) {
+      if (finished) {
+        return [];
+      }
+
+      const choice = chunk.choices[0];
+      if (!choice) {
+        return [];
+      }
+
+      const events: AGUIEvent[] = [];
+      const content = choice.delta.content;
+      if (typeof content === 'string' && content.length > 0) {
+        if (!textStarted) {
+          textStarted = true;
+          events.push({
+            type: EventType.TEXT_MESSAGE_START,
+            messageId,
+            role: 'assistant',
+          });
+        }
+
+        events.push({
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId,
+          delta: content,
+        });
+      }
+
+      for (const delta of choice.delta.toolCalls ?? []) {
+        const index =
+          delta.index ??
+          (delta.id ? toolCallIndexById.get(delta.id) : undefined);
+        if (index === undefined) {
+          continue;
+        }
+
+        const previous = toolCalls.get(index) ?? {
+          arguments: '',
+          started: false,
+        };
+        const argumentDelta = serializeArguments(
+          delta.function?.arguments as unknown,
+        );
+        const next: LegacyToolCall = {
+          id: delta.id ?? previous.id,
+          name: delta.function?.name ?? previous.name,
+          arguments:
+            previous.arguments +
+            (argumentDelta !== undefined ? argumentDelta : ''),
+          metadata: delta.metadata
+            ? { ...(previous.metadata ?? {}), ...delta.metadata }
+            : previous.metadata,
+          started: previous.started,
+        };
+
+        if (next.id) {
+          toolCallIndexById.set(next.id, index);
+        }
+
+        if (!next.started && next.id && next.name) {
+          next.started = true;
+          events.push({
+            type: EventType.TOOL_CALL_START,
+            toolCallId: next.id,
+            toolCallName: next.name,
+            parentMessageId: messageId,
+            ...(next.metadata
+              ? {
+                  rawEvent: {
+                    hashbrown: { metadata: next.metadata },
+                  },
+                }
+              : {}),
+          });
+          if (next.arguments.length > 0) {
+            events.push({
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: next.id,
+              delta: next.arguments,
+            });
+          }
+        } else if (
+          next.started &&
+          next.id &&
+          ((argumentDelta !== undefined && argumentDelta.length > 0) ||
+            delta.metadata)
+        ) {
+          events.push({
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: next.id,
+            delta: argumentDelta ?? '',
+            ...(delta.metadata
+              ? {
+                  rawEvent: {
+                    hashbrown: { metadata: delta.metadata },
+                  },
+                }
+              : {}),
+          });
+        }
+
+        toolCalls.set(index, next);
+      }
+
+      return events;
+    },
+    finish() {
+      if (finished) {
+        return [];
+      }
+      finished = true;
+
+      const events: AGUIEvent[] = [];
+      if (textStarted) {
+        events.push({
+          type: EventType.TEXT_MESSAGE_END,
+          messageId,
+        });
+      }
+      for (const toolCall of toolCalls.values()) {
+        if (toolCall.started && toolCall.id) {
+          events.push({
+            type: EventType.TOOL_CALL_END,
+            toolCallId: toolCall.id,
+          });
+        }
+      }
+
+      return events;
+    },
+  };
+}

--- a/packages/ollama/src/integration.spec.ts
+++ b/packages/ollama/src/integration.spec.ts
@@ -96,10 +96,9 @@ test('Ollama tool calling emits tool call deltas', async () => {
     toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
   ).toBe(true);
   expect(
-    JSON.stringify(
-      toolCallDeltas.map((toolCall) => toolCall.function?.arguments ?? ''),
-    ),
-  ).toContain('hashbrown');
+    toolCallDeltas.find((toolCall) => toolCall.function?.name === 'lookup')
+      ?.function?.arguments as unknown,
+  ).toEqual({ query: 'hashbrown' });
 });
 
 test('Ollama structured output fixture emits JSON text content', async () => {

--- a/packages/react/e2e/package-shape.e2e.spec.ts
+++ b/packages/react/e2e/package-shape.e2e.spec.ts
@@ -58,6 +58,11 @@ function createPackageSandbox(): string {
   cpSync(reactDistPath, join(scopePath, 'react'), { recursive: true });
   cpSync(coreDistPath, join(scopePath, 'core'), { recursive: true });
   symlinkSync(
+    join(workspaceRoot, 'node_modules/@ag-ui'),
+    join(nodeModulesPath, '@ag-ui'),
+    'dir',
+  );
+  symlinkSync(
     join(workspaceRoot, 'node_modules/@cacheplane'),
     join(nodeModulesPath, '@cacheplane'),
     'dir',

--- a/samples/smart-home/angular/project.json
+++ b/samples/smart-home/angular/project.json
@@ -30,7 +30,7 @@
             {
               "type": "initial",
               "maximumWarning": "500kb",
-              "maximumError": "1mb"
+              "maximumError": "1.1mb"
             },
             {
               "type": "anyComponentStyle",


### PR DESCRIPTION
## Summary

- add `@ag-ui/core` as a direct Core dependency and consume its event types directly
- translate the existing frame transport into canonical AG-UI run, text, and tool events at the effect boundary
- move streaming/status reducers to AG-UI events while retaining Cacheplane incremental structured-output and tool-argument parsing
- harden interleaved tool calls, metadata, object-valued arguments, premature EOF, retry, and cancellation behavior

## Why

This establishes AG-UI as Hashbrown's internal event contract without removing the framework's reducer, tool-loop, or incremental parsing capabilities. The current binary frame protocol remains isolated behind a private ingress adapter so later HTTP/SSE transport work can replace it without another reducer rewrite.

## Verification

- CI affected lint, test, typecheck, build, and e2e validation
- CI smart-home React tooling and Cloudflare preview deployment
- 250 Core tests, 79 React tests, 152 Angular tests, 7 Ollama tests locally
- sequential Core build and API report
- independent review found no remaining Critical or Important issues

## Notes

AG-UI Core's runtime `EventType` import adds about 37 kB to the smart-home Angular initial bundle because the package eagerly initializes its Zod schemas. The sample's warning remains at 500 kB, while its hard error budget is raised from 1 MB to 1.1 MB for this intentional dependency cost.