### PR TITLE
feat(core): add AG-UI HTTP transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@ag-ui/client": "0.0.58",
         "@ag-ui/core": "0.0.58",
         "@analogjs/content": "3.0.0-alpha.64",
         "@analogjs/router": "3.0.0-alpha.64",
@@ -215,6 +216,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ag-ui/client": {
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.58.tgz",
+      "integrity": "sha512-9tAUJ6Ot0y2f5Va7xGFhUSO5OPAjilMsPdmKNmAUR774LKWcvNpriJ6mqH3p/ewUue1zfoUo4vpX+9Xo/zsuzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/core": "0.0.58",
+        "@ag-ui/encoder": "0.0.58",
+        "@ag-ui/proto": "0.0.58",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@ag-ui/core": {
       "version": "0.0.58",
       "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.58.tgz",
@@ -222,6 +250,27 @@
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/encoder": {
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.58.tgz",
+      "integrity": "sha512-eMfjJbfAGTQECgNX3QO0Mt0V5OrIViowSPmGLzdO92q2x506K2hRs2VBlfEuAzpDFp6Eq23Q/vjNHFzv37StZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/core": "0.0.58",
+        "@ag-ui/proto": "0.0.58"
+      }
+    },
+    "node_modules/@ag-ui/proto": {
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.58.tgz",
+      "integrity": "sha512-fErOnFPfpZlNSreeOEdUVuCzTQI463JoUo1DNx4grAvSZPOg4tVgqvG2s82qJE9pZoh48VSUqk6hyV82GT/wIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/core": "0.0.58",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8119,7 +8168,6 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
       "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
-      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cacheplane/json-stream": {
@@ -17081,6 +17129,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -21163,6 +21220,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -26343,7 +26406,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/compress-commons": {
@@ -29972,6 +30034,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -51638,6 +51706,12 @@
         "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
+    },
+    "node_modules/untruncate-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/untruncate-json/-/untruncate-json-0.0.1.tgz",
+      "integrity": "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     ]
   },
   "dependencies": {
+    "@ag-ui/client": "0.0.58",
     "@ag-ui/core": "0.0.58",
     "@analogjs/content": "3.0.0-alpha.64",
     "@analogjs/router": "3.0.0-alpha.64",

--- a/packages/angular/e2e/package-compatibility.e2e.test.mjs
+++ b/packages/angular/e2e/package-compatibility.e2e.test.mjs
@@ -1,11 +1,103 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 const packageDirectory = new URL(
   '../../../dist/packages/angular/',
   import.meta.url,
 );
+const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const angularDistPath = fileURLToPath(packageDirectory);
+const coreDistPath = join(workspaceRoot, 'dist/packages/core');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const childProcessTimeoutMs = 90_000;
+
+function assertProcessSucceeded(label, command, args, result) {
+  if (!result.error && !result.signal && result.status === 0) {
+    return;
+  }
+
+  const failureDetails = [
+    result.error
+      ? `${result.error.code ?? result.error.name}: ${result.error.message}`
+      : undefined,
+    result.signal ? `signal ${result.signal}` : undefined,
+    result.status !== null ? `exit status ${result.status}` : undefined,
+  ].filter(Boolean);
+  throw new Error(
+    `${label} failed (${failureDetails.join(', ')})\n` +
+      `Command: ${command} ${args.join(' ')}\n` +
+      `stdout:\n${result.stdout || '<empty>'}\n` +
+      `stderr:\n${result.stderr || '<empty>'}`,
+  );
+}
+
+function runNpm(args, cwd) {
+  const result = spawnSync(npmCommand, args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: childProcessTimeoutMs,
+  });
+  assertProcessSucceeded('npm command', npmCommand, args, result);
+
+  return result.stdout;
+}
+
+function packPackage(packagePath, packPath) {
+  const output = runNpm(
+    ['pack', packagePath, '--json', '--pack-destination', packPath],
+    workspaceRoot,
+  );
+  const filename = JSON.parse(output)[0]?.filename;
+  if (!filename) {
+    throw new Error(`npm pack did not report a filename for ${packagePath}`);
+  }
+
+  return join(packPath, filename);
+}
+
+function createPackageSandbox() {
+  const sandboxPath = mkdtempSync(join(tmpdir(), 'hashbrown-angular-package-'));
+  try {
+    const packPath = join(sandboxPath, 'packs');
+    mkdirSync(packPath);
+    writeFileSync(
+      join(sandboxPath, 'package.json'),
+      JSON.stringify({
+        name: 'hashbrown-angular-package-e2e',
+        private: true,
+        type: 'module',
+      }),
+    );
+    const coreTarball = packPackage(coreDistPath, packPath);
+    const angularTarball = packPackage(angularDistPath, packPath);
+    runNpm(
+      [
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        '--no-package-lock',
+        coreTarball,
+        angularTarball,
+        '@angular/common@22.1.1',
+        '@angular/compiler@22.1.1',
+        '@angular/core@22.1.1',
+      ],
+      sandboxPath,
+    );
+
+    return sandboxPath;
+  } catch (error) {
+    rmSync(sandboxPath, { recursive: true, force: true });
+    throw error;
+  }
+}
 
 test('published package declares the Angular 22 compatibility boundary', async () => {
   const [packageContents, bundle] = await Promise.all([
@@ -23,3 +115,55 @@ test('published package declares the Angular 22 compatibility boundary', async (
   assert.match(bundle, /from '@cacheplane\/partial-json'/);
   assert.match(bundle, /ChangeDetectionStrategy\.Eager/);
 });
+
+test(
+  'packed Angular and core packages install and load in a clean consumer',
+  { timeout: 120_000 },
+  () => {
+    const sandboxPath = createPackageSandbox();
+
+    try {
+      const args = [
+        '--input-type=module',
+        '--eval',
+        `
+            import { createRequire } from 'node:module';
+
+            const require = createRequire(import.meta.url);
+            await import('@angular/compiler');
+            const angular = await import('@hashbrownai/angular');
+            const cjsCore = require('@hashbrownai/core');
+            const esmCore = await import('@hashbrownai/core');
+
+            if (typeof angular.provideHashbrown !== 'function') {
+              throw new Error('Angular entrypoint did not expose provideHashbrown');
+            }
+
+            if (typeof cjsCore.HttpTransport !== 'function') {
+              throw new Error('CJS core did not load the AG-UI transport dependency tree');
+            }
+
+            if (typeof esmCore.HttpTransport !== 'function') {
+              throw new Error('ESM core did not load the AG-UI transport dependency tree');
+            }
+          `,
+      ];
+      const result = spawnSync(process.execPath, args, {
+        cwd: sandboxPath,
+        encoding: 'utf8',
+        timeout: childProcessTimeoutMs,
+      });
+      assertProcessSucceeded(
+        'Consumer Node check',
+        process.execPath,
+        args,
+        result,
+      );
+
+      assert.equal(result.stderr, '');
+      assert.equal(result.status, 0);
+    } finally {
+      rmSync(sandboxPath, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/core/e2e/package-shape.e2e.spec.ts
+++ b/packages/core/e2e/package-shape.e2e.spec.ts
@@ -82,8 +82,15 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
             '@hashbrownai/core/package.json',
           );
           const packageJson = require(packageJsonPath);
-          if (packageJson.dependencies?.['@ag-ui/core'] !== '0.0.58') {
-            throw new Error('Core must declare an exact @ag-ui/core dependency');
+          const agUiCoreVersion = packageJson.dependencies?.['@ag-ui/core'];
+          const agUiClientVersion = packageJson.dependencies?.['@ag-ui/client'];
+          if (
+            agUiCoreVersion !== '0.0.58' ||
+            agUiClientVersion !== agUiCoreVersion
+          ) {
+            throw new Error(
+              'Core must declare exact matching @ag-ui/core and @ag-ui/client dependencies',
+            );
           }
           const cjs = require('@hashbrownai/core');
           const cjsPartialJson = require('@cacheplane/partial-json');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ag-ui/client": "0.0.58",
     "@ag-ui/core": "0.0.58",
     "@cacheplane/partial-json": "0.2.2"
   },

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1,7 +1,7 @@
-import { EventType } from '@ag-ui/core';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { Chat } from '../models';
 import { s } from '../schema';
-import { apiActions, devActions } from '../actions';
+import { apiActions, devActions, internalActions } from '../actions';
 import {
   selectApiMessages,
   selectApiTools,
@@ -20,11 +20,18 @@ import {
   selectSystem,
   selectThreadId,
   selectToolEntities,
+  selectTools,
   selectTransport,
   selectUiRequested,
 } from '../reducers';
 import { decodeFrames } from '../frames/decode-frames';
-import { ModelResolver, TransportError } from '../transport';
+import { createCompletionChunkEventAdapter } from '../transport/completion-chunk-to-agui-events';
+import {
+  framesToLengthPrefixedStream,
+  ModelResolver,
+  TransportError,
+  type TransportRequest,
+} from '../transport';
 import {
   _extractMessageDelta,
   _updateMessagesWithDelta,
@@ -38,6 +45,18 @@ jest.mock('../frames/decode-frames', () => ({
     }
   }),
 }));
+
+jest.mock('../transport/completion-chunk-to-agui-events', () => {
+  const actual = jest.requireActual(
+    '../transport/completion-chunk-to-agui-events',
+  );
+  return {
+    ...actual,
+    createCompletionChunkEventAdapter: jest.fn(
+      actual.createCompletionChunkEventAdapter,
+    ),
+  };
+});
 
 jest.mock('../transport', () => {
   const actual = jest.requireActual('../transport');
@@ -74,6 +93,7 @@ function createTestStore(selectorOverrides: SelectorMap = new Map()) {
     [selectRetries, 0],
     [selectApiTools, []],
     [selectToolEntities, {}],
+    [selectTools, []],
     [selectSystem, 'You are a test bot'],
     [selectEmulateStructuredOutput, false],
     [selectStructuredOutput, undefined],
@@ -642,8 +662,15 @@ function mockSuccessfulSelection() {
 
 const ModelResolverMock = jest.mocked(ModelResolver);
 const decodeFramesMock = jest.mocked(decodeFrames);
+const framesToLengthPrefixedStreamMock = jest.mocked(
+  framesToLengthPrefixedStream,
+);
+const createCompletionChunkEventAdapterMock = jest.mocked(
+  createCompletionChunkEventAdapter,
+);
 
 type MockTransportResponse = {
+  events?: AsyncIterable<AGUIEvent>;
   frames?: AsyncIterable<unknown>;
   stream?: AsyncIterable<unknown>;
   dispose?: jest.Mock;
@@ -651,26 +678,1432 @@ type MockTransportResponse = {
 };
 
 function makeSelection(
-  transportResponseFactory: (request: {
-    signal: AbortSignal;
-  }) => Promise<MockTransportResponse>,
+  transportResponseFactory: (
+    request: TransportRequest,
+  ) => Promise<MockTransportResponse>,
+  transportOverrides: { supportsLegacyThreadLoading?: boolean } = {},
 ) {
   const send = jest.fn().mockImplementation(transportResponseFactory);
   const selection = {
     spec: { name: 'selected-model' },
-    transport: { send },
+    transport: { ...transportOverrides, send },
     metadata: { chosenSpec: 'selected-model', skippedSpecs: [] },
   };
+  const select = jest.fn(async () => selection);
   ModelResolverMock.mockImplementation(
     () =>
       ({
-        select: jest.fn(async () => selection),
+        select,
         skipFromError: jest.fn(),
         getMetadata: jest.fn(() => selection.metadata),
       }) as unknown as ModelResolver,
   );
-  return { send, selection };
+  return { select, send, selection };
 }
+
+type TestSelection = {
+  spec: { name: string };
+  transport: {
+    send: jest.Mock;
+    supportsLegacyThreadLoading?: boolean;
+  };
+  metadata: { chosenSpec: string; skippedSpecs: [] };
+};
+
+function mockSelectionSequence(selections: Array<TestSelection | undefined>) {
+  const select = jest.fn();
+  for (const selection of selections) {
+    select.mockResolvedValueOnce(selection);
+  }
+  select.mockResolvedValue(undefined);
+  const skipFromError = jest.fn();
+  ModelResolverMock.mockImplementation(
+    () =>
+      ({
+        select,
+        skipFromError,
+        getMetadata: jest.fn(() => ({ skippedSpecs: [] })),
+      }) as unknown as ModelResolver,
+  );
+
+  return { select, skipFromError };
+}
+
+function createTestSelection(
+  name: string,
+  send: jest.Mock,
+  supportsLegacyThreadLoading?: boolean,
+): TestSelection {
+  return {
+    spec: { name },
+    transport: { send, supportsLegacyThreadLoading },
+    metadata: { chosenSpec: name, skippedSpecs: [] },
+  };
+}
+
+function getInputIdentity(request: TransportRequest) {
+  if (!request.input) {
+    throw new Error('Expected modern AG-UI input');
+  }
+
+  return {
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+}
+
+test.each(['FEATURE_UNSUPPORTED', 'PLATFORM_UNSUPPORTED'] as const)(
+  'sends a compatible replacement after %s without consuming a retry',
+  async (code) => {
+    jest.clearAllMocks();
+    const unsupportedSend = jest.fn<
+      Promise<MockTransportResponse>,
+      [TransportRequest]
+    >(async () => {
+      throw new TransportError('unsupported transport', {
+        retryable: false,
+        code,
+      });
+    });
+    const replacementSend = jest.fn(async (request: TransportRequest) => {
+      const identity = getInputIdentity(request);
+
+      return {
+        events: (async function* () {
+          yield { type: EventType.RUN_STARTED, ...identity };
+          yield { type: EventType.RUN_FINISHED, ...identity };
+        })(),
+      };
+    });
+    const unsupportedSelection = createTestSelection(
+      'unsupported',
+      unsupportedSend,
+    );
+    const replacementSelection = createTestSelection(
+      'replacement',
+      replacementSend,
+    );
+    const { select, skipFromError } = mockSelectionSequence([
+      unsupportedSelection,
+      replacementSelection,
+    ]);
+    const store = createTestStore(
+      new Map<SelectorKey, unknown>([
+        [
+          selectRawStreamingMessage,
+          {
+            role: 'assistant',
+            content: 'Fallback succeeded',
+            toolCallIds: [],
+          },
+        ],
+      ]),
+    );
+    const teardown = generateMessage(store);
+
+    await store.trigger(
+      devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+    );
+
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(skipFromError).toHaveBeenCalledWith(
+      unsupportedSelection.spec,
+      expect.objectContaining({ code }),
+    );
+    expect(unsupportedSend).toHaveBeenCalledTimes(1);
+    expect(replacementSend).toHaveBeenCalledTimes(1);
+    expect(unsupportedSend.mock.calls[0]?.[0]).toMatchObject({
+      attempt: 1,
+      maxAttempts: 1,
+      params: { model: 'unsupported' },
+    });
+    expect(replacementSend.mock.calls[0]?.[0]).toMatchObject({
+      attempt: 1,
+      maxAttempts: 1,
+      params: { model: 'replacement' },
+    });
+    expect(
+      store.actions.filter(
+        (action) => action.type === apiActions.generateMessageSuccess.type,
+      ),
+    ).toHaveLength(1);
+
+    teardown?.();
+  },
+);
+
+test('does not load an empty configured thread through a modern transport', async () => {
+  jest.clearAllMocks();
+  const send = jest.fn();
+  const modernSelection = createTestSelection('modern', send, false);
+  const { select, skipFromError } = mockSelectionSequence([
+    modernSelection,
+    undefined,
+  ]);
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectApiMessages, []],
+      [selectShouldGenerateMessage, false],
+      [selectThreadId, 'configured-thread'],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(internalActions.sizzle());
+
+  expect(select).toHaveBeenCalledTimes(2);
+  expect(skipFromError).toHaveBeenCalledWith(
+    modernSelection.spec,
+    expect.objectContaining({
+      name: 'TransportError',
+      code: 'FEATURE_UNSUPPORTED',
+      retryable: false,
+      message: expect.stringMatching(/legacy thread load/i),
+    }),
+  );
+  expect(send).not.toHaveBeenCalled();
+
+  teardown?.();
+});
+
+test('skips a modern transport and loads an empty thread with the next legacy transport', async () => {
+  jest.clearAllMocks();
+  const modernSend = jest.fn();
+  const legacySend = jest.fn<
+    Promise<MockTransportResponse>,
+    [TransportRequest]
+  >(async () => ({
+    frames: (async function* () {
+      yield { type: 'thread-load-start' as const };
+      yield { type: 'thread-load-success' as const, thread: [] };
+    })(),
+  }));
+  const modernSelection = createTestSelection('modern', modernSend, false);
+  const legacySelection = createTestSelection('legacy', legacySend, true);
+  const { select, skipFromError } = mockSelectionSequence([
+    modernSelection,
+    legacySelection,
+  ]);
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectApiMessages, []],
+      [selectShouldGenerateMessage, false],
+      [selectThreadId, 'configured-thread'],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(internalActions.sizzle());
+
+  expect(select).toHaveBeenCalledTimes(2);
+  expect(skipFromError).toHaveBeenCalledTimes(1);
+  expect(modernSend).not.toHaveBeenCalled();
+  expect(legacySend).toHaveBeenCalledTimes(1);
+  expect(legacySend.mock.calls[0]?.[0]).toMatchObject({
+    attempt: 1,
+    params: { operation: 'load-thread', messages: [] },
+  });
+
+  teardown?.();
+});
+
+test('does not send an empty thread request to a modern fallback', async () => {
+  jest.clearAllMocks();
+  const legacySend = jest.fn<
+    Promise<MockTransportResponse>,
+    [TransportRequest]
+  >(async () => {
+    throw new TransportError('legacy transport unavailable', {
+      retryable: false,
+      code: 'FEATURE_UNSUPPORTED',
+    });
+  });
+  const modernSend = jest.fn(async (request: TransportRequest) => {
+    const identity = getInputIdentity(request);
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const legacySelection = createTestSelection('legacy', legacySend, true);
+  const modernSelection = createTestSelection('modern', modernSend, false);
+  const { select, skipFromError } = mockSelectionSequence([
+    legacySelection,
+    modernSelection,
+    undefined,
+  ]);
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectApiMessages, []],
+      [selectShouldGenerateMessage, false],
+      [selectThreadId, 'configured-thread'],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(internalActions.sizzle());
+
+  expect(select).toHaveBeenCalledTimes(3);
+  expect(skipFromError).toHaveBeenNthCalledWith(
+    1,
+    legacySelection.spec,
+    expect.objectContaining({ code: 'FEATURE_UNSUPPORTED' }),
+  );
+  expect(skipFromError).toHaveBeenNthCalledWith(
+    2,
+    modernSelection.spec,
+    expect.objectContaining({
+      code: 'FEATURE_UNSUPPORTED',
+      retryable: false,
+    }),
+  );
+  expect(legacySend).toHaveBeenCalledTimes(1);
+  expect(legacySend.mock.calls[0]?.[0]).toMatchObject({ attempt: 1 });
+  expect(modernSend).not.toHaveBeenCalled();
+
+  teardown?.();
+});
+
+test.each([undefined, true])(
+  'loads an empty configured thread when legacy capability is %s',
+  async (supportsLegacyThreadLoading) => {
+    jest.clearAllMocks();
+    const dispose = jest.fn();
+    const { send } = makeSelection(
+      async () => ({
+        frames: (async function* () {
+          yield { type: 'thread-load-start' as const };
+          yield { type: 'thread-load-success' as const, thread: [] };
+        })(),
+        dispose,
+      }),
+      supportsLegacyThreadLoading === undefined
+        ? {}
+        : { supportsLegacyThreadLoading },
+    );
+    const store = createTestStore(
+      new Map<SelectorKey, unknown>([
+        [selectApiMessages, []],
+        [selectShouldGenerateMessage, false],
+        [selectThreadId, 'configured-thread'],
+      ]),
+    );
+    const teardown = generateMessage(store);
+
+    await store.trigger(internalActions.sizzle());
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0].params).toMatchObject({
+      operation: 'load-thread',
+      messages: [],
+      threadId: 'configured-thread',
+    });
+    expect(dispose).toHaveBeenCalledTimes(1);
+
+    teardown?.();
+  },
+);
+
+test('reuses a generated thread across retries and tool continuation', async () => {
+  jest.clearAllMocks();
+  let sendCount = 0;
+  const { send } = makeSelection(async (request) => {
+    sendCount++;
+    if (sendCount === 1) {
+      throw new TransportError('retry once', { retryable: true });
+    }
+
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Done',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  await store.trigger(
+    internalActions.runToolCallsSuccess({ toolMessages: [] }),
+  );
+
+  const requests = send.mock.calls.map(([request]) => request);
+  expect(requests).toHaveLength(3);
+  expect(new Set(requests.map((request) => request.input?.threadId)).size).toBe(
+    1,
+  );
+  expect(new Set(requests.map((request) => request.input?.runId)).size).toBe(3);
+  expect(new Set(requests.map((request) => request.requestId)).size).toBe(3);
+  expect(
+    requests.every((request) => request.input?.runId === request.requestId),
+  ).toBe(true);
+
+  teardown?.();
+});
+
+test('sends full modern input while preserving legacy completion params', async () => {
+  jest.clearAllMocks();
+  const responseSchema = s.object('answer', {
+    answer: s.string('answer text'),
+  });
+  const jsonSchema = s.toJsonSchema(responseSchema);
+  const messages: Chat.Api.Message[] = [
+    { role: 'user', content: 'First question' },
+    { role: 'assistant', content: 'First answer' },
+    { role: 'user', content: 'Follow-up question' },
+  ];
+  const internalTool: Chat.Internal.Tool = {
+    name: 'search',
+    description: 'Search records',
+    schema: s.object('search input', { query: s.string('query') }),
+    handler: async () => undefined,
+  };
+  const modernTool = Chat.helpers.toApiToolsFromInternal(
+    [internalTool],
+    false,
+    responseSchema,
+  )[0];
+  const legacyTools = Chat.helpers.toApiToolsFromInternal(
+    [internalTool],
+    true,
+    responseSchema,
+  );
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectApiMessages, messages],
+      [selectApiTools, legacyTools],
+      [selectTools, [internalTool]],
+      [selectToolEntities, { search: internalTool }],
+      [selectResponseSchema, responseSchema],
+      [selectStructuredOutput, { mode: 'tool' }],
+      [selectThreadId, 'configured-thread'],
+      [selectUiRequested, true],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Second answer',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({
+      message: { role: 'user', content: 'Follow-up question' },
+    }),
+  );
+
+  const request = send.mock.calls[0]?.[0];
+  expect(request.params).toEqual({
+    operation: 'generate',
+    model: 'selected-model',
+    system: 'You are a test bot',
+    messages: [{ role: 'user', content: 'Follow-up question' }],
+    tools: legacyTools,
+    toolChoice: 'required',
+    responseFormat: undefined,
+    responseFormatMode: undefined,
+    threadId: 'configured-thread',
+  });
+  expect(request.input).toEqual({
+    threadId: 'configured-thread',
+    runId: request.requestId,
+    messages: [
+      {
+        id: 'configured-thread:system',
+        role: 'system',
+        content: 'You are a test bot',
+      },
+      {
+        id: 'configured-thread:message:0',
+        role: 'user',
+        content: 'First question',
+      },
+      {
+        id: 'configured-thread:message:1',
+        role: 'assistant',
+        content: 'First answer',
+      },
+      {
+        id: 'configured-thread:message:2',
+        role: 'user',
+        content: 'Follow-up question',
+      },
+    ],
+    tools: [
+      {
+        name: modernTool?.name,
+        description: modernTool?.description,
+        parameters: modernTool?.parameters,
+      },
+    ],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    hashbrown: { responseSchema: jsonSchema, ui: true },
+  });
+  expect(request.input).not.toHaveProperty('model');
+  expect(request.input).not.toHaveProperty('provider');
+  expect(request.input).not.toHaveProperty('emulateStructuredOutput');
+  expect(
+    request.input?.tools.map((tool: { name: string }) => tool.name),
+  ).not.toContain('output');
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageStart.type,
+    )?.payload,
+  ).toEqual({
+    responseSchema,
+    emulateStructuredOutput: false,
+    toolsByName: { search: internalTool },
+  });
+
+  teardown?.();
+});
+
+test('consumes direct AG-UI events without invoking the legacy stream path', async () => {
+  jest.clearAllMocks();
+  let serverEvents: AGUIEvent[] = [];
+  const iteratorReturn = jest.fn(async () => ({
+    done: true as const,
+    value: undefined,
+  }));
+  const dispose = jest.fn();
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+    serverEvents = [
+      { type: EventType.RUN_STARTED, ...identity },
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: 'server-message',
+        role: 'assistant',
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: 'server-message',
+        delta: 'Hello',
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: 'server-message',
+      },
+      {
+        type: EventType.CUSTOM,
+        name: 'server-metadata',
+        value: { source: 'server' },
+      },
+      { type: EventType.RUN_FINISHED, ...identity },
+    ];
+    const events = {
+      [Symbol.asyncIterator]() {
+        const iterator = serverEvents[Symbol.iterator]();
+        return {
+          next: async () => iterator.next(),
+          return: iteratorReturn,
+        };
+      },
+    };
+
+    return { events, dispose };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Hello',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(decodeFramesMock).not.toHaveBeenCalled();
+  expect(framesToLengthPrefixedStreamMock).not.toHaveBeenCalled();
+  expect(createCompletionChunkEventAdapterMock).not.toHaveBeenCalled();
+  expect(store.actions.map((action) => action.type)).toEqual([
+    apiActions.generateMessageStart.type,
+    ...serverEvents.map(() => apiActions.generateMessageEvent.type),
+    apiActions.generateMessageSuccess.type,
+    apiActions.assistantTurnFinalized.type,
+  ]);
+  expect(
+    store.actions
+      .filter((action) => action.type === apiActions.generateMessageEvent.type)
+      .map((action) => action.payload),
+  ).toEqual(serverEvents);
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageSuccess.type,
+    )?.payload,
+  ).toEqual({
+    message: {
+      role: 'assistant',
+      content: 'Hello',
+      toolCallIds: [],
+    },
+    toolCalls: [],
+  });
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+
+  teardown?.();
+});
+
+test('retries when direct iterator cleanup rejects before message commit', async () => {
+  jest.clearAllMocks();
+  const cleanupError = new Error('iterator cleanup failed');
+  const iteratorReturn = jest.fn(async () => {
+    throw cleanupError;
+  });
+  const firstDispose = jest.fn();
+  const secondDispose = jest.fn();
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    if (attempt === 1) {
+      const serverEvents: AGUIEvent[] = [
+        { type: EventType.RUN_STARTED, ...identity },
+        { type: EventType.RUN_FINISHED, ...identity },
+      ];
+      return {
+        events: {
+          [Symbol.asyncIterator]() {
+            const iterator = serverEvents[Symbol.iterator]();
+            return {
+              next: async () => iterator.next(),
+              return: iteratorReturn,
+            };
+          },
+        },
+        dispose: firstDispose,
+      };
+    }
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+      dispose: secondDispose,
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+
+  const errorIndex = store.actions.findIndex(
+    (action) => action.type === apiActions.generateMessageError.type,
+  );
+  const successIndex = store.actions.findIndex(
+    (action) => action.type === apiActions.generateMessageSuccess.type,
+  );
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(firstDispose).toHaveBeenCalledTimes(1);
+  expect(secondDispose).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toEqual([apiActions.generateMessageError(cleanupError)]);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageSuccess.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.filter(
+      (action) =>
+        action.type === apiActions.generateMessageEvent.type &&
+        (action.payload as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(0);
+  expect(errorIndex).toBeLessThan(successIndex);
+
+  teardown?.();
+});
+
+test('retries when direct response disposal rejects before message commit', async () => {
+  jest.clearAllMocks();
+  const disposeError = new Error('response disposal failed');
+  const firstDispose = jest.fn(async () => {
+    throw disposeError;
+  });
+  const secondDispose = jest.fn();
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+      dispose: attempt === 1 ? firstDispose : secondDispose,
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+  let thrown: unknown;
+
+  try {
+    await store.trigger(
+      devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+    );
+  } catch (error) {
+    thrown = error;
+  }
+
+  const errorIndex = store.actions.findIndex(
+    (action) => action.type === apiActions.generateMessageError.type,
+  );
+  const successIndex = store.actions.findIndex(
+    (action) => action.type === apiActions.generateMessageSuccess.type,
+  );
+  expect(thrown).toBeUndefined();
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(firstDispose).toHaveBeenCalledTimes(1);
+  expect(secondDispose).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toEqual([apiActions.generateMessageError(disposeError)]);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageSuccess.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.filter(
+      (action) =>
+        action.type === apiActions.generateMessageEvent.type &&
+        (action.payload as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(0);
+  expect(errorIndex).toBeLessThan(successIndex);
+
+  teardown?.();
+});
+
+test('retries an early direct server RUN_ERROR without starting the failed attempt', async () => {
+  jest.clearAllMocks();
+  const serverError: AGUIEvent = {
+    type: EventType.RUN_ERROR,
+    message: 'server rejected request',
+  };
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    if (attempt === 1) {
+      return {
+        events: (async function* () {
+          yield serverError;
+        })(),
+      };
+    }
+
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+
+  const dispatchedEvents = store.actions
+    .filter((action) => action.type === apiActions.generateMessageEvent.type)
+    .map((action) => action.payload);
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(dispatchedEvents.filter((event) => event === serverError)).toEqual([
+    serverError,
+  ]);
+  expect(
+    dispatchedEvents.filter(
+      (event) => (event as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageStart.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toEqual([apiActions.generateMessageError(new Error(serverError.message))]);
+
+  teardown?.();
+});
+
+test('retries a direct server RUN_ERROR without dispatching it twice', async () => {
+  jest.clearAllMocks();
+  const serverError: AGUIEvent = {
+    type: EventType.RUN_ERROR,
+    message: 'server failed',
+  };
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    if (attempt === 1) {
+      return {
+        events: (async function* () {
+          yield { type: EventType.RUN_STARTED, ...identity };
+          yield serverError;
+          yield {
+            type: EventType.CUSTOM,
+            name: 'must-not-dispatch',
+            value: 'tail',
+          };
+        })(),
+      };
+    }
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+
+  const dispatchedEvents = store.actions
+    .filter((action) => action.type === apiActions.generateMessageEvent.type)
+    .map((action) => action.payload);
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(dispatchedEvents.filter((event) => event === serverError)).toEqual([
+    serverError,
+  ]);
+  expect(dispatchedEvents).not.toContainEqual(
+    expect.objectContaining({ name: 'must-not-dispatch' }),
+  );
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageSuccess.type,
+    ),
+  ).toHaveLength(1);
+
+  teardown?.();
+});
+
+test('treats duplicate direct RUN_STARTED events as a protocol error', async () => {
+  jest.clearAllMocks();
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  const dispatchedEvents = store.actions
+    .filter((action) => action.type === apiActions.generateMessageEvent.type)
+    .map((action) => action.payload);
+  const errorAction = store.actions.find(
+    (action) => action.type === apiActions.generateMessageError.type,
+  );
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageStart.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    dispatchedEvents.filter(
+      (event) => (event as AGUIEvent).type === EventType.RUN_STARTED,
+    ),
+  ).toHaveLength(1);
+  expect(
+    dispatchedEvents.filter(
+      (event) => (event as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(1);
+  expect(errorAction?.payload).toMatchObject({
+    name: 'TransportError',
+    code: 'PROTOCOL_ERROR',
+    retryable: true,
+  });
+
+  teardown?.();
+});
+
+test('retries a mismatched direct RUN_STARTED without accepting the run', async () => {
+  jest.clearAllMocks();
+  let attempt = 0;
+  let mismatchedStart: AGUIEvent | undefined;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    if (attempt === 1) {
+      mismatchedStart = {
+        type: EventType.RUN_STARTED,
+        threadId: identity.threadId,
+        runId: `${identity.runId}:mismatch`,
+      };
+      return {
+        events: (async function* () {
+          yield mismatchedStart as AGUIEvent;
+        })(),
+      };
+    }
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+
+  const dispatchedEvents = store.actions
+    .filter((action) => action.type === apiActions.generateMessageEvent.type)
+    .map((action) => action.payload);
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(dispatchedEvents).not.toContain(mismatchedStart);
+  expect(
+    dispatchedEvents.filter(
+      (event) => (event as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(0);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageStart.type,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageError.type,
+    )?.payload,
+  ).toMatchObject({
+    name: 'TransportError',
+    code: 'PROTOCOL_ERROR',
+    retryable: true,
+  });
+
+  teardown?.();
+});
+
+test('retries a mismatched direct RUN_FINISHED with one terminal error', async () => {
+  jest.clearAllMocks();
+  let attempt = 0;
+  let acceptedStart: AGUIEvent | undefined;
+  let mismatchedFinish: AGUIEvent | undefined;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    if (attempt === 1) {
+      acceptedStart = { type: EventType.RUN_STARTED, ...identity };
+      mismatchedFinish = {
+        type: EventType.RUN_FINISHED,
+        threadId: `${identity.threadId}:mismatch`,
+        runId: identity.runId,
+      };
+      return {
+        events: (async function* () {
+          yield acceptedStart as AGUIEvent;
+          yield mismatchedFinish as AGUIEvent;
+        })(),
+      };
+    }
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+
+  const dispatchedEvents = store.actions
+    .filter((action) => action.type === apiActions.generateMessageEvent.type)
+    .map((action) => action.payload);
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(dispatchedEvents).toContain(acceptedStart);
+  expect(dispatchedEvents).not.toContain(mismatchedFinish);
+  expect(
+    dispatchedEvents.filter(
+      (event) => (event as AGUIEvent).type === EventType.RUN_ERROR,
+    ),
+  ).toHaveLength(1);
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageError.type,
+    )?.payload,
+  ).toMatchObject({
+    name: 'TransportError',
+    code: 'PROTOCOL_ERROR',
+    retryable: true,
+  });
+
+  teardown?.();
+});
+
+test('retries premature direct EOF after start with one terminal error', async () => {
+  jest.clearAllMocks();
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        if (attempt === 2) {
+          yield { type: EventType.RUN_FINISHED, ...identity };
+        }
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  const runErrors = store.actions.filter(
+    (action) =>
+      action.type === apiActions.generateMessageEvent.type &&
+      (action.payload as AGUIEvent).type === EventType.RUN_ERROR,
+  );
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(runErrors).toHaveLength(1);
+  expect(runErrors[0]?.payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Generation stream ended before RUN_FINISHED or RUN_ERROR',
+  });
+
+  teardown?.();
+});
+
+test('retries premature direct EOF before start without a terminal event', async () => {
+  jest.clearAllMocks();
+  let attempt = 0;
+  const { send } = makeSelection(async (request) => {
+    attempt++;
+    const identity = getInputIdentity(request);
+    return {
+      events: (async function* () {
+        if (attempt === 2) {
+          yield { type: EventType.RUN_STARTED, ...identity };
+          yield { type: EventType.RUN_FINISHED, ...identity };
+        }
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        {
+          role: 'assistant',
+          content: 'Recovered',
+          toolCallIds: [],
+        },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  const runErrors = store.actions.filter(
+    (action) =>
+      action.type === apiActions.generateMessageEvent.type &&
+      (action.payload as AGUIEvent).type === EventType.RUN_ERROR,
+  );
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(runErrors).toHaveLength(0);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toHaveLength(1);
+
+  teardown?.();
+});
+
+test('rejects direct RUN_FINISHED before RUN_STARTED as a protocol error', async () => {
+  jest.clearAllMocks();
+  makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore();
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageEvent.type,
+    ),
+  ).toHaveLength(0);
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageError.type,
+    )?.payload,
+  ).toMatchObject({
+    name: 'TransportError',
+    code: 'PROTOCOL_ERROR',
+    retryable: true,
+  });
+
+  teardown?.();
+});
+
+test('does not retry a direct finish-time parser error', async () => {
+  jest.clearAllMocks();
+  const parserError = new Error('Structured output is incomplete');
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 2],
+      [selectStreamingMessageError, parserError],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageError.type,
+    ),
+  ).toEqual([apiActions.generateMessageError(parserError)]);
+
+  teardown?.();
+});
+
+test('does not retry when direct RUN_FINISHED produces no message', async () => {
+  jest.clearAllMocks();
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        yield { type: EventType.RUN_FINISHED, ...identity };
+      })(),
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, 2]]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.find(
+      (action) => action.type === apiActions.generateMessageError.type,
+    )?.payload,
+  ).toEqual(new Error('No message was generated'));
+
+  teardown?.();
+});
+
+test('cancels a direct active run once without retrying and disposes', async () => {
+  jest.clearAllMocks();
+  let notifyStarted: () => void = () => undefined;
+  const started = new Promise<void>((resolve) => {
+    notifyStarted = resolve;
+  });
+  const dispose = jest.fn();
+  const { send } = makeSelection(async (request) => {
+    const identity = getInputIdentity(request);
+
+    return {
+      events: (async function* () {
+        yield { type: EventType.RUN_STARTED, ...identity };
+        notifyStarted();
+        await new Promise<void>((resolve) => {
+          if (request.signal.aborted) {
+            resolve();
+            return;
+          }
+          request.signal.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+      })(),
+      dispose,
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, 2]]),
+  );
+  const teardown = generateMessage(store);
+
+  const generation = store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  await started;
+  await store.trigger(devActions.stopMessageGeneration(true));
+  await generation;
+
+  const runErrors = store.actions.filter(
+    (action) =>
+      action.type === apiActions.generateMessageEvent.type &&
+      (action.payload as AGUIEvent).type === EventType.RUN_ERROR,
+  );
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(runErrors).toHaveLength(1);
+  expect(runErrors[0]?.payload).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Generation cancelled',
+  });
+  expect(dispose).toHaveBeenCalledTimes(1);
+
+  teardown?.();
+});
+
+test('cancels a direct run before start without a terminal event and disposes', async () => {
+  jest.clearAllMocks();
+  let notifyWaiting: () => void = () => undefined;
+  const waiting = new Promise<void>((resolve) => {
+    notifyWaiting = resolve;
+  });
+  const dispose = jest.fn();
+  const { send } = makeSelection(async ({ signal }) => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            notifyWaiting();
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) {
+                resolve();
+                return;
+              }
+              signal.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
+            });
+            return { done: true as const, value: undefined };
+          },
+        };
+      },
+    },
+    dispose,
+  }));
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, 2]]),
+  );
+  const teardown = generateMessage(store);
+
+  const generation = store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  await waiting;
+  await store.trigger(devActions.stopMessageGeneration(true));
+  await generation;
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    store.actions.filter(
+      (action) => action.type === apiActions.generateMessageEvent.type,
+    ),
+  ).toHaveLength(0);
+  expect(dispose).toHaveBeenCalledTimes(1);
+
+  teardown?.();
+});
 
 test('dispatches AG-UI lifecycle events and success on happy path', async () => {
   jest.clearAllMocks();

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -25,6 +25,7 @@ import {
   selectSystem,
   selectThreadId,
   selectToolEntities,
+  selectTools,
   selectTransport,
   selectUiRequested,
 } from '../reducers';
@@ -35,12 +36,14 @@ import {
   TransportError,
   TransportResponse,
 } from '../transport';
+import { createHashbrownRunAgentInput } from '../transport/hashbrown-run-agent-input';
 
 export const generateMessage = createEffect((store) => {
   const effectAbortController = new AbortController();
   // This controller is used to cancel the current message generation
   // when a new message is sent or the user stops the generation.
   let cancelAbortController = new AbortController();
+  let generatedThreadId: string | undefined;
 
   store.when(
     internalActions.sizzle,
@@ -57,6 +60,12 @@ export const generateMessage = createEffect((store) => {
       const debounce = store.read(selectDebounce);
       const retries = store.read(selectRetries);
       const tools = store.read(selectApiTools);
+      const internalTools = store.read(selectTools);
+      const modernTools = Chat.helpers.toApiToolsFromInternal(
+        internalTools,
+        false,
+        responseSchema ?? s.nullish(),
+      );
       const toolsByName = store.read(selectToolEntities);
       const system = store.read(selectSystem);
       const emulateStructuredOutput = store.read(selectEmulateStructuredOutput);
@@ -65,8 +74,12 @@ export const generateMessage = createEffect((store) => {
         ? (structuredOutput?.mode ??
           (emulateStructuredOutput ? 'tool' : 'strict'))
         : undefined;
+      const responseJsonSchema = responseSchema
+        ? s.toJsonSchema(responseSchema)
+        : undefined;
       const shouldGenerateMessage = store.read(selectShouldGenerateMessage);
       const threadId = store.read(selectThreadId);
+      const uiRequested = store.read(selectUiRequested);
       const shouldLoadThread = Boolean(threadId) && messages.length === 0;
       const messagePayload = threadId
         ? _extractMessageDelta(messages)
@@ -90,7 +103,7 @@ export const generateMessage = createEffect((store) => {
         toolChoice: structuredOutputMode === 'tool' ? 'required' : undefined,
         responseFormat:
           structuredOutputMode === 'strict' && responseSchema
-            ? s.toJsonSchema(responseSchema)
+            ? responseJsonSchema
             : undefined,
         responseFormatMode:
           structuredOutputMode === 'strict'
@@ -105,7 +118,7 @@ export const generateMessage = createEffect((store) => {
         tools:
           Boolean(params.tools?.length) || params.toolChoice === 'required',
         structured: Boolean(params.responseFormatMode),
-        ui: store.read(selectUiRequested),
+        ui: uiRequested,
         threads: Boolean(threadId),
       };
 
@@ -119,18 +132,68 @@ export const generateMessage = createEffect((store) => {
         transport: transportProvider,
       });
 
-      let selection = await resolver.select(requestedFeatures);
-      if (!selection) {
-        store.dispatch(
-          apiActions.generateMessageError(
-            new Error(
-              'No compatible model spec found for the requested features.',
+      let skippedLegacyThreadLoad = false;
+      const selectCompatibleTransport = async () => {
+        let nextSelection = await resolver.select(requestedFeatures);
+        while (
+          shouldLoadThread &&
+          nextSelection?.transport.supportsLegacyThreadLoading === false
+        ) {
+          skippedLegacyThreadLoad = true;
+          resolver.skipFromError(
+            nextSelection.spec,
+            new TransportError(
+              `Model spec "${nextSelection.spec.name}" does not support legacy thread loading.`,
+              { retryable: false, code: 'FEATURE_UNSUPPORTED' },
             ),
-          ),
-        );
+          );
+          nextSelection = await resolver.select(requestedFeatures);
+        }
+
+        return nextSelection;
+      };
+
+      let selection = await selectCompatibleTransport();
+      if (!selection) {
+        if (!skippedLegacyThreadLoad) {
+          store.dispatch(
+            apiActions.generateMessageError(
+              new Error(
+                'No compatible model spec found for the requested features.',
+              ),
+            ),
+          );
+        }
         return;
       }
 
+      const finalizeGeneration = () => {
+        const streamingError = store.read(selectStreamingMessageError);
+        if (streamingError) {
+          store.dispatch(apiActions.generateMessageError(streamingError));
+          return;
+        }
+
+        const streamingMessage = store.read(selectRawStreamingMessage);
+        const streamingToolCalls = store.read(selectRawStreamingToolCalls);
+
+        if (streamingMessage) {
+          store.dispatch(
+            apiActions.generateMessageSuccess({
+              message: streamingMessage,
+              toolCalls: streamingToolCalls,
+            }),
+          );
+        } else {
+          store.dispatch(
+            apiActions.generateMessageError(
+              new Error('No message was generated'),
+            ),
+          );
+        }
+      };
+
+      let retryWithReplacement = false;
       try {
         do {
           if (
@@ -148,6 +211,16 @@ export const generateMessage = createEffect((store) => {
           let transportResponse: TransportResponse | undefined;
           let activeRun:
             { threadId: string; runId: string; terminal: boolean } | undefined;
+          let shouldFinalizeGeneration = false;
+          let disposed = false;
+          const disposeTransportResponse = async () => {
+            if (disposed) {
+              return;
+            }
+
+            disposed = true;
+            await transportResponse?.dispose?.();
+          };
           const dispatchRunError = (message: string) => {
             if (!activeRun || activeRun.terminal) {
               return;
@@ -163,223 +236,308 @@ export const generateMessage = createEffect((store) => {
           };
 
           try {
-            attempt++;
-
-            const requestAbortSignal = AbortSignal.any([
-              switchSignal,
-              effectAbortController.signal,
-              cancelAbortController.signal,
-            ]);
-
-            const paramsWithModel: Chat.Api.CompletionCreateParams = {
-              ...params,
-              model: selection.spec.name,
-            };
-            const requestId = _createRequestId();
-            const runId = requestId;
-            const aguiThreadId = threadId ?? requestId;
-            const completionChunkAdapter =
-              createCompletionChunkEventAdapter(requestId);
-
-            transportResponse = await selection.transport.send({
-              params: paramsWithModel,
-              signal: requestAbortSignal,
-              attempt,
-              maxAttempts: retries + 1,
-              requestId,
-            });
-
-            if (cancelAbortController.signal.aborted) {
-              cancelAbortController = new AbortController();
-              return;
-            }
-
-            const frameStream = transportResponse.frames
-              ? framesToLengthPrefixedStream(transportResponse.frames)
-              : transportResponse.stream;
-
-            if (!frameStream) {
-              throw new TransportError(
-                'Transport returned neither frames nor stream',
-                { retryable: false },
-              );
-            }
-
-            transportResponse = {
-              ...transportResponse,
-              metadata: {
-                ...(transportResponse.metadata ?? {}),
-                selection: selection.metadata,
-              },
-            };
-
-            for await (const frame of decodeFrames(frameStream, {
-              signal: AbortSignal.any([
-                cancelAbortController.signal,
-                effectAbortController.signal,
-              ]),
-            })) {
-              switch (frame.type) {
-                case 'thread-load-start': {
-                  store.dispatch(apiActions.threadLoadStart());
-                  break;
-                }
-                case 'thread-load-success': {
-                  store.dispatch(
-                    apiActions.threadLoadSuccess({
-                      thread: frame.thread,
-                      responseSchema,
-                      toolsByName,
-                    }),
-                  );
-                  if (params.operation === 'load-thread') {
-                    return;
-                  }
-                  break;
-                }
-                case 'thread-load-failure': {
-                  store.dispatch(
-                    apiActions.threadLoadFailure({
-                      error: frame.error,
-                      stacktrace: frame.stacktrace,
-                    }),
-                  );
-                  throw new Error(frame.error);
-                }
-                case 'generation-start': {
-                  activeRun = {
-                    threadId: aguiThreadId,
-                    runId,
-                    terminal: false,
-                  };
-                  store.dispatch(
-                    apiActions.generateMessageStart({
-                      responseSchema,
-                      emulateStructuredOutput,
-                      toolsByName:
-                        emulateStructuredOutput && responseSchema
-                          ? {
-                              ...toolsByName,
-                              output: {
-                                name: 'output',
-                                description:
-                                  'Reserved tool for emulated structured output.',
-                                schema: s.normalizeSchemaOutput(responseSchema),
-                                handler: async () => undefined,
-                              },
-                            }
-                          : toolsByName,
-                    }),
-                  );
-                  store.dispatch(
-                    apiActions.generateMessageEvent({
-                      type: EventType.RUN_STARTED,
-                      threadId: aguiThreadId,
-                      runId,
-                    }),
-                  );
-                  break;
-                }
-                case 'generation-chunk': {
-                  for (const event of completionChunkAdapter.push(
-                    frame.chunk,
-                  )) {
-                    store.dispatch(apiActions.generateMessageEvent(event));
-                  }
-                  break;
-                }
-                case 'thread-save-success': {
-                  store.dispatch(
-                    apiActions.threadSaveSuccess({ threadId: frame.threadId }),
-                  );
-                  break;
-                }
-                case 'thread-save-start': {
-                  store.dispatch(apiActions.threadSaveStart());
-                  break;
-                }
-                case 'thread-save-failure': {
-                  store.dispatch(
-                    apiActions.threadSaveFailure({
-                      error: frame.error,
-                      stacktrace: frame.stacktrace,
-                    }),
-                  );
-                  break;
-                }
-                case 'generation-error': {
-                  dispatchRunError(frame.error);
-                  // Assumption: a 'finish' will follow the 'error', but we know we need to retry
-                  // as soon as we see the error.  Therefore, throw an exception to break out
-                  // of the for loop.
-                  throw new Error(frame.error);
-                }
-                case 'generation-finish': {
-                  if (activeRun) {
-                    activeRun = { ...activeRun, terminal: true };
-                  }
-                  const events: AGUIEvent[] = [
-                    ...completionChunkAdapter.finish(),
-                    {
-                      type: EventType.RUN_FINISHED,
-                      threadId: aguiThreadId,
-                      runId,
-                    },
-                  ];
-                  for (const event of events) {
-                    store.dispatch(apiActions.generateMessageEvent(event));
-                  }
-
-                  const streamingError = store.read(
-                    selectStreamingMessageError,
-                  );
-                  if (streamingError) {
-                    store.dispatch(
-                      apiActions.generateMessageError(streamingError),
-                    );
-                    break;
-                  }
-
-                  const streamingMessage = store.read(
-                    selectRawStreamingMessage,
-                  );
-                  const streamingToolCalls = store.read(
-                    selectRawStreamingToolCalls,
-                  );
-
-                  if (streamingMessage) {
-                    store.dispatch(
-                      apiActions.generateMessageSuccess({
-                        message: streamingMessage,
-                        toolCalls: streamingToolCalls,
-                      }),
-                    );
-                  } else {
-                    store.dispatch(
-                      apiActions.generateMessageError(
-                        new Error('No message was generated'),
-                      ),
-                    );
-                  }
-                  break;
-                }
+            try {
+              if (!retryWithReplacement) {
+                attempt++;
               }
-            }
+              retryWithReplacement = false;
 
-            if (activeRun && !activeRun.terminal) {
-              const cancelled =
-                effectAbortController.signal.aborted ||
-                switchSignal.aborted ||
-                cancelAbortController.signal.aborted;
-              if (cancelled) {
-                dispatchRunError('Generation cancelled');
+              const requestAbortSignal = AbortSignal.any([
+                switchSignal,
+                effectAbortController.signal,
+                cancelAbortController.signal,
+              ]);
+
+              const paramsWithModel: Chat.Api.CompletionCreateParams = {
+                ...params,
+                model: selection.spec.name,
+              };
+              const aguiThreadId =
+                threadId ?? (generatedThreadId ??= _createRequestId());
+              const requestId = _createRequestId();
+              const runId = requestId;
+
+              transportResponse = await selection.transport.send({
+                input: createHashbrownRunAgentInput({
+                  threadId: aguiThreadId,
+                  runId,
+                  system,
+                  messages,
+                  tools: modernTools,
+                  responseSchema: responseJsonSchema,
+                  ui: uiRequested,
+                }),
+                params: paramsWithModel,
+                signal: requestAbortSignal,
+                attempt,
+                maxAttempts: retries + 1,
+                requestId,
+              });
+
+              if (cancelAbortController.signal.aborted) {
+                cancelAbortController = new AbortController();
                 return;
               }
 
-              throw new TransportError(
-                'Generation stream ended before generation-finish',
-                { retryable: true },
-              );
+              if (transportResponse.events) {
+                for await (const event of transportResponse.events) {
+                  if (event.type === EventType.RUN_STARTED) {
+                    if (activeRun) {
+                      throw new TransportError(
+                        'Received duplicate RUN_STARTED',
+                        {
+                          retryable: true,
+                          code: 'PROTOCOL_ERROR',
+                        },
+                      );
+                    }
+
+                    if (
+                      event.threadId !== aguiThreadId ||
+                      event.runId !== runId
+                    ) {
+                      throw new TransportError(
+                        'RUN_STARTED identity does not match the attempted run',
+                        { retryable: true, code: 'PROTOCOL_ERROR' },
+                      );
+                    }
+
+                    activeRun = {
+                      threadId: event.threadId,
+                      runId: event.runId,
+                      terminal: false,
+                    };
+                    store.dispatch(
+                      apiActions.generateMessageStart({
+                        responseSchema,
+                        emulateStructuredOutput: false,
+                        toolsByName,
+                      }),
+                    );
+                    store.dispatch(apiActions.generateMessageEvent(event));
+                    continue;
+                  }
+
+                  if (event.type === EventType.RUN_ERROR) {
+                    if (activeRun) {
+                      activeRun = { ...activeRun, terminal: true };
+                    }
+                    store.dispatch(apiActions.generateMessageEvent(event));
+                    throw new Error(event.message);
+                  }
+
+                  if (!activeRun) {
+                    throw new TransportError(
+                      `Received ${event.type} before RUN_STARTED`,
+                      { retryable: true, code: 'PROTOCOL_ERROR' },
+                    );
+                  }
+
+                  if (event.type === EventType.RUN_FINISHED) {
+                    if (
+                      event.threadId !== activeRun.threadId ||
+                      event.runId !== activeRun.runId
+                    ) {
+                      throw new TransportError(
+                        'RUN_FINISHED identity does not match the active run',
+                        { retryable: true, code: 'PROTOCOL_ERROR' },
+                      );
+                    }
+
+                    activeRun = { ...activeRun, terminal: true };
+                    store.dispatch(apiActions.generateMessageEvent(event));
+                    shouldFinalizeGeneration = true;
+                    break;
+                  }
+
+                  store.dispatch(apiActions.generateMessageEvent(event));
+                }
+
+                if (activeRun && !activeRun.terminal) {
+                  throw new TransportError(
+                    'Generation stream ended before RUN_FINISHED or RUN_ERROR',
+                    { retryable: true },
+                  );
+                }
+
+                if (!activeRun) {
+                  throw new TransportError(
+                    'Generation stream ended before RUN_STARTED',
+                    { retryable: true },
+                  );
+                }
+              }
+
+              if (!transportResponse.events) {
+                const completionChunkAdapter =
+                  createCompletionChunkEventAdapter(requestId);
+
+                const frameStream = transportResponse.frames
+                  ? framesToLengthPrefixedStream(transportResponse.frames)
+                  : transportResponse.stream;
+
+                if (!frameStream) {
+                  throw new TransportError(
+                    'Transport returned neither frames nor stream',
+                    { retryable: false },
+                  );
+                }
+
+                transportResponse = {
+                  ...transportResponse,
+                  metadata: {
+                    ...(transportResponse.metadata ?? {}),
+                    selection: selection.metadata,
+                  },
+                };
+
+                for await (const frame of decodeFrames(frameStream, {
+                  signal: AbortSignal.any([
+                    cancelAbortController.signal,
+                    effectAbortController.signal,
+                  ]),
+                })) {
+                  switch (frame.type) {
+                    case 'thread-load-start': {
+                      store.dispatch(apiActions.threadLoadStart());
+                      break;
+                    }
+                    case 'thread-load-success': {
+                      store.dispatch(
+                        apiActions.threadLoadSuccess({
+                          thread: frame.thread,
+                          responseSchema,
+                          toolsByName,
+                        }),
+                      );
+                      if (params.operation === 'load-thread') {
+                        return;
+                      }
+                      break;
+                    }
+                    case 'thread-load-failure': {
+                      store.dispatch(
+                        apiActions.threadLoadFailure({
+                          error: frame.error,
+                          stacktrace: frame.stacktrace,
+                        }),
+                      );
+                      throw new Error(frame.error);
+                    }
+                    case 'generation-start': {
+                      activeRun = {
+                        threadId: aguiThreadId,
+                        runId,
+                        terminal: false,
+                      };
+                      store.dispatch(
+                        apiActions.generateMessageStart({
+                          responseSchema,
+                          emulateStructuredOutput,
+                          toolsByName:
+                            emulateStructuredOutput && responseSchema
+                              ? {
+                                  ...toolsByName,
+                                  output: {
+                                    name: 'output',
+                                    description:
+                                      'Reserved tool for emulated structured output.',
+                                    schema:
+                                      s.normalizeSchemaOutput(responseSchema),
+                                    handler: async () => undefined,
+                                  },
+                                }
+                              : toolsByName,
+                        }),
+                      );
+                      store.dispatch(
+                        apiActions.generateMessageEvent({
+                          type: EventType.RUN_STARTED,
+                          threadId: aguiThreadId,
+                          runId,
+                        }),
+                      );
+                      break;
+                    }
+                    case 'generation-chunk': {
+                      for (const event of completionChunkAdapter.push(
+                        frame.chunk,
+                      )) {
+                        store.dispatch(apiActions.generateMessageEvent(event));
+                      }
+                      break;
+                    }
+                    case 'thread-save-success': {
+                      store.dispatch(
+                        apiActions.threadSaveSuccess({
+                          threadId: frame.threadId,
+                        }),
+                      );
+                      break;
+                    }
+                    case 'thread-save-start': {
+                      store.dispatch(apiActions.threadSaveStart());
+                      break;
+                    }
+                    case 'thread-save-failure': {
+                      store.dispatch(
+                        apiActions.threadSaveFailure({
+                          error: frame.error,
+                          stacktrace: frame.stacktrace,
+                        }),
+                      );
+                      break;
+                    }
+                    case 'generation-error': {
+                      dispatchRunError(frame.error);
+                      // Assumption: a 'finish' will follow the 'error', but we know we need to retry
+                      // as soon as we see the error.  Therefore, throw an exception to break out
+                      // of the for loop.
+                      throw new Error(frame.error);
+                    }
+                    case 'generation-finish': {
+                      if (activeRun) {
+                        activeRun = { ...activeRun, terminal: true };
+                      }
+                      const events: AGUIEvent[] = [
+                        ...completionChunkAdapter.finish(),
+                        {
+                          type: EventType.RUN_FINISHED,
+                          threadId: aguiThreadId,
+                          runId,
+                        },
+                      ];
+                      for (const event of events) {
+                        store.dispatch(apiActions.generateMessageEvent(event));
+                      }
+                      shouldFinalizeGeneration = true;
+                      break;
+                    }
+                  }
+                }
+
+                if (activeRun && !activeRun.terminal) {
+                  const cancelled =
+                    effectAbortController.signal.aborted ||
+                    switchSignal.aborted ||
+                    cancelAbortController.signal.aborted;
+                  if (cancelled) {
+                    dispatchRunError('Generation cancelled');
+                    return;
+                  }
+
+                  throw new TransportError(
+                    'Generation stream ended before generation-finish',
+                    { retryable: true },
+                  );
+                }
+              }
+            } finally {
+              await disposeTransportResponse();
+            }
+
+            if (shouldFinalizeGeneration) {
+              finalizeGeneration();
             }
           } catch (e) {
             const cancelled =
@@ -405,10 +563,11 @@ export const generateMessage = createEffect((store) => {
                 e.code === 'PLATFORM_UNSUPPORTED')
             ) {
               resolver.skipFromError(selection.spec, e);
-              selection = await resolver.select(requestedFeatures);
+              selection = await selectCompatibleTransport();
               if (!selection) {
                 break;
               }
+              retryWithReplacement = true;
               continue;
             }
 
@@ -418,14 +577,13 @@ export const generateMessage = createEffect((store) => {
 
             continue;
           } finally {
-            await transportResponse?.dispose?.();
             if (cancelAbortController.signal.aborted) {
               cancelAbortController = new AbortController();
             }
           }
 
           break;
-        } while (retries > 0 && attempt < retries + 1);
+        } while (retryWithReplacement || attempt < retries + 1);
       } finally {
         store.dispatch(apiActions.assistantTurnFinalized());
       }

--- a/packages/core/src/reducers/status.reducer.spec.ts
+++ b/packages/core/src/reducers/status.reducer.spec.ts
@@ -1,6 +1,44 @@
 import { EventType } from '@ag-ui/core';
-import { apiActions } from '../actions';
+import { apiActions, devActions } from '../actions';
+import { Chat } from '../models';
+import {
+  reducers as rootReducers,
+  selectIsRunningToolCalls,
+  selectUnifiedError,
+} from './index';
 import { initialStatusState, reducer } from './status.reducer';
+
+const initAction = { type: '@@init' } as const;
+
+function createRootState() {
+  return {
+    config: rootReducers.config(undefined, initAction),
+    messages: rootReducers.messages(undefined, initAction),
+    status: rootReducers.status(undefined, initAction),
+    streamingMessage: rootReducers.streamingMessage(undefined, initAction),
+    toolCalls: rootReducers.toolCalls(undefined, initAction),
+    tools: rootReducers.tools(undefined, initAction),
+    thread: rootReducers.thread(undefined, initAction),
+  };
+}
+
+function reduceRoot(
+  state: ReturnType<typeof createRootState>,
+  action: { type: string },
+) {
+  return {
+    config: rootReducers.config(state.config, action),
+    messages: rootReducers.messages(state.messages, action),
+    status: rootReducers.status(state.status, action),
+    streamingMessage: rootReducers.streamingMessage(
+      state.streamingMessage,
+      action,
+    ),
+    toolCalls: rootReducers.toolCalls(state.toolCalls, action),
+    tools: rootReducers.tools(state.tools, action),
+    thread: rootReducers.thread(state.thread, action),
+  };
+}
 
 test('marks generation active from an AG-UI run start event', () => {
   const state = {
@@ -62,4 +100,117 @@ test('ignores AG-UI events unrelated to generation status', () => {
   );
 
   expect(next).toBe(state);
+});
+
+test('clears prestart errors when a retry starts and succeeds', () => {
+  const prestartError = new Error('request failed before start');
+  let state = reducer(
+    initialStatusState,
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  state = reducer(state, apiActions.generateMessageError(prestartError));
+
+  state = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-2',
+    }),
+  );
+
+  expect(state).toMatchObject({
+    isSending: false,
+    isReceiving: true,
+    isGenerating: true,
+    sendingError: undefined,
+    generatingError: undefined,
+    error: undefined,
+  });
+
+  state = reducer(
+    state,
+    apiActions.generateMessageSuccess({
+      message: { role: 'assistant', content: 'Hello', toolCallIds: [] },
+      toolCalls: [],
+    }),
+  );
+
+  expect(state.sendingError).toBeUndefined();
+});
+
+test('clears an active-run server error when a retry starts', () => {
+  const serverError = new Error('server failed');
+  let state = reducer(
+    initialStatusState,
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  state = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    }),
+  );
+  state = reducer(state, apiActions.generateMessageError(serverError));
+
+  state = reducer(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-2',
+    }),
+  );
+
+  expect(state).toMatchObject({
+    isSending: false,
+    isReceiving: true,
+    isGenerating: true,
+    sendingError: undefined,
+    generatingError: undefined,
+    error: undefined,
+  });
+});
+
+test('retry success clears unified error and enables pending tool calls', () => {
+  const toolCall: Chat.Internal.ToolCall = {
+    id: 'call-1',
+    name: 'lookup',
+    arguments: '{}',
+    status: 'pending',
+  };
+  let state = createRootState();
+  state = reduceRoot(
+    state,
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+  state = reduceRoot(
+    state,
+    apiActions.generateMessageError(new Error('request failed before start')),
+  );
+  state = reduceRoot(
+    state,
+    apiActions.generateMessageEvent({
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-2',
+    }),
+  );
+
+  state = reduceRoot(
+    state,
+    apiActions.generateMessageSuccess({
+      message: {
+        role: 'assistant',
+        content: '',
+        toolCallIds: [toolCall.id],
+      },
+      toolCalls: [toolCall],
+    }),
+  );
+
+  expect(selectUnifiedError(state)).toBeUndefined();
+  expect(selectIsRunningToolCalls(state)).toBe(true);
 });

--- a/packages/core/src/reducers/status.reducer.ts
+++ b/packages/core/src/reducers/status.reducer.ts
@@ -57,7 +57,9 @@ export const reducer = createReducer(
           isSending: false,
           isReceiving: true,
           isGenerating: true,
+          sendingError: undefined,
           generatingError: undefined,
+          error: undefined,
         };
       case EventType.TEXT_MESSAGE_START:
       case EventType.TEXT_MESSAGE_CONTENT:
@@ -79,6 +81,7 @@ export const reducer = createReducer(
       ...state,
       isReceiving: false,
       isGenerating: false,
+      sendingError: undefined,
       error: undefined,
       generatingError: undefined,
       exhaustedRetries: false,

--- a/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
@@ -1,0 +1,425 @@
+import { type Message, RunAgentInputSchema, type Tool } from '@ag-ui/core';
+import { Chat } from '../models';
+import { createHashbrownRunAgentInput } from './hashbrown-run-agent-input';
+
+const threadId = 'thread-1';
+const runId = 'run-1';
+
+function createInput(
+  overrides: Partial<Parameters<typeof createHashbrownRunAgentInput>[0]> = {},
+) {
+  return createHashbrownRunAgentInput({
+    threadId,
+    runId,
+    system: undefined,
+    messages: [],
+    tools: [],
+    ui: false,
+    ...overrides,
+  });
+}
+
+test('omits the system message when no system prompt is provided', () => {
+  const input = createInput();
+
+  expect(input.messages).toEqual([] satisfies Message[]);
+  expect(input.context).toEqual([]);
+  expect(input.state).toEqual({});
+  expect(input.forwardedProps).toEqual({});
+});
+
+test('prepends a standard AG-UI system message to the full history', () => {
+  const input = createInput({
+    system: 'You are concise.',
+    messages: [{ role: 'user', content: 'Hello' }],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: expect.any(String),
+      role: 'system',
+      content: 'You are concise.',
+    },
+    {
+      id: expect.any(String),
+      role: 'user',
+      content: 'Hello',
+    },
+  ] satisfies Message[]);
+});
+
+test('maps assistant content and function tool calls', () => {
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'assistant',
+      content: 'Checking.',
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-weather',
+          type: 'provider-specific',
+          function: {
+            name: 'getWeather',
+            arguments: '{"city":"Paris"}',
+          },
+          metadata: { provider: 'opaque' },
+        },
+      ],
+    },
+  ];
+
+  const input = createInput({ messages });
+
+  expect(input.messages).toEqual([
+    {
+      id: expect.any(String),
+      role: 'assistant',
+      content: 'Checking.',
+      toolCalls: [
+        {
+          id: 'call-weather',
+          type: 'function',
+          function: {
+            name: 'getWeather',
+            arguments: '{"city":"Paris"}',
+          },
+        },
+      ],
+    },
+  ] satisfies Message[]);
+});
+
+test('maps fulfilled tool results without losing strings', () => {
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'tool',
+      toolCallId: 'call-string',
+      toolName: 'stringResult',
+      content: { status: 'fulfilled', value: 'already serialized' },
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-object',
+      toolName: 'objectResult',
+      content: { status: 'fulfilled', value: { temperature: 21 } },
+    },
+  ];
+
+  const input = createInput({ messages });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'call-string',
+      role: 'tool',
+      toolCallId: 'call-string',
+      content: 'already serialized',
+    },
+    {
+      id: 'call-object',
+      role: 'tool',
+      toolCallId: 'call-object',
+      content: '{"temperature":21}',
+    },
+  ] satisfies Message[]);
+});
+
+test('normalizes rejected tool results into content and error', () => {
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'tool',
+      toolCallId: 'call-error',
+      toolName: 'failingTool',
+      content: { status: 'rejected', reason: new Error('tool failed') },
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-reason',
+      toolName: 'rejectedValue',
+      content: { status: 'rejected', reason: { code: 503 } },
+    },
+  ];
+
+  const input = createInput({ messages });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'call-error',
+      role: 'tool',
+      toolCallId: 'call-error',
+      content: 'tool failed',
+      error: 'tool failed',
+    },
+    {
+      id: 'call-reason',
+      role: 'tool',
+      toolCallId: 'call-reason',
+      content: '{"code":503}',
+      error: '{"code":503}',
+    },
+  ] satisfies Message[]);
+});
+
+test('normalizes unusual rejected values without throwing', () => {
+  const circular: Record<string, unknown> = {};
+  circular['self'] = circular;
+  const coercionFailure = {
+    toJSON() {
+      throw new Error('cannot serialize');
+    },
+    toString() {
+      throw new Error('cannot coerce');
+    },
+  };
+  const hostileProxy = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('cannot access properties');
+      },
+      getPrototypeOf() {
+        throw new Error('cannot access prototype');
+      },
+    },
+  );
+  const hostileErrorProxy = new Proxy(new Error('hidden'), {
+    get(target, property, receiver) {
+      if (property === 'message') {
+        throw new Error('cannot access message');
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  const reasons = [
+    undefined,
+    null,
+    BigInt(42),
+    circular,
+    coercionFailure,
+    hostileErrorProxy,
+    hostileProxy,
+  ];
+  const messages: Chat.Api.Message[] = reasons.map((reason, index) => ({
+    role: 'tool',
+    toolCallId: `call-${index}`,
+    toolName: 'unusualRejection',
+    content: { status: 'rejected', reason },
+  }));
+
+  const input = createInput({ messages });
+
+  expect(
+    input.messages.map((message: Message) => ({
+      content: message.content,
+      error: message.role === 'tool' ? message.error : undefined,
+    })),
+  ).toEqual([
+    { content: '', error: '' },
+    { content: '', error: '' },
+    { content: '42', error: '42' },
+    { content: '[object Object]', error: '[object Object]' },
+    { content: '', error: '' },
+    { content: '{}', error: '{}' },
+    { content: '', error: '' },
+  ]);
+});
+
+test('normalizes unusual fulfilled values without throwing', () => {
+  const circular: Record<string, unknown> = {};
+  circular['self'] = circular;
+  const coercionFailure = {
+    toJSON() {
+      throw new Error('cannot serialize');
+    },
+    toString() {
+      throw new Error('cannot coerce');
+    },
+  };
+  const values = [undefined, null, BigInt(42), circular, coercionFailure];
+  const messages: Chat.Api.Message[] = values.map((value, index) => ({
+    role: 'tool',
+    toolCallId: `call-${index}`,
+    toolName: 'unusualResult',
+    content: { status: 'fulfilled', value },
+  }));
+
+  const input = createInput({ messages });
+
+  expect(input.messages.map((message: Message) => message.content)).toEqual([
+    '',
+    '',
+    '42',
+    '[object Object]',
+    '',
+  ]);
+});
+
+test('omits Hashbrown error messages without renumbering later history', () => {
+  const withError = createInput({
+    messages: [
+      { role: 'user', content: 'First' },
+      { role: 'error', content: 'Internal failure' },
+      { role: 'user', content: 'Second' },
+    ],
+  });
+  const withoutError = createInput({
+    messages: [
+      { role: 'user', content: 'First' },
+      { role: 'user', content: 'Second' },
+    ],
+  });
+
+  expect(withError.messages).toHaveLength(2);
+  expect(withError.messages.map((message: Message) => message.content)).toEqual(
+    ['First', 'Second'],
+  );
+  expect(withError.messages[1]?.id).not.toBe(withoutError.messages[1]?.id);
+});
+
+test('maps tools to standard AG-UI declarations', () => {
+  const tools: Chat.Api.Tool[] = [
+    {
+      name: 'getWeather',
+      description: 'Get the current weather.',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+      },
+    },
+  ];
+
+  const input = createInput({ tools });
+
+  expect(input.tools).toEqual([
+    {
+      name: 'getWeather',
+      description: 'Get the current weather.',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+      },
+    },
+  ] satisfies Tool[]);
+});
+
+test('adds the Hashbrown extension only for framework semantics', () => {
+  const responseSchema = {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+  };
+
+  const standard = createInput();
+  const structured = createInput({ responseSchema });
+  const ui = createInput({ ui: true });
+  const structuredUi = createInput({ responseSchema, ui: true });
+
+  expect(standard).not.toHaveProperty('hashbrown');
+  expect(structured.hashbrown).toEqual({ responseSchema });
+  expect(ui.hashbrown).toEqual({ ui: true });
+  expect(structuredUi.hashbrown).toEqual({ responseSchema, ui: true });
+});
+
+test('creates deterministic IDs scoped by thread and original position', () => {
+  const messages: Chat.Api.Message[] = [
+    { role: 'user', content: 'First' },
+    { role: 'assistant', content: 'Second' },
+  ];
+
+  const first = createInput({ system: 'System', messages });
+  const repeated = createInput({ system: 'System', messages });
+  const otherThread = createInput({
+    threadId: 'thread-2',
+    system: 'System',
+    messages,
+  });
+
+  expect(first.messages.map((message: Message) => message.id)).toEqual(
+    repeated.messages.map((message: Message) => message.id),
+  );
+  expect(first.messages.map((message: Message) => message.id)).not.toEqual(
+    otherThread.messages.map((message: Message) => message.id),
+  );
+  expect(
+    new Set(first.messages.map((message: Message) => message.id)).size,
+  ).toBe(3);
+});
+
+test('produces a standard portion accepted by RunAgentInputSchema', () => {
+  const input = createInput({
+    system: 'System',
+    messages: [
+      { role: 'user', content: 'Hello' },
+      {
+        role: 'assistant',
+        content: 'Calling tools.',
+        toolCalls: [
+          {
+            index: 0,
+            id: 'call-success',
+            type: 'function',
+            function: { name: 'echo', arguments: '{"value":"Hello"}' },
+          },
+          {
+            index: 1,
+            id: 'call-failure',
+            type: 'function',
+            function: { name: 'echo', arguments: '{"value":"Fail"}' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'call-success',
+        toolName: 'echo',
+        content: { status: 'fulfilled', value: 'Hello' },
+      },
+      {
+        role: 'tool',
+        toolCallId: 'call-failure',
+        toolName: 'echo',
+        content: { status: 'rejected', reason: new Error('Echo failed') },
+      },
+    ],
+    tools: [
+      {
+        name: 'echo',
+        description: 'Echo a value.',
+        parameters: { type: 'object' },
+      },
+    ],
+    responseSchema: { type: 'string' },
+    ui: true,
+  });
+  const { hashbrown, ...standard } = input;
+
+  const result = RunAgentInputSchema.safeParse(standard);
+
+  expect(hashbrown).toBeDefined();
+  expect(standard.messages.slice(-2).map((message) => message.id)).toEqual([
+    'call-success',
+    'call-failure',
+  ]);
+  expect(result.success).toBe(true);
+});
+
+test('does not emit legacy or provider-specific wire keys', () => {
+  const input = createInput({
+    responseSchema: { type: 'string' },
+    ui: true,
+  });
+  const wire = JSON.stringify(input);
+
+  expect(input).toMatchObject({
+    threadId,
+    runId,
+    messages: [],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  });
+  expect(wire).not.toContain('model');
+  expect(wire).not.toContain('providerOptions');
+  expect(wire).not.toContain('emulateStructuredOutput');
+});

--- a/packages/core/src/transport/hashbrown-run-agent-input.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.ts
@@ -1,0 +1,174 @@
+import type { Message, RunAgentInput, Tool } from '@ag-ui/core';
+import { Chat } from '../models';
+
+/**
+ * AG-UI run input with Hashbrown framework semantics.
+ *
+ * @internal
+ */
+export type HashbrownRunAgentInput = RunAgentInput & {
+  hashbrown?: {
+    responseSchema?: object;
+    ui?: boolean;
+  };
+};
+
+/**
+ * Inputs used to create an AG-UI run request from Hashbrown chat state.
+ *
+ * @internal
+ */
+export interface CreateHashbrownRunAgentInputOptions {
+  threadId: string;
+  runId: string;
+  system?: string;
+  messages: Chat.Api.Message[];
+  tools: Chat.Api.Tool[];
+  responseSchema?: object;
+  ui?: boolean;
+}
+
+function normalizeValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    if (typeof serialized === 'string') {
+      return serialized;
+    }
+  } catch {
+    // Fall through to string coercion.
+  }
+
+  try {
+    return String(value);
+  } catch {
+    return '';
+  }
+}
+
+function normalizeRejection(reason: unknown): string {
+  try {
+    if (reason instanceof Error) {
+      return normalizeValue(reason.message);
+    }
+  } catch {
+    // Fall through to total value normalization.
+  }
+
+  return normalizeValue(reason);
+}
+
+function mapMessage(
+  message: Chat.Api.Message,
+  threadId: string,
+  index: number,
+): Message | undefined {
+  const id = `${threadId}:message:${index}`;
+
+  switch (message.role) {
+    case 'user':
+      return { id, role: 'user', content: message.content };
+    case 'assistant':
+      return {
+        id,
+        role: 'assistant',
+        ...(message.content !== undefined ? { content: message.content } : {}),
+        ...(message.toolCalls !== undefined
+          ? {
+              toolCalls: message.toolCalls.map((toolCall) => ({
+                id: toolCall.id,
+                type: 'function' as const,
+                function: {
+                  name: toolCall.function.name,
+                  arguments: toolCall.function.arguments,
+                },
+              })),
+            }
+          : {}),
+      };
+    case 'tool': {
+      if (message.content.status === 'fulfilled') {
+        return {
+          id: message.toolCallId,
+          role: 'tool',
+          toolCallId: message.toolCallId,
+          content: normalizeValue(message.content.value),
+        };
+      }
+
+      const error = normalizeRejection(message.content.reason);
+      return {
+        id: message.toolCallId,
+        role: 'tool',
+        toolCallId: message.toolCallId,
+        content: error,
+        error,
+      };
+    }
+    case 'error':
+      return undefined;
+  }
+}
+
+function mapTool(tool: Chat.Api.Tool): Tool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+  };
+}
+
+/**
+ * Maps Hashbrown chat state to the AG-UI run input sent over modern transports.
+ *
+ * @internal
+ */
+export function createHashbrownRunAgentInput({
+  threadId,
+  runId,
+  system,
+  messages,
+  tools,
+  responseSchema,
+  ui,
+}: CreateHashbrownRunAgentInputOptions): HashbrownRunAgentInput {
+  const history = messages.flatMap((message, index) => {
+    const mapped = mapMessage(message, threadId, index);
+    return mapped ? [mapped] : [];
+  });
+  const hashbrown =
+    responseSchema !== undefined || ui === true
+      ? {
+          ...(responseSchema !== undefined ? { responseSchema } : {}),
+          ...(ui === true ? { ui: true } : {}),
+        }
+      : undefined;
+
+  return {
+    threadId,
+    runId,
+    messages: [
+      ...(system
+        ? [
+            {
+              id: `${threadId}:system`,
+              role: 'system' as const,
+              content: system,
+            },
+          ]
+        : []),
+      ...history,
+    ],
+    tools: tools.map(mapTool),
+    context: [],
+    state: {},
+    forwardedProps: {},
+    ...(hashbrown ? { hashbrown } : {}),
+  };
+}

--- a/packages/core/src/transport/http-transport.spec.ts
+++ b/packages/core/src/transport/http-transport.spec.ts
@@ -1,6 +1,8 @@
-import { HttpTransport } from './http-transport';
-import { TransportError } from './transport-error';
+import { type AGUIEvent, EventType, type RunAgentInput } from '@ag-ui/core';
 import { Chat } from '../models';
+import { HttpTransport } from './http-transport';
+import type { TransportRequest, TransportResponse } from './transport';
+import { TransportError } from './transport-error';
 
 const defaultParams: Chat.Api.CompletionCreateParams = {
   operation: 'generate',
@@ -9,78 +11,804 @@ const defaultParams: Chat.Api.CompletionCreateParams = {
   messages: [],
 };
 
-test('applies middleware before issuing fetch', async () => {
-  const fetchMock = jest.fn(
-    async () =>
-      new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array());
-            controller.close();
-          },
-        }),
-        { status: 200 },
-      ),
-  );
+const input: RunAgentInput = {
+  threadId: 'thread-1',
+  runId: 'run-1',
+  messages: [],
+  tools: [],
+  context: [],
+  state: {},
+  forwardedProps: {},
+};
 
+function createRequest(
+  overrides: Partial<TransportRequest> = {},
+): TransportRequest {
+  return {
+    input,
+    params: defaultParams,
+    signal: new AbortController().signal,
+    attempt: 1,
+    maxAttempts: 1,
+    requestId: 'test-request',
+    ...overrides,
+  };
+}
+
+function encodeSse(events: unknown[]): Uint8Array {
+  return new TextEncoder().encode(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''),
+  );
+}
+
+function splitBytes(bytes: Uint8Array, splitPoints: number[]): Uint8Array[] {
+  const chunks: Uint8Array[] = [];
+  let start = 0;
+  for (const end of splitPoints) {
+    chunks.push(bytes.slice(start, end));
+    start = end;
+  }
+  chunks.push(bytes.slice(start));
+  return chunks;
+}
+
+function createSseResponse(
+  chunks: Uint8Array[],
+  options: { close?: boolean; contentType?: string } = {},
+) {
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const cancel = jest.fn();
+  const stream = new ReadableStream<Uint8Array>({
+    start(nextController) {
+      controller = nextController;
+      for (const chunk of chunks) {
+        nextController.enqueue(chunk);
+      }
+      if (options.close ?? true) {
+        nextController.close();
+      }
+    },
+    cancel,
+  });
+  const response = new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': options.contentType ?? 'text/event-stream',
+    },
+  });
+
+  return { response, controller, cancel };
+}
+
+function createPullDrivenSseResponse(chunks: Uint8Array[]) {
+  let chunkIndex = 0;
+  let resolveExhausted: (value: 'exhausted') => void = () => undefined;
+  const exhausted = new Promise<'exhausted'>((resolve) => {
+    resolveExhausted = resolve;
+  });
+  const waitForCancellation = new Promise<void>(() => undefined);
+  const cancel = jest.fn();
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        const chunk = chunks[chunkIndex];
+        if (chunk) {
+          chunkIndex += 1;
+          controller.enqueue(chunk);
+          return;
+        }
+
+        resolveExhausted('exhausted');
+        return waitForCancellation;
+      },
+      cancel,
+    },
+    { highWaterMark: 0 },
+  );
+  const response = new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+
+  return { response, exhausted, cancel };
+}
+
+function successfulResponse(): Response {
+  return createSseResponse([], { close: true }).response;
+}
+
+function requireEvents(response: TransportResponse): AsyncIterable<AGUIEvent> {
+  if (!response.events) {
+    throw new Error('Expected AG-UI events');
+  }
+  return response.events;
+}
+
+async function collectEvents(
+  events: AsyncIterable<AGUIEvent>,
+): Promise<AGUIEvent[]> {
+  const values: AGUIEvent[] = [];
+  for await (const event of events) {
+    values.push(event);
+  }
+  return values;
+}
+
+test('rejects missing input before calling fetch', async () => {
+  const fetchMock = jest.fn(async () => successfulResponse());
   const transport = new HttpTransport({
-    baseUrl: 'https://example.com/chat',
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+
+  const sendPromise = transport.send(createRequest({ input: undefined }));
+
+  await expect(sendPromise).rejects.toMatchObject({
+    name: 'TransportError',
+    retryable: false,
+  });
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test('cleans up the request listener when JSON serialization fails', async () => {
+  const circularValue: { self?: unknown } = {};
+  circularValue.self = circularValue;
+  const requestController = new AbortController();
+  const addListener = jest.spyOn(requestController.signal, 'addEventListener');
+  const removeListener = jest.spyOn(
+    requestController.signal,
+    'removeEventListener',
+  );
+  const abort = jest.spyOn(AbortController.prototype, 'abort');
+  const fetchMock = jest.fn(async () => successfulResponse());
+  const transport = new HttpTransport({
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+
+  try {
+    const sendPromise = transport.send(
+      createRequest({
+        input: {
+          ...input,
+          forwardedProps: circularValue,
+        },
+        signal: requestController.signal,
+      }),
+    );
+
+    await expect(sendPromise).rejects.toBeInstanceOf(TypeError);
+    const abortListener = addListener.mock.calls[0][1];
+    expect(removeListener).toHaveBeenCalledWith('abort', abortListener);
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  } finally {
+    addListener.mockRestore();
+    removeListener.mockRestore();
+    abort.mockRestore();
+  }
+});
+
+test('cleans up the request listener when async middleware fails', async () => {
+  const middlewareError = new Error('middleware failed');
+  const requestController = new AbortController();
+  const addListener = jest.spyOn(requestController.signal, 'addEventListener');
+  const removeListener = jest.spyOn(
+    requestController.signal,
+    'removeEventListener',
+  );
+  const fetchMock = jest.fn(async () => successfulResponse());
+  let internalSignal: AbortSignal | null | undefined;
+  const transport = new HttpTransport({
     middleware: [
-      async (init) => ({
-        ...init,
-        headers: {
-          ...init.headers,
-          'x-test': 'first',
-        },
-      }),
-      (init) => ({
-        ...init,
-        headers: {
-          ...(init.headers as Record<string, string>),
-          'x-test-2': 'second',
-        },
-      }),
+      async (init) => {
+        internalSignal = init.signal;
+        await Promise.resolve();
+        throw middlewareError;
+      },
     ],
     fetchImpl: fetchMock as unknown as typeof fetch,
   });
 
-  await transport.send({
-    params: defaultParams,
-    signal: new AbortController().signal,
-    attempt: 1,
-    maxAttempts: 1,
-    requestId: 'test',
+  try {
+    const sendPromise = transport.send(
+      createRequest({ signal: requestController.signal }),
+    );
+
+    await expect(sendPromise).rejects.toBe(middlewareError);
+    const abortListener = addListener.mock.calls[0][1];
+    expect(removeListener).toHaveBeenCalledWith('abort', abortListener);
+    expect(internalSignal?.aborted).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  } finally {
+    addListener.mockRestore();
+    removeListener.mockRestore();
+  }
+});
+
+test('does not support legacy thread loading', () => {
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn() as unknown as typeof fetch,
   });
 
-  expect(fetchMock).toHaveBeenCalledWith(
-    'https://example.com/chat',
-    expect.objectContaining({
-      headers: expect.objectContaining({
-        'Content-Type': 'application/json',
-        'x-test': 'first',
-        'x-test-2': 'second',
-      }),
+  const supportsLegacyThreadLoading = transport.supportsLegacyThreadLoading;
+
+  expect(supportsLegacyThreadLoading).toBe(false);
+});
+
+test.each([undefined, '', '  \n'])(
+  'uses /run for a missing or blank base URL',
+  async (baseUrl) => {
+    const fetchMock = jest.fn(async () => successfulResponse());
+    const transport = new HttpTransport({
+      baseUrl,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    await transport.send(createRequest());
+
+    expect(fetchMock).toHaveBeenCalledWith('/run', expect.any(Object));
+  },
+);
+
+test('preserves a non-whitespace explicit URL byte-for-byte', async () => {
+  const fetchMock = jest.fn(async () => successfulResponse());
+  const endpoint = '  https://example.com/ag-ui?x=1  ';
+  const transport = new HttpTransport({
+    baseUrl: endpoint,
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+
+  await transport.send(createRequest());
+
+  expect(fetchMock).toHaveBeenCalledWith(endpoint, expect.any(Object));
+});
+
+test('posts the AG-UI input with exact default headers', async () => {
+  const fetchMock = jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>(
+    async () => successfulResponse(),
+  );
+  const transport = new HttpTransport({
+    fetchImpl: fetchMock as unknown as typeof fetch,
+  });
+
+  await transport.send(createRequest());
+
+  const [, init] = fetchMock.mock.calls[0];
+  expect(init).toMatchObject({
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+  expect(new Headers(init?.headers)).toEqual(
+    new Headers({
+      Accept: 'text/event-stream',
+      'Content-Type': 'application/json',
     }),
   );
 });
 
-test('throws TransportError on HTTP failure', async () => {
-  const fetchMock = jest.fn(
-    async () => new Response(null, { status: 500, statusText: 'boom' }),
+test('applies middleware in order and restores the authoritative signal', async () => {
+  const calls: string[] = [];
+  const replacementSignal = new AbortController().signal;
+  const requestController = new AbortController();
+  const fetchMock = jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>(
+    async () => successfulResponse(),
   );
-
   const transport = new HttpTransport({
-    baseUrl: 'https://example.com/chat',
+    middleware: [
+      (init) => {
+        calls.push('first');
+        const headers = new Headers(init.headers);
+        headers.set('x-first', '1');
+        return {
+          ...init,
+          headers,
+        };
+      },
+      (init) => {
+        calls.push(new Headers(init.headers).get('x-first') ?? 'missing');
+        return { ...init, signal: replacementSignal };
+      },
+    ],
     fetchImpl: fetchMock as unknown as typeof fetch,
   });
 
-  const sendPromise = transport.send({
-    params: defaultParams,
-    signal: new AbortController().signal,
-    attempt: 1,
-    maxAttempts: 1,
-    requestId: 'test',
+  await transport.send(
+    createRequest({
+      signal: requestController.signal,
+    }),
+  );
+  const [, init] = fetchMock.mock.calls[0];
+  requestController.abort('cancelled');
+
+  expect(calls).toEqual(['first', '1']);
+  expect(init?.signal).not.toBe(replacementSignal);
+  expect(init?.signal?.aborted).toBe(true);
+});
+
+test('parses and validates canonical RUN, TEXT, and TOOL events across byte splits', async () => {
+  const expectedEvents: AGUIEvent[] = [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-1',
+      delta: 'hello',
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'lookup',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{"query":"weather"}',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    },
+  ];
+  const bytes = encodeSse(expectedEvents);
+  const chunks = splitBytes(bytes, [1, 7, 31, 79, 143, bytes.length - 3]);
+  const { response } = createSseResponse(chunks, {
+    contentType: 'Text/Event-Stream; Charset=UTF-8',
+  });
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
   });
 
-  await expect(sendPromise).rejects.toBeInstanceOf(TransportError);
+  const result = await transport.send(createRequest());
+
+  await expect(collectEvents(requireEvents(result))).resolves.toEqual(
+    expectedEvents,
+  );
+});
+
+test('preserves buffered events when a single SSE chunk completes normally', async () => {
+  const expectedEvents: AGUIEvent[] = [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-1',
+      delta: 'hello',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'message-1',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-1',
+      runId: 'run-1',
+    },
+  ];
+  const { response } = createSseResponse([encodeSse(expectedEvents)]);
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+
+  const result = await transport.send(createRequest());
+  const events = await collectEvents(requireEvents(result));
+
+  expect(events).toEqual(expectedEvents);
+});
+
+test('emits CRLF-delimited SSE before an open connection closes', async () => {
+  const expectedEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const bytes = new TextEncoder().encode(
+    `data: ${JSON.stringify(expectedEvent)}\r\n\r\n`,
+  );
+  const carriageReturns = Array.from(bytes.keys()).filter(
+    (index) => bytes[index] === 13,
+  );
+  const chunks = splitBytes(
+    bytes,
+    carriageReturns.map((index) => index + 1),
+  );
+  const { response, exhausted, cancel } = createPullDrivenSseResponse(chunks);
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+  const iterator = requireEvents(result)[Symbol.asyncIterator]();
+
+  const outcome = await Promise.race([
+    iterator.next().then((event) => ({ type: 'event' as const, event })),
+    exhausted.then(() => ({ type: 'exhausted' as const })),
+  ]);
+
+  expect(outcome).toEqual({
+    type: 'event',
+    event: { done: false, value: expectedEvent },
+  });
+  await result.dispose?.();
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('preserves non-2xx TransportError formatting, status, and truncation', async () => {
+  const body = 'x'.repeat(501);
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(
+      async () => new Response(body, { status: 429, statusText: 'Too Many' }),
+    ) as unknown as typeof fetch,
+  });
+  const response = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(response)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.toEqual(
+    new TransportError(`Too Many (429): ${'x'.repeat(500)}…`, {
+      status: 429,
+      retryable: false,
+    }),
+  );
+});
+
+test('rejects a successful response with a null body as nonretryable', async () => {
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(
+      async () =>
+        new Response(null, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+    ) as unknown as typeof fetch,
+  });
+  const response = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(response)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.toMatchObject({
+    name: 'TransportError',
+    message: 'Response body is null',
+    status: 200,
+    retryable: false,
+  });
+});
+
+test.each([undefined, 'application/json'])(
+  'rejects a missing or wrong SSE content type',
+  async (contentType) => {
+    const headers = contentType ? { 'Content-Type': contentType } : undefined;
+    const transport = new HttpTransport({
+      fetchImpl: jest.fn(
+        async () => new Response('data: {}\n\n', { status: 200, headers }),
+      ) as unknown as typeof fetch,
+    });
+    const response = await transport.send(createRequest());
+
+    const nextPromise = requireEvents(response)[Symbol.asyncIterator]().next();
+
+    await expect(nextPromise).rejects.toMatchObject({
+      name: 'TransportError',
+      status: 200,
+      retryable: false,
+    });
+  },
+);
+
+test('leaves network errors ordinary and retryable', async () => {
+  const networkError = new Error('network unavailable');
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () =>
+      Promise.reject(networkError),
+    ) as unknown as typeof fetch,
+  });
+  const response = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(response)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.toBe(networkError);
+  expect(networkError).not.toBeInstanceOf(TransportError);
+});
+
+test('leaves malformed SSE JSON as an ordinary iterator error', async () => {
+  const { response } = createSseResponse([
+    new TextEncoder().encode('data: {not-json}\n\n'),
+  ]);
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(result)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.toBeInstanceOf(SyntaxError);
+});
+
+test('leaves schema-invalid SSE JSON as an ordinary iterator error', async () => {
+  const { response, cancel } = createSseResponse(
+    [encodeSse([{ type: EventType.RUN_STARTED }])],
+    { close: false },
+  );
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(result)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.not.toBeInstanceOf(TransportError);
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('request abort settles pending reads and cancels the reader', async () => {
+  const firstEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const { response, cancel } = createSseResponse([encodeSse([firstEvent])], {
+    close: false,
+  });
+  const requestController = new AbortController();
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(
+    createRequest({ signal: requestController.signal }),
+  );
+  const iterator = requireEvents(result)[Symbol.asyncIterator]();
+  await iterator.next();
+  const pendingNext = iterator.next();
+
+  requestController.abort('cancelled');
+
+  await expect(pendingNext).resolves.toEqual({ done: true, value: undefined });
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('iterator return settles pending reads and cancels the reader', async () => {
+  const firstEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const { response, cancel } = createSseResponse([encodeSse([firstEvent])], {
+    close: false,
+  });
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+  const iterator = requireEvents(result)[Symbol.asyncIterator]();
+  await iterator.next();
+  const pendingNext = iterator.next();
+
+  await iterator.return?.();
+
+  await expect(pendingNext).resolves.toEqual({ done: true, value: undefined });
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('iterator throw rejects pending reads and cancels the reader idempotently', async () => {
+  const firstEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const { response, cancel } = createSseResponse([encodeSse([firstEvent])], {
+    close: false,
+  });
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+  const iterator = requireEvents(result)[Symbol.asyncIterator]();
+  await iterator.next();
+  const firstPendingNext = iterator.next();
+  const secondPendingNext = iterator.next();
+  const iteratorError = new Error('iterator failed');
+
+  const throwPromise = iterator.throw?.(iteratorError);
+
+  await expect(throwPromise).rejects.toBe(iteratorError);
+  await expect(firstPendingNext).rejects.toBe(iteratorError);
+  await expect(secondPendingNext).rejects.toBe(iteratorError);
+  await expect(iterator.next()).rejects.toBe(iteratorError);
+  await result.dispose?.();
+  await result.dispose?.();
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('dispose settles pending reads and cancels the reader idempotently', async () => {
+  const firstEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const { response, cancel } = createSseResponse([encodeSse([firstEvent])], {
+    close: false,
+  });
+  const requestController = new AbortController();
+  const addListener = jest.spyOn(requestController.signal, 'addEventListener');
+  const removeListener = jest.spyOn(
+    requestController.signal,
+    'removeEventListener',
+  );
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+
+  try {
+    const result = await transport.send(
+      createRequest({ signal: requestController.signal }),
+    );
+    const iterator = requireEvents(result)[Symbol.asyncIterator]();
+    await iterator.next();
+    const pendingNext = iterator.next();
+
+    await result.dispose?.();
+    await result.dispose?.();
+
+    await expect(pendingNext).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    const abortListener = addListener.mock.calls[0][1];
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(removeListener).toHaveBeenCalledWith('abort', abortListener);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  } finally {
+    addListener.mockRestore();
+    removeListener.mockRestore();
+  }
+});
+
+test('dispose before fetch resolves cancels an eventual invalid response body', async () => {
+  let resolveResponse: (response: Response) => void = () => undefined;
+  const responsePromise = new Promise<Response>((resolve) => {
+    resolveResponse = resolve;
+  });
+  const cancel = jest.fn();
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      cancel,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(() => responsePromise) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+
+  await result.dispose?.();
+  resolveResponse(response);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+test('cancellation failures do not escape detached AG-UI teardown', async () => {
+  const firstEvent = {
+    type: EventType.RUN_STARTED,
+    threadId: 'thread-1',
+    runId: 'run-1',
+  } satisfies AGUIEvent;
+  const cancelError = new Error('cancel failed');
+  const cancel = jest.fn(async () => Promise.reject(cancelError));
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encodeSse([firstEvent]));
+    },
+    cancel,
+  });
+  const response = new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const unhandledRejections: unknown[] = [];
+  const handleUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on('unhandledRejection', handleUnhandledRejection);
+
+  try {
+    const result = await transport.send(createRequest());
+    const iterator = requireEvents(result)[Symbol.asyncIterator]();
+    await iterator.next();
+    const pendingNext = iterator.next();
+
+    await Promise.all([iterator.return?.(), result.dispose?.()]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(pendingNext).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    process.removeListener('unhandledRejection', handleUnhandledRejection);
+  }
+});
+
+test('read failures reject once without escaping detached teardown', async () => {
+  const readError = new Error('read failed');
+  const stream = new ReadableStream<Uint8Array>({
+    pull: () => Promise.reject(readError),
+  });
+  const response = new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+  const body = response.body;
+  if (!body) {
+    throw new Error('Expected response body');
+  }
+  const reader = body.getReader();
+  const cancel = jest.spyOn(reader, 'cancel');
+  const getReader = jest.spyOn(body, 'getReader').mockReturnValue(reader);
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const unhandledRejections: unknown[] = [];
+  const handleUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+  process.on('unhandledRejection', handleUnhandledRejection);
+
+  try {
+    const result = await transport.send(createRequest());
+    const iterator = requireEvents(result)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toBe(readError);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(unhandledRejections).toEqual([]);
+  } finally {
+    process.removeListener('unhandledRejection', handleUnhandledRejection);
+    getReader.mockRestore();
+    cancel.mockRestore();
+  }
+});
+
+test('parser errors cancel the active reader', async () => {
+  const { response, cancel } = createSseResponse(
+    [new TextEncoder().encode('data: {not-json}\n\n')],
+    { close: false },
+  );
+  const transport = new HttpTransport({
+    fetchImpl: jest.fn(async () => response) as unknown as typeof fetch,
+  });
+  const result = await transport.send(createRequest());
+
+  const nextPromise = requireEvents(result)[Symbol.asyncIterator]().next();
+
+  await expect(nextPromise).rejects.toBeInstanceOf(SyntaxError);
+  expect(cancel).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/src/transport/http-transport.ts
+++ b/packages/core/src/transport/http-transport.ts
@@ -1,30 +1,66 @@
+import { parseSSEStream } from '@ag-ui/client';
+import { type AGUIEvent, EventSchemas } from '@ag-ui/core';
 import { Chat } from '../models';
+import { observableToAsyncIterable } from './observable-to-async-iterable';
+import {
+  captureAgUiClient058Subscription,
+  normalizeSseLineEndings,
+} from './sse-line-ending-normalizer';
 import { Transport, TransportRequest, TransportResponse } from './transport';
 import { TransportError } from './transport-error';
+
+interface HttpEventObserver {
+  next(event: HttpStreamEvent): void;
+  error(error: unknown): void;
+  complete(): void;
+}
+
+interface HttpEventSubscription {
+  unsubscribe(): void;
+}
+
+interface HttpEventSubscribable {
+  subscribe(observer: HttpEventObserver): HttpEventSubscription;
+}
+
+type HttpStreamEvent =
+  | { type: 'headers'; status: number; headers: Headers }
+  | { type: 'data'; data: Uint8Array };
 
 /**
  * Options for the default HTTP transport.
  * @public
  */
 export interface HttpTransportOptions {
-  baseUrl: string;
+  /**
+   * URL that accepts AG-UI run requests.
+   *
+   * @defaultValue `/run`
+   */
+  baseUrl?: string;
+  /** Middleware applied in declaration order before each request is fetched. */
   middleware?: Chat.Middleware[];
+  /** Fetch implementation used to issue requests. Defaults to global `fetch`. */
   fetchImpl?: typeof fetch;
 }
 
 /**
- * Default HTTP-based transport that mirrors Hashbrown's legacy behavior.
+ * Default HTTP transport for AG-UI event streams.
  *
  * @public
  */
 export class HttpTransport implements Transport {
   readonly name = 'HttpTransport';
+  readonly supportsLegacyThreadLoading = false;
   private readonly baseUrl: string;
   private readonly middleware?: Chat.Middleware[];
   private readonly fetchImpl: typeof fetch;
 
   constructor(options: HttpTransportOptions) {
-    this.baseUrl = options.baseUrl;
+    this.baseUrl =
+      !options.baseUrl || options.baseUrl.trim() === ''
+        ? '/run'
+        : options.baseUrl;
     this.middleware = options.middleware;
     const boundFetch =
       typeof fetch === 'function' ? fetch.bind(globalThis) : undefined;
@@ -37,66 +73,274 @@ export class HttpTransport implements Transport {
   }
 
   async send(request: TransportRequest): Promise<TransportResponse> {
-    if (!this.baseUrl) {
-      throw new TransportError('Missing base URL for HttpTransport', {
+    if (!request.input) {
+      throw new TransportError('Missing AG-UI run input', {
         retryable: false,
       });
     }
 
-    let requestInit: RequestInit = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(request.params),
-      signal: request.signal,
-    };
-
-    if (this.middleware?.length) {
-      for (const middleware of this.middleware) {
-        requestInit = await middleware(requestInit);
+    const internalAbortController = new AbortController();
+    let requestAbortListenerAttached = false;
+    const handleRequestAbort = () => {
+      if (!internalAbortController.signal.aborted) {
+        internalAbortController.abort(request.signal.reason);
       }
-    }
-
-    const response = await this.fetchImpl(this.baseUrl, requestInit);
-
-    if (!response.ok) {
-      let bodyText: string | undefined;
-      try {
-        bodyText = await response.text();
-      } catch {
-        bodyText = undefined;
+    };
+    const removeRequestAbortListener = () => {
+      if (!requestAbortListenerAttached) {
+        return;
       }
 
-      const trimmedBody =
-        bodyText && bodyText.length > 500
-          ? `${bodyText.slice(0, 500)}…`
-          : bodyText;
-
-      const statusText = response.statusText || 'HTTP error';
-      const message = trimmedBody
-        ? `${statusText} (${response.status}): ${trimmedBody}`
-        : `${statusText} (${response.status})`;
-
-      throw new TransportError(message, {
-        status: response.status,
-        retryable: false,
-      });
-    }
-
-    if (!response.body) {
-      throw new TransportError('Response body is null', {
-        status: response.status,
-        retryable: false,
-      });
-    }
-
-    return {
-      stream: response.body,
-      metadata: {
-        status: response.status,
-      },
+      requestAbortListenerAttached = false;
+      request.signal.removeEventListener('abort', handleRequestAbort);
     };
+    let upstreamSubscription: { unsubscribe(): void } | undefined;
+    let cancellationRequested = false;
+    let cancelled = false;
+    const cancelUpstream = () => {
+      if (cancelled) {
+        return;
+      }
+
+      cancelled = true;
+      removeRequestAbortListener();
+      if (!internalAbortController.signal.aborted) {
+        internalAbortController.abort();
+      }
+      if (upstreamSubscription) {
+        upstreamSubscription.unsubscribe();
+      } else {
+        cancellationRequested = true;
+      }
+    };
+
+    try {
+      if (request.signal.aborted) {
+        handleRequestAbort();
+      } else {
+        request.signal.addEventListener('abort', handleRequestAbort, {
+          once: true,
+        });
+        requestAbortListenerAttached = true;
+      }
+
+      let requestInit: RequestInit = {
+        method: 'POST',
+        headers: {
+          Accept: 'text/event-stream',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request.input),
+        signal: internalAbortController.signal,
+      };
+
+      if (this.middleware?.length) {
+        for (const middleware of this.middleware) {
+          requestInit = await middleware(requestInit);
+        }
+      }
+      requestInit = {
+        ...requestInit,
+        signal: internalAbortController.signal,
+      };
+
+      const httpEvents = createHttpEventSource(() =>
+        this.fetchImpl(this.baseUrl, requestInit),
+      );
+      const normalizedHttpEvents = normalizeSseLineEndings(httpEvents);
+      const capturedHttpEvents = captureAgUiClient058Subscription(
+        normalizedHttpEvents,
+        (subscription) => {
+          upstreamSubscription = subscription;
+          if (cancellationRequested) {
+            subscription.unsubscribe();
+          }
+        },
+      );
+
+      const parsedEvents = parseSSEStream(capturedHttpEvents);
+      const events = observableToAsyncIterable<unknown, AGUIEvent>(
+        parsedEvents,
+        (value) => EventSchemas.parse(value),
+        cancelUpstream,
+      );
+      internalAbortController.signal.addEventListener(
+        'abort',
+        () => {
+          if (!cancelled) {
+            events.close();
+          }
+        },
+        { once: true },
+      );
+      if (internalAbortController.signal.aborted) {
+        events.close();
+      }
+
+      return {
+        events,
+        dispose: () => events.close(),
+      };
+    } catch (error) {
+      cancelUpstream();
+      throw error;
+    }
+  }
+}
+
+function createHttpEventSource(
+  fetchResponse: () => Promise<Response>,
+): HttpEventSubscribable {
+  return {
+    subscribe(observer) {
+      let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+      let stopped = false;
+      let cancellationStarted = false;
+
+      const cancelReader = async () => {
+        if (!reader || cancellationStarted) {
+          return;
+        }
+
+        cancellationStarted = true;
+        try {
+          await reader.cancel();
+        } catch {
+          // Cancellation is teardown-only and the observable state has already
+          // settled. Keep the owned cancellation promise from escaping.
+        }
+      };
+      const unsubscribe = () => {
+        if (stopped) {
+          return;
+        }
+
+        stopped = true;
+        void cancelReader();
+      };
+      const error = (cause: unknown) => {
+        if (stopped) {
+          return;
+        }
+
+        stopped = true;
+        void cancelReader();
+        observer.error(cause);
+      };
+      const complete = () => {
+        if (stopped) {
+          return;
+        }
+
+        stopped = true;
+        void cancelReader();
+        observer.complete();
+      };
+
+      const consumeResponse = async () => {
+        try {
+          const response = await fetchResponse();
+          if (response.body) {
+            reader = response.body.getReader();
+          }
+          if (stopped) {
+            void cancelReader();
+            return;
+          }
+
+          await validateResponse(response, reader);
+          if (!reader) {
+            throw new Error('Response body is null');
+          }
+          if (stopped) {
+            void cancelReader();
+            return;
+          }
+
+          observer.next({
+            type: 'headers',
+            status: response.status,
+            headers: response.headers,
+          });
+          while (!stopped) {
+            const { done, value } = await reader.read();
+            if (done) {
+              complete();
+              return;
+            }
+
+            observer.next({ type: 'data', data: value });
+          }
+        } catch (cause) {
+          error(cause);
+        }
+      };
+
+      void consumeResponse();
+      return { unsubscribe };
+    },
+  };
+}
+
+async function validateResponse(
+  response: Response,
+  reader: ReadableStreamDefaultReader<Uint8Array> | undefined,
+): Promise<void> {
+  if (!response.ok) {
+    const bodyText = reader ? await readResponseText(reader) : undefined;
+
+    const trimmedBody =
+      bodyText && bodyText.length > 500
+        ? `${bodyText.slice(0, 500)}…`
+        : bodyText;
+    const statusText = response.statusText || 'HTTP error';
+    const message = trimmedBody
+      ? `${statusText} (${response.status}): ${trimmedBody}`
+      : `${statusText} (${response.status})`;
+
+    throw new TransportError(message, {
+      status: response.status,
+      retryable: false,
+    });
+  }
+
+  if (!response.body) {
+    throw new TransportError('Response body is null', {
+      status: response.status,
+      retryable: false,
+    });
+  }
+
+  const contentType = response.headers.get('content-type');
+  const mediaType = contentType?.split(';', 1)[0].trim().toLowerCase();
+  if (mediaType !== 'text/event-stream') {
+    throw new TransportError(
+      `Expected text/event-stream response but received ${contentType ?? 'no content type'}`,
+      {
+        status: response.status,
+        retryable: false,
+      },
+    );
+  }
+}
+
+async function readResponseText(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string | undefined> {
+  const decoder = new TextDecoder();
+  let bodyText = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return bodyText + decoder.decode();
+      }
+
+      bodyText += decoder.decode(value, { stream: true });
+    }
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/core/src/transport/model-spec.spec.ts
+++ b/packages/core/src/transport/model-spec.spec.ts
@@ -1,5 +1,6 @@
 import { Frame } from '../frames';
 import { Chat } from '../models';
+import type { RunAgentInput } from '@ag-ui/core';
 import { TransportError } from './transport-error';
 import {
   ModelResolver,
@@ -17,6 +18,37 @@ const features: RequestedFeatures = {
   ui: false,
   threads: false,
 };
+
+const input: RunAgentInput = {
+  threadId: 'thread-1',
+  runId: 'run-1',
+  messages: [],
+  tools: [],
+  context: [],
+  state: {},
+  forwardedProps: {},
+};
+
+const params: Chat.Api.CompletionCreateParams = {
+  operation: 'generate',
+  model: '' as Chat.Api.CompletionCreateParams['model'],
+  system: '',
+  messages: [],
+};
+
+function createSseResponse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    },
+  );
+}
 
 test('skips specs without required capabilities', async () => {
   const ineligibleSpec: ModelSpec = {
@@ -81,13 +113,6 @@ test('advances after PLATFORM_UNSUPPORTED errors', async () => {
   expect(first?.spec.name).toBe('platform-unavailable');
 
   if (first) {
-    const params: Chat.Api.CompletionCreateParams = {
-      operation: 'generate',
-      model: '' as Chat.Api.CompletionCreateParams['model'],
-      system: '',
-      messages: [],
-    };
-
     try {
       await first.transport.send({
         params,
@@ -103,4 +128,64 @@ test('advances after PLATFORM_UNSUPPORTED errors', async () => {
 
   const selection = await resolver.select(features);
   expect(selection?.spec.name).toBe('fallback');
+});
+
+test.each([undefined, '', ' \n '])(
+  'default string models use /run for a missing or blank API URL',
+  async (url) => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(async () => createSseResponse());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const resolver = new ModelResolver('test-model', { url });
+      const selection = await resolver.select(features);
+
+      const response = await selection?.transport.send({
+        input,
+        params,
+        signal: new AbortController().signal,
+        attempt: 1,
+        maxAttempts: 1,
+        requestId: 'test-request',
+      });
+      await response?.dispose?.();
+
+      expect(selection?.spec.name).toBe('test-model');
+      expect(fetchMock).toHaveBeenCalledWith('/run', expect.any(Object));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  },
+);
+
+test('default string models preserve a non-whitespace API URL exactly', async () => {
+  const originalFetch = globalThis.fetch;
+  const fetchMock = jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>(
+    async () => createSseResponse(),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const endpoint = '  https://example.com/custom-run?x=1  ';
+
+  try {
+    const resolver = new ModelResolver('test-model', { url: endpoint });
+    const selection = await resolver.select(features);
+
+    const response = await selection?.transport.send({
+      input,
+      params,
+      signal: new AbortController().signal,
+      attempt: 1,
+      maxAttempts: 1,
+      requestId: 'test-request',
+    });
+    await response?.dispose?.();
+
+    expect(fetchMock).toHaveBeenCalledWith(endpoint, expect.any(Object));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/packages/core/src/transport/model-spec.ts
+++ b/packages/core/src/transport/model-spec.ts
@@ -266,20 +266,13 @@ export class ModelResolver {
     return candidate;
   }
 
-  private buildDefaultTransport(): TransportFactory | Transport | undefined {
+  private buildDefaultTransport(): TransportFactory | Transport {
     if (this.config.transport) {
       return this.config.transport;
     }
 
     const baseUrl =
       typeof this.config.url === 'string' ? this.config.url : undefined;
-
-    if (!baseUrl) {
-      console.warn(
-        'No url provided for default transport; string model specs will be skipped.',
-      );
-      return undefined;
-    }
 
     const options: HttpTransportOptions = {
       baseUrl,

--- a/packages/core/src/transport/observable-to-async-iterable.spec.ts
+++ b/packages/core/src/transport/observable-to-async-iterable.spec.ts
@@ -1,0 +1,279 @@
+import { observableToAsyncIterable } from './observable-to-async-iterable';
+import { Observable, Subject } from 'rxjs';
+
+test('subscribes immediately when the adapter is created', () => {
+  const subscribe = jest.fn(() => ({ unsubscribe: jest.fn() }));
+
+  observableToAsyncIterable({ subscribe });
+
+  expect(subscribe).toHaveBeenCalledTimes(1);
+});
+
+test('buffers values emitted before next is called', async () => {
+  const source = new Subject<number>();
+  const iterator = observableToAsyncIterable(source);
+  source.next(1);
+  source.next(2);
+
+  const first = await iterator.next();
+  const second = await iterator.next();
+
+  expect(first).toEqual({ done: false, value: 1 });
+  expect(second).toEqual({ done: false, value: 2 });
+});
+
+test('resolves multiple pending next calls in order', async () => {
+  const source = new Subject<number>();
+  const iterator = observableToAsyncIterable(source);
+  const firstPromise = iterator.next();
+  const secondPromise = iterator.next();
+
+  source.next(1);
+  source.next(2);
+
+  await expect(firstPromise).resolves.toEqual({ done: false, value: 1 });
+  await expect(secondPromise).resolves.toEqual({ done: false, value: 2 });
+});
+
+test('buffers synchronous values before synchronous completion', async () => {
+  const source = new Observable<number>((observer) => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  const iterator = observableToAsyncIterable(source);
+
+  await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+  await expect(iterator.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+});
+
+test('close after synchronous completion discards buffered values', async () => {
+  const source = new Observable<number>((observer) => {
+    observer.next(1);
+    observer.complete();
+  });
+  const iterator = observableToAsyncIterable(source);
+
+  iterator.close();
+
+  await expect(iterator.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+});
+
+test('return after synchronous completion discards buffered values', async () => {
+  const source = new Observable<number>((observer) => {
+    observer.next(1);
+    observer.complete();
+  });
+  const iterator = observableToAsyncIterable(source);
+
+  const returnResult = await iterator.return?.('closed');
+
+  expect(returnResult).toEqual({ done: true, value: 'closed' });
+  await expect(iterator.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+});
+
+test('throw after synchronous completion discards buffered values and establishes its error', async () => {
+  const source = new Observable<number>((observer) => {
+    observer.next(1);
+    observer.complete();
+  });
+  const iterator = observableToAsyncIterable(source);
+  const iteratorError = new Error('iterator failed');
+
+  const throwPromise = iterator.throw?.(iteratorError);
+
+  await expect(throwPromise).rejects.toBe(iteratorError);
+  await expect(iterator.next()).rejects.toBe(iteratorError);
+});
+
+test('close overrides a synchronous source error and discards buffered values', async () => {
+  const source = new Observable<number>((observer) => {
+    observer.next(1);
+    observer.error(new Error('source failed'));
+  });
+  const iterator = observableToAsyncIterable(source);
+
+  iterator.close();
+
+  await expect(iterator.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+});
+
+test('rejects next calls after a synchronous source error', async () => {
+  const sourceError = new Error('source failed');
+  const source = new Observable<number>((observer) => {
+    observer.error(sourceError);
+  });
+
+  const iterator = observableToAsyncIterable(source);
+
+  await expect(iterator.next()).rejects.toBe(sourceError);
+});
+
+test('rejects all pending and future next calls with a terminal error', async () => {
+  const source = new Subject<number>();
+  const iterator = observableToAsyncIterable(source);
+  const firstPromise = iterator.next();
+  const secondPromise = iterator.next();
+  const sourceError = new Error('source failed');
+
+  source.error(sourceError);
+
+  await expect(firstPromise).rejects.toBe(sourceError);
+  await expect(secondPromise).rejects.toBe(sourceError);
+  await expect(iterator.next()).rejects.toBe(sourceError);
+});
+
+test('return settles pending reads and closes the source exactly once', async () => {
+  const unsubscribe = jest.fn();
+  const onClose = jest.fn();
+  const source = new Observable<number>(() => unsubscribe);
+  const iterator = observableToAsyncIterable(source, (value) => value, onClose);
+  const firstPromise = iterator.next();
+  const secondPromise = iterator.next();
+
+  const returnResult = await iterator.return?.('closed');
+  iterator.close();
+
+  expect(returnResult).toEqual({ done: true, value: 'closed' });
+  await expect(firstPromise).resolves.toEqual({ done: true, value: undefined });
+  await expect(secondPromise).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('throw rejects pending reads and closes the source exactly once', async () => {
+  const unsubscribe = jest.fn();
+  const onClose = jest.fn();
+  const source = new Observable<number>(() => unsubscribe);
+  const iterator = observableToAsyncIterable(source, (value) => value, onClose);
+  const firstPromise = iterator.next();
+  const secondPromise = iterator.next();
+  const iteratorError = new Error('iterator failed');
+
+  const throwPromise = iterator.throw?.(iteratorError);
+  iterator.close();
+
+  await expect(throwPromise).rejects.toBe(iteratorError);
+  await expect(firstPromise).rejects.toBe(iteratorError);
+  await expect(secondPromise).rejects.toBe(iteratorError);
+  await expect(iterator.next()).rejects.toBe(iteratorError);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('close settles pending reads and cleans up exactly once', async () => {
+  const unsubscribe = jest.fn();
+  const onClose = jest.fn();
+  const source = new Observable<number>(() => unsubscribe);
+  const iterator = observableToAsyncIterable(source, (value) => value, onClose);
+  const nextPromise = iterator.next();
+
+  iterator.close();
+  iterator.close();
+
+  await expect(nextPromise).resolves.toEqual({ done: true, value: undefined });
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('turns mapper exceptions into terminal iterator errors and cleans up', async () => {
+  let observer:
+    | {
+        next(value: number): void;
+        error(error: unknown): void;
+        complete(): void;
+      }
+    | undefined;
+  const unsubscribe = jest.fn();
+  const onClose = jest.fn();
+  const mapperError = new Error('mapping failed');
+  const source = {
+    subscribe(nextObserver: NonNullable<typeof observer>) {
+      observer = nextObserver;
+      return { unsubscribe };
+    },
+  };
+  const iterator = observableToAsyncIterable(
+    source,
+    () => {
+      throw mapperError;
+    },
+    onClose,
+  );
+  const nextPromise = iterator.next();
+
+  expect(() => observer?.next(1)).not.toThrow();
+
+  await expect(nextPromise).rejects.toBe(mapperError);
+  await expect(iterator.next()).rejects.toBe(mapperError);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('source errors clean up the subscription and close callback', async () => {
+  let observer:
+    | {
+        next(value: number): void;
+        error(error: unknown): void;
+        complete(): void;
+      }
+    | undefined;
+  const unsubscribe = jest.fn();
+  const onClose = jest.fn();
+  const source = {
+    subscribe(nextObserver: NonNullable<typeof observer>) {
+      observer = nextObserver;
+      return { unsubscribe };
+    },
+  };
+  const iterator = observableToAsyncIterable(source, (value) => value, onClose);
+  const sourceError = new Error('parser failed');
+
+  observer?.error(sourceError);
+
+  await expect(iterator.next()).rejects.toBe(sourceError);
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test('ignores emissions after the iterator reaches a terminal state', async () => {
+  let observer:
+    | {
+        next(value: number): void;
+        error(error: unknown): void;
+        complete(): void;
+      }
+    | undefined;
+  const map = jest.fn((value: number) => value);
+  const source = {
+    subscribe(nextObserver: NonNullable<typeof observer>) {
+      observer = nextObserver;
+      return { unsubscribe: jest.fn() };
+    },
+  };
+  const iterator = observableToAsyncIterable(source, map);
+
+  observer?.complete();
+  observer?.next(1);
+
+  await expect(iterator.next()).resolves.toEqual({
+    done: true,
+    value: undefined,
+  });
+  expect(map).not.toHaveBeenCalled();
+});

--- a/packages/core/src/transport/observable-to-async-iterable.ts
+++ b/packages/core/src/transport/observable-to-async-iterable.ts
@@ -1,0 +1,204 @@
+interface Subscription {
+  unsubscribe(): void;
+}
+
+interface Observer<T> {
+  next(value: T): void;
+  error(error: unknown): void;
+  complete(): void;
+}
+
+interface Subscribable<T> {
+  subscribe(observer: Observer<T>): Subscription;
+}
+
+/**
+ * Async iterator with an explicit synchronous close operation.
+ *
+ * @internal
+ */
+export interface ClosableAsyncIterableIterator<
+  T,
+> extends AsyncIterableIterator<T> {
+  close(): void;
+}
+
+/**
+ * Adapts the minimal observable contract to an eagerly subscribed async iterator.
+ *
+ * @internal
+ */
+export function observableToAsyncIterable<T, U = T>(
+  source: Subscribable<T>,
+  map: (value: T) => U = (value) => value as unknown as U,
+  onClose?: () => void,
+): ClosableAsyncIterableIterator<U> {
+  const bufferedValues: U[] = [];
+  const pendingNextCalls: Array<{
+    resolve: (result: IteratorResult<U>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let terminalState:
+    | 'active'
+    | 'source-completed'
+    | 'source-errored'
+    | 'explicit-completed'
+    | 'explicit-errored' = 'active';
+  let terminalError: unknown;
+  let subscription: Subscription | undefined;
+  let unsubscribeRequested = false;
+  let unsubscribed = false;
+  let closeCallbackCalled = false;
+
+  const unsubscribe = () => {
+    if (unsubscribed) {
+      return;
+    }
+    if (!subscription) {
+      unsubscribeRequested = true;
+      return;
+    }
+
+    unsubscribed = true;
+    subscription.unsubscribe();
+  };
+
+  const cleanup = () => {
+    if (!closeCallbackCalled) {
+      closeCallbackCalled = true;
+      onClose?.();
+    }
+    unsubscribe();
+  };
+
+  const completeFromSource = () => {
+    if (terminalState !== 'active') {
+      return;
+    }
+
+    terminalState = 'source-completed';
+    for (const pending of pendingNextCalls.splice(0)) {
+      pending.resolve({ done: true, value: undefined });
+    }
+    cleanup();
+  };
+
+  const errorFromSource = (error: unknown) => {
+    if (terminalState !== 'active') {
+      return;
+    }
+
+    terminalState = 'source-errored';
+    terminalError = error;
+    for (const pending of pendingNextCalls.splice(0)) {
+      pending.reject(error);
+    }
+    cleanup();
+  };
+
+  const terminateWithCompletion = () => {
+    if (
+      terminalState === 'explicit-completed' ||
+      terminalState === 'explicit-errored'
+    ) {
+      return;
+    }
+
+    terminalState = 'explicit-completed';
+    bufferedValues.length = 0;
+    for (const pending of pendingNextCalls.splice(0)) {
+      pending.resolve({ done: true, value: undefined });
+    }
+    cleanup();
+  };
+
+  const terminateWithError = (error: unknown) => {
+    if (
+      terminalState === 'explicit-completed' ||
+      terminalState === 'explicit-errored'
+    ) {
+      return;
+    }
+
+    terminalState = 'explicit-errored';
+    terminalError = error;
+    bufferedValues.length = 0;
+    for (const pending of pendingNextCalls.splice(0)) {
+      pending.reject(error);
+    }
+    cleanup();
+  };
+
+  try {
+    subscription = source.subscribe({
+      next: (sourceValue) => {
+        if (terminalState !== 'active') {
+          return;
+        }
+
+        let value: U;
+        try {
+          value = map(sourceValue);
+        } catch (error) {
+          errorFromSource(error);
+          return;
+        }
+
+        const pending = pendingNextCalls.shift();
+        if (pending) {
+          pending.resolve({ done: false, value });
+        } else {
+          bufferedValues.push(value);
+        }
+      },
+      error: (error) => {
+        errorFromSource(error);
+      },
+      complete: () => {
+        completeFromSource();
+      },
+    });
+  } catch (error) {
+    errorFromSource(error);
+  }
+  if (unsubscribeRequested) {
+    unsubscribe();
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next: () => {
+      if (bufferedValues.length > 0) {
+        const value = bufferedValues.shift() as U;
+        return Promise.resolve({ done: false, value } as IteratorResult<U>);
+      }
+      if (
+        terminalState === 'source-errored' ||
+        terminalState === 'explicit-errored'
+      ) {
+        return Promise.reject(terminalError);
+      }
+      if (
+        terminalState === 'source-completed' ||
+        terminalState === 'explicit-completed'
+      ) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+
+      return new Promise<IteratorResult<U>>((resolve, reject) => {
+        pendingNextCalls.push({ resolve, reject });
+      });
+    },
+    return: async (value?: unknown) => {
+      terminateWithCompletion();
+      return { done: true, value };
+    },
+    throw: async (error?: unknown) => {
+      terminateWithError(error);
+      return Promise.reject(error);
+    },
+    close: terminateWithCompletion,
+  };
+}

--- a/packages/core/src/transport/sse-line-ending-normalizer.spec.ts
+++ b/packages/core/src/transport/sse-line-ending-normalizer.spec.ts
@@ -1,0 +1,69 @@
+import { Subject } from 'rxjs';
+import { normalizeSseLineEndings } from './sse-line-ending-normalizer';
+
+interface TestHttpEvent {
+  type: 'data' | 'headers';
+  data?: Uint8Array;
+  status?: number;
+}
+
+function concatenate(chunks: Uint8Array[]): Uint8Array {
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+test('normalizes CRLF split across data chunks before completion', () => {
+  const source = new Subject<TestHttpEvent>();
+  const normalized = normalizeSseLineEndings<TestHttpEvent>(source);
+  const chunks: Uint8Array[] = [];
+  normalized.subscribe({
+    next: (event) => {
+      if (event.data) {
+        chunks.push(event.data);
+      }
+    },
+    error: () => undefined,
+    complete: () => undefined,
+  });
+
+  source.next({
+    type: 'data',
+    data: new TextEncoder().encode('data: {}\r'),
+  });
+  source.next({ type: 'data', data: new TextEncoder().encode('\n\r') });
+  source.next({ type: 'data', data: new TextEncoder().encode('\n') });
+
+  expect(new TextDecoder().decode(concatenate(chunks))).toBe('data: {}\n\n');
+});
+
+test('normalizes lone and trailing CR while preserving UTF-8 and headers', () => {
+  const source = new Subject<TestHttpEvent>();
+  const normalized = normalizeSseLineEndings<TestHttpEvent>(source);
+  const headerEvent: TestHttpEvent = { type: 'headers', status: 200 };
+  const events: TestHttpEvent[] = [];
+  normalized.subscribe({
+    next: (event) => events.push(event),
+    error: () => undefined,
+    complete: () => undefined,
+  });
+
+  source.next(headerEvent);
+  source.next({
+    type: 'data',
+    data: new TextEncoder().encode('data: café ☕\rdata: fin\r'),
+  });
+  source.complete();
+
+  expect(events[0]).toBe(headerEvent);
+  expect(
+    new TextDecoder().decode(
+      concatenate(events.flatMap((event) => (event.data ? [event.data] : []))),
+    ),
+  ).toBe('data: café ☕\ndata: fin\n');
+});

--- a/packages/core/src/transport/sse-line-ending-normalizer.ts
+++ b/packages/core/src/transport/sse-line-ending-normalizer.ts
@@ -1,0 +1,142 @@
+import type { parseSSEStream } from '@ag-ui/client';
+
+interface Subscription {
+  unsubscribe(): void;
+}
+
+interface Observer<T> {
+  next(value: T): void;
+  error(error: unknown): void;
+  complete(): void;
+}
+
+interface Subscribable<T> {
+  subscribe(observer: Observer<T>): Subscription;
+}
+
+interface HttpStreamEvent {
+  type: string;
+  data?: Uint8Array;
+}
+
+const CARRIAGE_RETURN = 13;
+const LINE_FEED = 10;
+
+function normalizeChunk(
+  data: Uint8Array,
+  hasTrailingCarriageReturn: boolean,
+): { data: Uint8Array; hasTrailingCarriageReturn: boolean } {
+  if (data.length === 0) {
+    return { data, hasTrailingCarriageReturn };
+  }
+
+  const output = new Uint8Array(
+    data.length + (hasTrailingCarriageReturn ? 1 : 0),
+  );
+  let inputIndex = 0;
+  let outputIndex = 0;
+
+  if (hasTrailingCarriageReturn) {
+    output[outputIndex] = LINE_FEED;
+    outputIndex += 1;
+    if (data[0] === LINE_FEED) {
+      inputIndex += 1;
+    }
+  }
+
+  let trailingCarriageReturn = false;
+  while (inputIndex < data.length) {
+    const byte = data[inputIndex];
+    if (byte !== CARRIAGE_RETURN) {
+      output[outputIndex] = byte;
+      outputIndex += 1;
+      inputIndex += 1;
+      continue;
+    }
+
+    if (inputIndex === data.length - 1) {
+      trailingCarriageReturn = true;
+      inputIndex += 1;
+      continue;
+    }
+
+    output[outputIndex] = LINE_FEED;
+    outputIndex += 1;
+    inputIndex += data[inputIndex + 1] === LINE_FEED ? 2 : 1;
+  }
+
+  return {
+    data: output.slice(0, outputIndex),
+    hasTrailingCarriageReturn: trailingCarriageReturn,
+  };
+}
+
+/**
+ * Normalizes valid SSE CRLF and CR line endings without decoding UTF-8 data.
+ *
+ * @internal
+ */
+export function normalizeSseLineEndings<T extends HttpStreamEvent>(
+  source: Subscribable<T>,
+): Subscribable<T> {
+  return {
+    subscribe(observer) {
+      let trailingCarriageReturnEvent: T | undefined;
+
+      return source.subscribe({
+        next(event) {
+          if (event.type !== 'data' || !event.data) {
+            observer.next(event);
+            return;
+          }
+
+          const normalized = normalizeChunk(
+            event.data,
+            trailingCarriageReturnEvent !== undefined,
+          );
+          trailingCarriageReturnEvent = normalized.hasTrailingCarriageReturn
+            ? event
+            : undefined;
+          if (normalized.data.length > 0) {
+            observer.next({ ...event, data: normalized.data });
+          }
+        },
+        error(error) {
+          observer.error(error);
+        },
+        complete() {
+          if (trailingCarriageReturnEvent) {
+            observer.next({
+              ...trailingCarriageReturnEvent,
+              data: Uint8Array.of(LINE_FEED),
+            });
+          }
+          observer.complete();
+        },
+      });
+    },
+  };
+}
+
+/**
+ * Captures the upstream subscription hidden by `parseSSEStream` in AG-UI 0.0.58.
+ *
+ * The pinned parser only calls `subscribe` on its input and does not propagate
+ * teardown, so this keeps the version-specific structural cast in one boundary.
+ *
+ * @internal
+ */
+export function captureAgUiClient058Subscription<T>(
+  source: Subscribable<T>,
+  capture: (subscription: Subscription) => void,
+): Parameters<typeof parseSSEStream>[0] {
+  const capturedSource = {
+    subscribe(observer: Observer<T>) {
+      const subscription = source.subscribe(observer);
+      capture(subscription);
+      return subscription;
+    },
+  };
+
+  return capturedSource as unknown as Parameters<typeof parseSSEStream>[0];
+}

--- a/packages/core/src/transport/transport.ts
+++ b/packages/core/src/transport/transport.ts
@@ -1,3 +1,4 @@
+import type { AGUIEvent, RunAgentInput } from '@ag-ui/core';
 import { Chat } from '../models';
 import { Frame } from '../frames';
 /**
@@ -15,6 +16,20 @@ export interface TransportMetadata {
  * @public
  */
 export interface TransportRequest {
+  /**
+   * Modern AG-UI input sent directly to AG-UI-compatible transports.
+   */
+  input?: RunAgentInput & {
+    hashbrown?: {
+      responseSchema?: object;
+      ui?: boolean;
+    };
+  };
+  /**
+   * Legacy completion parameters used by frame-based providers.
+   *
+   * @deprecated Modern transports should consume `input`.
+   */
   params: Chat.Api.CompletionCreateParams;
   signal: AbortSignal;
   attempt: number;
@@ -28,6 +43,8 @@ export interface TransportRequest {
  * @public
  */
 export interface TransportResponse {
+  /** Validated AG-UI events streamed by a modern transport. */
+  events?: AsyncIterable<AGUIEvent>;
   stream?: ReadableStream<Uint8Array>;
   frames?: AsyncGenerator<Frame>;
   metadata?: TransportMetadata;
@@ -35,12 +52,19 @@ export interface TransportResponse {
 }
 
 /**
- * Abstraction that converts chat params into a frame stream.
+ * Abstraction for modern AG-UI event responses and deprecated legacy frame or
+ * byte-stream responses.
  *
  * @public
  */
 export interface Transport {
   readonly name: string;
+  /**
+   * Whether this transport supports legacy thread-loading requests. When
+   * omitted, the current legacy behavior is preserved. Modern HTTP transport
+   * implementations set this to `false`.
+   */
+  readonly supportsLegacyThreadLoading?: boolean;
   send(request: TransportRequest): Promise<TransportResponse>;
 }
 

--- a/packages/react/e2e/package-shape.e2e.spec.ts
+++ b/packages/react/e2e/package-shape.e2e.spec.ts
@@ -1,15 +1,14 @@
 import {
-  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
-  symlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 
 type PackageJson = {
   dependencies?: Record<string, string>;
@@ -28,6 +27,8 @@ type PackageJson = {
 const workspaceRoot = resolve(__dirname, '../../..');
 const reactDistPath = join(workspaceRoot, 'dist/packages/react');
 const coreDistPath = join(workspaceRoot, 'dist/packages/core');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const childProcessTimeoutMs = 90_000;
 
 function readReactPackageJson(): PackageJson {
   return JSON.parse(
@@ -35,49 +36,108 @@ function readReactPackageJson(): PackageJson {
   ) as PackageJson;
 }
 
-function runNodePackageCheck(script: string, sandboxPath: string) {
-  return spawnSync(
-    process.execPath,
-    ['--input-type=module', '--eval', script],
-    {
-      cwd: sandboxPath,
-      env: {
-        ...process.env,
-        NODE_PATH: join(sandboxPath, 'node_modules'),
-      },
-      encoding: 'utf8',
-    },
+function assertProcessSucceeded(
+  label: string,
+  command: string,
+  args: string[],
+  result: SpawnSyncReturns<string>,
+): void {
+  if (!result.error && !result.signal && result.status === 0) {
+    return;
+  }
+
+  const processError = result.error as NodeJS.ErrnoException | undefined;
+  const failureDetails = [
+    processError
+      ? `${processError.code ?? processError.name}: ${processError.message}`
+      : undefined,
+    result.signal ? `signal ${result.signal}` : undefined,
+    result.status !== null ? `exit status ${result.status}` : undefined,
+  ].filter(Boolean);
+  throw new Error(
+    `${label} failed (${failureDetails.join(', ')})\n` +
+      `Command: ${command} ${args.join(' ')}\n` +
+      `stdout:\n${result.stdout || '<empty>'}\n` +
+      `stderr:\n${result.stderr || '<empty>'}`,
   );
+}
+
+function runNodePackageCheck(script: string, sandboxPath: string) {
+  const args = ['--input-type=module', '--eval', script];
+  const result = spawnSync(process.execPath, args, {
+    cwd: sandboxPath,
+    env: {
+      ...process.env,
+      NODE_PATH: join(sandboxPath, 'node_modules'),
+    },
+    encoding: 'utf8',
+    timeout: childProcessTimeoutMs,
+  });
+  assertProcessSucceeded('Consumer Node check', process.execPath, args, result);
+
+  return result;
+}
+
+function runNpm(args: string[], cwd: string): string {
+  const result = spawnSync(npmCommand, args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: childProcessTimeoutMs,
+  });
+  assertProcessSucceeded('npm command', npmCommand, args, result);
+
+  return result.stdout;
+}
+
+function packPackage(packagePath: string, packPath: string): string {
+  const output = runNpm(
+    ['pack', packagePath, '--json', '--pack-destination', packPath],
+    workspaceRoot,
+  );
+  const packs = JSON.parse(output) as Array<{ filename?: string }>;
+  const filename = packs[0]?.filename;
+  if (!filename) {
+    throw new Error(`npm pack did not report a filename for ${packagePath}`);
+  }
+
+  return join(packPath, filename);
 }
 
 function createPackageSandbox(): string {
   const sandboxPath = mkdtempSync(join(tmpdir(), 'hashbrown-react-package-'));
-  const nodeModulesPath = join(sandboxPath, 'node_modules');
-  const scopePath = join(nodeModulesPath, '@hashbrownai');
-  mkdirSync(scopePath, { recursive: true });
-  cpSync(reactDistPath, join(scopePath, 'react'), { recursive: true });
-  cpSync(coreDistPath, join(scopePath, 'core'), { recursive: true });
-  symlinkSync(
-    join(workspaceRoot, 'node_modules/@ag-ui'),
-    join(nodeModulesPath, '@ag-ui'),
-    'dir',
-  );
-  symlinkSync(
-    join(workspaceRoot, 'node_modules/@cacheplane'),
-    join(nodeModulesPath, '@cacheplane'),
-    'dir',
-  );
-  symlinkSync(
-    join(workspaceRoot, 'node_modules/react'),
-    join(nodeModulesPath, 'react'),
-    'dir',
-  );
-  symlinkSync(
-    join(workspaceRoot, 'node_modules/react-dom'),
-    join(nodeModulesPath, 'react-dom'),
-    'dir',
-  );
-  return sandboxPath;
+  try {
+    const packPath = join(sandboxPath, 'packs');
+    mkdirSync(packPath);
+    writeFileSync(
+      join(sandboxPath, 'package.json'),
+      JSON.stringify({
+        name: 'hashbrown-react-package-e2e',
+        private: true,
+        type: 'module',
+      }),
+    );
+    const coreTarball = packPackage(coreDistPath, packPath);
+    const reactTarball = packPackage(reactDistPath, packPath);
+    runNpm(
+      [
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        '--no-package-lock',
+        coreTarball,
+        reactTarball,
+        'react@19.2.8',
+        'react-dom@19.2.8',
+      ],
+      sandboxPath,
+    );
+
+    return sandboxPath;
+  } catch (error) {
+    rmSync(sandboxPath, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 test('published React package metadata exposes ESM and CJS entrypoints', () => {
@@ -97,7 +157,7 @@ test('published React package metadata exposes ESM and CJS entrypoints', () => {
   expect(existsSync(join(reactDistPath, 'index.cjs'))).toBe(true);
 });
 
-test('published React package can be imported and required by package name', () => {
+test('packed React and core packages install and load in a clean consumer', () => {
   const sandboxPath = createPackageSandbox();
 
   try {
@@ -107,7 +167,17 @@ test('published React package can be imported and required by package name', () 
 
         const require = createRequire(import.meta.url);
         const cjs = require('@hashbrownai/react');
+        const cjsCore = require('@hashbrownai/core');
         const esm = await import('@hashbrownai/react');
+        const esmCore = await import('@hashbrownai/core');
+
+        if (typeof cjsCore.HttpTransport !== 'function') {
+          throw new Error('CJS core did not load the AG-UI transport dependency tree');
+        }
+
+        if (typeof esmCore.HttpTransport !== 'function') {
+          throw new Error('ESM core did not load the AG-UI transport dependency tree');
+        }
 
         if (typeof cjs.HashbrownProvider !== 'function') {
           throw new Error('CJS entrypoint did not expose HashbrownProvider');
@@ -125,4 +195,4 @@ test('published React package can be imported and required by package name', () 
   } finally {
     rmSync(sandboxPath, { recursive: true, force: true });
   }
-});
+}, 120_000);

--- a/tools/testing/aimock/agui-http-transport.spec.ts
+++ b/tools/testing/aimock/agui-http-transport.spec.ts
@@ -1,0 +1,451 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type {
+  AGUIEvent as AimockAGUIEvent,
+  AGUIMock,
+  AGUIRunAgentInput,
+} from '@copilotkit/aimock/agui';
+import {
+  Chat,
+  HttpTransport,
+  createHttpTransport,
+  fryHashbrown,
+  s,
+  type StateSignal,
+  type TransportRequest,
+  type TransportResponse,
+} from '@hashbrownai/core';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type AimockHandle, startAimock } from './aimock-runner';
+
+type HashbrownRunInput = NonNullable<TransportRequest['input']>;
+
+const defaultParams: Chat.Api.CompletionCreateParams = {
+  operation: 'generate',
+  model: '' as Chat.Api.CompletionCreateParams['model'],
+  system: '',
+  messages: [],
+};
+
+function createFixtureFile(workDir: string): string {
+  const fixturePath = join(workDir, 'providers.json');
+  writeFileSync(fixturePath, JSON.stringify({ fixtures: [] }));
+  return fixturePath;
+}
+
+function createRequest(
+  input: HashbrownRunInput,
+  requestId: string,
+): TransportRequest {
+  return {
+    input,
+    params: defaultParams,
+    signal: new AbortController().signal,
+    attempt: 1,
+    maxAttempts: 1,
+    requestId,
+  };
+}
+
+function requireEvents(response: TransportResponse): AsyncIterable<AGUIEvent> {
+  if (!response.events) {
+    throw new Error('Expected AG-UI events');
+  }
+  return response.events;
+}
+
+async function collectEvents(
+  events: AsyncIterable<AGUIEvent>,
+): Promise<AGUIEvent[]> {
+  const collected: AGUIEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+function parseRequestInput(body: BodyInit | null | undefined) {
+  if (typeof body !== 'string') {
+    throw new Error('Expected a JSON request body');
+  }
+
+  return JSON.parse(body) as HashbrownRunInput;
+}
+
+function waitForSignal<State>(
+  signal: StateSignal<State>,
+  predicate: (state: State) => boolean,
+  timeoutMs = 5_000,
+): Promise<State> {
+  const current = signal();
+  if (predicate(current)) {
+    return Promise.resolve(current);
+  }
+
+  return new Promise((resolve, reject) => {
+    let unsubscribe: (() => void) | undefined;
+    const timeout = setTimeout(() => {
+      unsubscribe?.();
+      reject(new Error(`Timed out waiting for state after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    unsubscribe = signal.subscribe((state) => {
+      if (!predicate(state)) {
+        return;
+      }
+
+      clearTimeout(timeout);
+      unsubscribe?.();
+      resolve(state);
+    });
+  });
+}
+
+function registerFixture(
+  aguiMock: AGUIMock,
+  predicate: (input: HashbrownRunInput) => boolean,
+  events: AGUIEvent[],
+): void {
+  aguiMock.onPredicate(
+    // Aimock 1.38 duplicates AG-UI's wire types and omits Hashbrown's extension.
+    (input: AGUIRunAgentInput) => predicate(input as HashbrownRunInput),
+    events as unknown as AimockAGUIEvent[],
+  );
+}
+
+test('createHttpTransport posts Hashbrown run input and collects text events over real SSE', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-agui-http-'));
+  const fixturePath = createFixtureFile(workDir);
+  const input: HashbrownRunInput = {
+    threadId: 'thread-text',
+    runId: 'run-text',
+    messages: [
+      {
+        id: 'message-system',
+        role: 'system',
+        content: 'Answer from the documentation.',
+      },
+      {
+        id: 'message-user',
+        role: 'user',
+        content: 'What is Hashbrown?',
+      },
+    ],
+    tools: [
+      {
+        name: 'searchDocs',
+        description: 'Search the Hashbrown documentation.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    context: [{ description: 'workspace', value: 'hashbrown' }],
+    state: { locale: 'en-US' },
+    forwardedProps: { traceId: 'trace-text' },
+    hashbrown: {
+      responseSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+      ui: true,
+    },
+  };
+  const expectedEvents: AGUIEvent[] = [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-text',
+      runId: 'run-text',
+      timestamp: 1_700_000_001_000,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'message-assistant-text',
+      role: 'assistant',
+      timestamp: 1_700_000_001_001,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-assistant-text',
+      delta: 'Hashbrown renders ',
+      timestamp: 1_700_000_001_002,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-assistant-text',
+      delta: 'generative UI.',
+      timestamp: 1_700_000_001_003,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'message-assistant-text',
+      timestamp: 1_700_000_001_004,
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-text',
+      runId: 'run-text',
+      timestamp: 1_700_000_001_005,
+    },
+  ];
+  const capturedInputs: HashbrownRunInput[] = [];
+  let handle: AimockHandle | null = null;
+  let response: TransportResponse | undefined;
+
+  try {
+    handle = await startAimock({ fixturePath });
+    registerFixture(
+      handle.aguiMock,
+      (requestInput) => {
+        if (requestInput.runId !== 'run-text') {
+          return false;
+        }
+        capturedInputs.push(requestInput);
+        return true;
+      },
+      expectedEvents,
+    );
+    const transport = createHttpTransport({ baseUrl: handle.aguiRunUrl });
+
+    response = await transport.send(createRequest(input, 'request-text'));
+    const events = await collectEvents(requireEvents(response));
+
+    expect(capturedInputs).toEqual([input]);
+    expect(events).toEqual(expectedEvents);
+  } finally {
+    await response?.dispose?.();
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('fryHashbrown executes and continues an AG-UI tool call over real SSE', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-agui-http-'));
+  const fixturePath = createFixtureFile(workDir);
+  const toolHandler = jest.fn(async ({ city }: { city: string }) => ({
+    city,
+    temperatureC: 21,
+    condition: 'sunny',
+  }));
+  const tool: Chat.Tool<
+    'getWeather',
+    { city: string },
+    { city: string; temperatureC: number; condition: string }
+  > = {
+    name: 'getWeather',
+    description: 'Get weather for a city.',
+    schema: s.object('weather lookup', {
+      city: s.string('city name'),
+    }),
+    handler: toolHandler,
+  };
+  const capturedInputs: HashbrownRunInput[] = [];
+  let handle: AimockHandle | null = null;
+  let teardown: (() => void) | undefined;
+
+  try {
+    handle = await startAimock({ fixturePath });
+    const fetchImpl: typeof fetch = async (input, init) => {
+      if (!handle) {
+        throw new Error('Aimock stopped before request');
+      }
+
+      const requestInput = parseRequestInput(init?.body);
+      capturedInputs.push(requestInput);
+      const events: AGUIEvent[] =
+        capturedInputs.length === 1
+          ? [
+              {
+                type: EventType.RUN_STARTED,
+                threadId: requestInput.threadId,
+                runId: requestInput.runId,
+                timestamp: 1_700_000_002_000,
+              },
+              {
+                type: EventType.TOOL_CALL_START,
+                toolCallId: 'call-weather',
+                toolCallName: 'getWeather',
+                parentMessageId: `${requestInput.threadId}:message:1`,
+                timestamp: 1_700_000_002_001,
+              },
+              {
+                type: EventType.TOOL_CALL_ARGS,
+                toolCallId: 'call-weather',
+                delta: '{"city":"Paris"}',
+                timestamp: 1_700_000_002_002,
+              },
+              {
+                type: EventType.TOOL_CALL_END,
+                toolCallId: 'call-weather',
+                timestamp: 1_700_000_002_003,
+              },
+              {
+                type: EventType.RUN_FINISHED,
+                threadId: requestInput.threadId,
+                runId: requestInput.runId,
+                timestamp: 1_700_000_002_004,
+              },
+            ]
+          : [
+              {
+                type: EventType.RUN_STARTED,
+                threadId: requestInput.threadId,
+                runId: requestInput.runId,
+                timestamp: 1_700_000_003_000,
+              },
+              {
+                type: EventType.TEXT_MESSAGE_START,
+                messageId: 'message-weather-final',
+                role: 'assistant',
+                timestamp: 1_700_000_003_001,
+              },
+              {
+                type: EventType.TEXT_MESSAGE_CONTENT,
+                messageId: 'message-weather-final',
+                delta: 'It is 21 C and sunny in Paris.',
+                timestamp: 1_700_000_003_002,
+              },
+              {
+                type: EventType.TEXT_MESSAGE_END,
+                messageId: 'message-weather-final',
+                timestamp: 1_700_000_003_003,
+              },
+              {
+                type: EventType.RUN_FINISHED,
+                threadId: requestInput.threadId,
+                runId: requestInput.runId,
+                timestamp: 1_700_000_003_004,
+              },
+            ];
+
+      registerFixture(
+        handle.aguiMock,
+        (candidate) =>
+          candidate.threadId === requestInput.threadId &&
+          candidate.runId === requestInput.runId,
+        events,
+      );
+
+      return fetch(input, init);
+    };
+    const transport = new HttpTransport({
+      baseUrl: handle.aguiRunUrl,
+      fetchImpl,
+    });
+    const hashbrown = fryHashbrown({
+      model: {
+        name: 'aimock-tool-model',
+        transport,
+        capabilities: { tools: true },
+      },
+      system: 'Answer weather questions with the available tool.',
+      tools: [tool],
+      threadId: 'thread-tool',
+    });
+    teardown = hashbrown.sizzle();
+    await Promise.resolve();
+
+    hashbrown.sendMessage({
+      role: 'user',
+      content: 'What is the weather in Paris?',
+    });
+    const messages = await waitForSignal(hashbrown.messages, (value) =>
+      value.some(
+        (message) =>
+          message.role === 'assistant' &&
+          message.content === 'It is 21 C and sunny in Paris.',
+      ),
+    );
+    await waitForSignal(hashbrown.isGenerating, (value) => !value);
+
+    expect(messages).toEqual([
+      { role: 'user', content: 'What is the weather in Paris?' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            role: 'tool',
+            status: 'done',
+            name: 'getWeather',
+            args: { city: 'Paris' },
+            result: {
+              status: 'fulfilled',
+              value: {
+                city: 'Paris',
+                temperatureC: 21,
+                condition: 'sunny',
+              },
+            },
+            toolCallId: 'call-weather',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: 'It is 21 C and sunny in Paris.',
+        toolCalls: [],
+      },
+    ]);
+    expect(hashbrown.error()).toBeUndefined();
+    expect(hashbrown.isLoading()).toBe(false);
+    expect(hashbrown.isReceiving()).toBe(false);
+    expect(hashbrown.isSending()).toBe(false);
+    expect(hashbrown.isGenerating()).toBe(false);
+    expect(hashbrown.isRunningToolCalls()).toBe(false);
+    expect(hashbrown.lastAssistantMessage()).toEqual(messages[2]);
+    expect(toolHandler).toHaveBeenCalledTimes(1);
+    expect(toolHandler).toHaveBeenCalledWith(
+      { city: 'Paris' },
+      expect.any(AbortSignal),
+    );
+    expect(capturedInputs).toHaveLength(2);
+    expect(capturedInputs[0]?.threadId).toBe('thread-tool');
+    expect(capturedInputs[1]?.threadId).toBe('thread-tool');
+    expect(capturedInputs[0]?.runId).not.toBe(capturedInputs[1]?.runId);
+    expect(capturedInputs[0]?.messages).toEqual([
+      {
+        id: 'thread-tool:system',
+        role: 'system',
+        content: 'Answer weather questions with the available tool.',
+      },
+      {
+        id: 'thread-tool:message:0',
+        role: 'user',
+        content: 'What is the weather in Paris?',
+      },
+    ]);
+    expect(capturedInputs[1]?.messages).toEqual([
+      ...capturedInputs[0]!.messages,
+      {
+        id: 'thread-tool:message:1',
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call-weather',
+            type: 'function',
+            function: {
+              name: 'getWeather',
+              arguments: '{"city":"Paris"}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'call-weather',
+        role: 'tool',
+        toolCallId: 'call-weather',
+        content: '{"city":"Paris","temperatureC":21,"condition":"sunny"}',
+      },
+    ]);
+  } finally {
+    teardown?.();
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}, 10_000);

--- a/tools/testing/aimock/aimock-runner.spec.ts
+++ b/tools/testing/aimock/aimock-runner.spec.ts
@@ -1,3 +1,4 @@
+import type { AGUIEvent } from '@copilotkit/aimock/agui';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -49,6 +50,54 @@ test('startAimock loads sorted JSON fixture files from a directory', async () =>
     handle = await startAimock({ fixturePath: workDir });
 
     expect(handle.port).toBeGreaterThan(0);
+  } finally {
+    await handle?.stop();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('startAimock serves fixture-backed AG-UI events from /run', async () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'hashbrown-aimock-'));
+  const fixturePath = createFixtureFile(workDir, 'text.json', 'say hi briefly');
+  let handle: AimockHandle | null = null;
+
+  try {
+    handle = await startAimock({ fixturePath });
+    const events = [
+      {
+        type: 'RUN_STARTED',
+        threadId: 'thread-runner',
+        runId: 'run-runner',
+        timestamp: 1_700_000_000_000,
+      },
+      {
+        type: 'RUN_FINISHED',
+        threadId: 'thread-runner',
+        runId: 'run-runner',
+        timestamp: 1_700_000_000_001,
+      },
+    ] satisfies AGUIEvent[];
+    handle.aguiMock.onPredicate(() => true, events);
+
+    const response = await fetch(handle.aguiRunUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        threadId: 'thread-runner',
+        runId: 'run-runner',
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+        forwardedProps: {},
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    await expect(response.text()).resolves.toBe(
+      events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''),
+    );
   } finally {
     await handle?.stop();
     rmSync(workDir, { recursive: true, force: true });

--- a/tools/testing/aimock/aimock-runner.ts
+++ b/tools/testing/aimock/aimock-runner.ts
@@ -1,4 +1,5 @@
 import { LLMock } from '@copilotkit/aimock';
+import { AGUIMock } from '@copilotkit/aimock/agui';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -10,6 +11,10 @@ export interface AimockHandle {
   readonly port: number;
   /** Raw aimock server URL without a provider-specific path suffix. */
   readonly url: string;
+  /** AG-UI run endpoint mounted on the shared aimock server. */
+  readonly aguiRunUrl: string;
+  /** AG-UI mock used to register deterministic run fixtures. */
+  readonly aguiMock: AGUIMock;
   /** OpenAI-compatible base URL including `/v1`. */
   readonly openAiBaseUrl: string;
   /** Anthropic-compatible base URL without `/v1`; the SDK appends it. */
@@ -68,6 +73,8 @@ export async function startAimock(
     port: 0,
     chunkSize: options.chunkSize ?? 4096,
   });
+  const aguiMock = new AGUIMock();
+  mock.mount('/run', aguiMock);
 
   if (entries.length > 0) {
     mock.addFixturesFromJSON(entries as never);
@@ -81,6 +88,8 @@ export async function startAimock(
   return {
     port: mock.port,
     url,
+    aguiRunUrl: `${url}/run`,
+    aguiMock,
     openAiBaseUrl: `${url}/v1`,
     anthropicBaseUrl: url,
     ollamaHost: url,

--- a/www/analog/vite.config.ts
+++ b/www/analog/vite.config.ts
@@ -24,6 +24,9 @@ export default defineConfig(({ command, mode }) => {
         },
       },
       ssr: {
+        resolve: {
+          noExternal: [/^@ag-ui\/client$/, /^rxjs(?:\/.*)?$/],
+        },
         build: {
           rollupOptions: {
             output: {


### PR DESCRIPTION
## Summary

- make the default HTTP transport POST AG-UI `RunAgentInput` to `/run` and consume validated AG-UI SSE events
- preserve Hashbrown's reducer, tool loop, structured parsing, retry semantics, and temporary legacy frame fallback
- add deterministic Aimock `/run` coverage, including a real tool call and automatic continuation request
- harden SSE parsing and teardown across CRLF, malformed/schema-invalid events, aborts, early disposal, reader failures, cancellation failures, delayed invalid responses, and single-chunk completion
- verify published Core, React, and Angular packages through clean packed npm consumer installs

## Behavior

The modern HTTP path now sends standard AG-UI messages and tools plus an optional top-level `hashbrown` extension for response schema and generative UI intent. It uses `@ag-ui/core` and `@ag-ui/client` directly without re-exporting their types or adopting the AG-UI agent runtime.

`TransportRequest.params`, frame streams, and legacy thread loading remain available for existing non-HTTP transports during the migration. The default HTTP transport is AG-UI-only and defaults to `POST /run`.

No documentation or design files are included in this PR.

## Verification

- `npx nx build core --skip-nx-cache`
- `npx nx test core --runInBand --skip-nx-cache` (338 tests)
- `npx nx lint core --skip-nx-cache`
- `npx nx build-api-report core --skip-nx-cache`
- `npx nx e2e core --skip-nx-cache`
- `npx nx test testing --runInBand --skip-nx-cache` (7 tests)
- `npx nx build react --skip-nx-cache`
- `npx nx test react --run --skip-nx-cache` (79 tests)
- `npx nx eslint:lint react --skip-nx-cache` (0 errors; 5 existing warnings)
- `npx nx build-api-report react --skip-nx-cache`
- `npx nx e2e react --skip-nx-cache`
- `npx nx build angular --skip-nx-cache`
- `npx nx test angular --runInBand --skip-nx-cache` (152 tests)
- `npx nx lint angular --skip-nx-cache`
- `npx nx build-api-report angular --skip-nx-cache`
- `npx nx e2e angular --skip-nx-cache`
- `npx nx build smart-home-angular --skip-nx-cache`
- Prettier, diff, dependency-deduplication, and architecture assertions

## Bundle impact

The representative smart-home Angular main bundle changes from 991,659 to 1,019,931 raw bytes and from 256,999 to 267,388 gzip bytes: +28,272 raw and +10,389 gzip. The build remains below the existing 1.1 MB error budget; the existing 500 kB warning remains.