### PR TITLE
fix: repair core inferred typecheck

### DIFF
--- a/packages/core/tsconfig.e2e.json
+++ b/packages/core/tsconfig.e2e.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "moduleResolution": "node10",

--- a/packages/core/tsconfig.spec.json
+++ b/packages/core/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "moduleResolution": "node10",


### PR DESCRIPTION
## Summary
- enable declaration output for core spec and e2e TypeScript configurations
- make the Nx-inferred declaration-only typecheck compatible with every core project reference
- restore the testing typecheck dependency chain from a clean build

## Verification
- `npx nx run testing:tsc:typecheck --skip-nx-cache`
- `npx nx run core:tsc:typecheck --skip-nx-cache --force`
- `npx nx build core --skip-nx-cache`
- `npx nx test core --skip-nx-cache`
- `npx nx lint core --skip-nx-cache`
- `npx nx build-api-report core --skip-nx-cache`
- `npx nx e2e core --skip-nx-cache`