### PR TITLE
feat(openai): adopt AG-UI event streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.58",
         "@ag-ui/core": "0.0.58",
+        "@ag-ui/encoder": "0.0.58",
         "@analogjs/content": "3.0.0-alpha.64",
         "@analogjs/router": "3.0.0-alpha.64",
         "@angular/animations": "22.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.58",
     "@ag-ui/core": "0.0.58",
+    "@ag-ui/encoder": "0.0.58",
     "@analogjs/content": "3.0.0-alpha.64",
     "@analogjs/router": "3.0.0-alpha.64",
     "@angular/animations": "22.1.1",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -12,8 +12,8 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.0",
-    "@hashbrownai/core": "0.5.0"
+    "@ag-ui/core": "0.0.58",
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "openai": "^6.9.0"

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,10 +1,22 @@
-import { text } from './stream/text.fn';
+import type { AGUIEvent } from '@ag-ui/core';
+import { type OpenAITextStreamOptions, text } from './stream/text.fn';
+
+export type {
+  OpenAIHashbrownRunAgentInput,
+  OpenAITextStreamOptions,
+} from './stream/text.fn';
 
 /**
  * Hashbrown adapter for OpenAI.
  * @public
  */
-export const HashbrownOpenAI = {
+export const HashbrownOpenAI: {
+  readonly stream: {
+    readonly text: (
+      options: OpenAITextStreamOptions,
+    ) => AsyncIterable<AGUIEvent>;
+  };
+} = {
   stream: {
     text,
   },

--- a/packages/openai/src/integration.spec.ts
+++ b/packages/openai/src/integration.spec.ts
@@ -1,7 +1,9 @@
 import { resolve } from 'node:path';
-import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
-import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import { startAimock } from '@hashbrownai/testing/aimock';
+import OpenAI from 'openai';
 import { HashbrownOpenAI } from './index';
+import type { OpenAIHashbrownRunAgentInput } from './stream/text.fn';
 
 const OPENAI_MODEL = 'gpt-4.1-mini';
 
@@ -9,214 +11,455 @@ function fixturePath(name: string): string {
   return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
 }
 
-function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
-  return frames.filter(
-    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
-  );
-}
-
-function streamedContent(frames: Frame[]): string {
-  return generationChunks(frames)
-    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
-    .join('');
-}
-
-function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
+function baseInput(userMessage: string): OpenAIHashbrownRunAgentInput {
   return {
-    operation: 'generate',
-    model: OPENAI_MODEL,
-    system: 'You are a deterministic test assistant.',
-    messages: [{ role: 'user', content: userMessage }],
+    threadId: 'thread-openai',
+    runId: 'run-openai',
+    messages: [
+      {
+        id: 'system-openai',
+        role: 'system',
+        content: 'You are a deterministic test assistant.',
+      },
+      {
+        id: 'user-openai',
+        role: 'user',
+        content: userMessage,
+      },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   };
 }
 
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
+async function collectEvents(
+  events: AsyncIterable<AGUIEvent>,
+): Promise<AGUIEvent[]> {
+  const collected: AGUIEvent[] = [];
+
+  for await (const event of events) {
+    collected.push(EventSchemas.parse(event));
+  }
+
+  return collected;
+}
+
+async function runFixture(
+  fixtureName: string,
+  input: OpenAIHashbrownRunAgentInput,
+): Promise<AGUIEvent[]> {
+  const aimock = await startAimock({ fixturePath: fixturePath(fixtureName) });
+
+  try {
+    return await collectEvents(
+      HashbrownOpenAI.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.openAiBaseUrl,
+        model: OPENAI_MODEL,
+        input,
+      }),
+    );
+  } finally {
+    await aimock.stop();
   }
 }
 
-test('OpenAI JSON response format mode requests JSON object output', async () => {
-  let capturedResponseFormat: unknown;
+function contentEvents(events: AGUIEvent[]) {
+  return events.filter(
+    (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+  );
+}
 
-  await consumeProviderStream(
-    HashbrownOpenAI.stream.text({
-      apiKey: 'test-api-key',
-      request: {
-        ...baseRequest('Hello'),
-        system: 'Respond with JSON.',
-        responseFormatMode: 'json',
-      },
-      transformRequestOptions: (options) => {
-        capturedResponseFormat = options.response_format;
-        throw new Error('stop');
-      },
-    }),
+function streamedContent(events: AGUIEvent[]): string {
+  return contentEvents(events)
+    .map((event) => event.delta)
+    .join('');
+}
+
+test('OpenAI consumes AG-UI input and emits a canonical text run', async () => {
+  const events = await runFixture('text.json', baseInput('say hi briefly'));
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-openai:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-openai:assistant',
+      delta: 'Hello from aimock.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-openai:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+  ]);
+});
+
+test('OpenAI preserves streamed text across multiple AG-UI events', async () => {
+  const events = await runFixture(
+    'streaming.json',
+    baseInput('stream deterministic text'),
   );
 
-  expect(capturedResponseFormat).toEqual({ type: 'json_object' });
-});
-
-test('OpenAI text streaming emits Hashbrown generation frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
-      HashbrownOpenAI.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.openAiBaseUrl,
-        request: baseRequest('say hi briefly'),
-      }),
-  });
-
-  expect(frames[0].type).toBe('generation-start');
-  expect(frames.at(-1)?.type).toBe('generation-finish');
-  expect(streamedContent(frames)).toBe('Hello from aimock.');
-});
-
-test('OpenAI streaming preserves chunked content across multiple frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('streaming.json'),
-    createStream: (aimock) =>
-      HashbrownOpenAI.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.openAiBaseUrl,
-        request: baseRequest('stream deterministic text'),
-      }),
-  });
-
-  expect(generationChunks(frames).length).toBeGreaterThan(1);
-  expect(streamedContent(frames)).toContain(
+  expect(contentEvents(events).length).toBeGreaterThan(1);
+  expect(streamedContent(events)).toContain(
     'Streaming fixture response with enough text',
   );
 });
 
-test('OpenAI tool calling emits tool call deltas', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('tool-call.json'),
-    createStream: (aimock) =>
-      HashbrownOpenAI.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.openAiBaseUrl,
-        request: {
-          ...baseRequest('call the lookup tool'),
-          tools: [
-            {
-              name: 'lookup',
-              description: 'Lookup deterministic fixture data.',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
-              },
-            },
-          ],
-          toolChoice: 'required',
+test('OpenAI emits complete AG-UI tool call lifecycles', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
         },
-      }),
-  });
+        required: ['query'],
+      },
+    },
+  ];
 
-  const toolCallDeltas = generationChunks(frames).flatMap(
-    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  const events = await runFixture('tool-call.json', input);
+  const toolEvents = events.filter((event) =>
+    [
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+    ].includes(event.type),
+  );
+  const start = toolEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
+  );
+  const args = toolEvents
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+  const end = toolEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_END,
   );
 
-  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
-  expect(
-    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
-  ).toBe(true);
-  expect(
-    toolCallDeltas
-      .map((toolCall) => toolCall.function?.arguments ?? '')
-      .join(''),
-  ).toContain('"query":"hashbrown"');
+  expect(start).toMatchObject({
+    type: EventType.TOOL_CALL_START,
+    toolCallName: 'lookup',
+    parentMessageId: 'run-openai:assistant',
+  });
+  expect(args).toContain('"query":"hashbrown"');
+  expect(end).toMatchObject({
+    type: EventType.TOOL_CALL_END,
+    toolCallId:
+      start?.type === EventType.TOOL_CALL_START
+        ? start.toolCallId
+        : 'missing-tool-call',
+  });
+  expect(events.at(-1)).toEqual({
+    type: EventType.RUN_FINISHED,
+    threadId: input.threadId,
+    runId: input.runId,
+  });
 });
 
-test('OpenAI structured output emits JSON text content', async () => {
-  const frames = await runProviderTextWithAimock({
+test('OpenAI maps the Hashbrown response schema to native structured output', async () => {
+  const input = baseInput('return structured output');
+  input.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        ok: { type: 'boolean' },
+      },
+      required: ['text', 'ok'],
+    },
+  };
+  let capturedResponseFormat: unknown;
+  const aimock = await startAimock({
     fixturePath: fixturePath('structured-output.json'),
-    createStream: (aimock) =>
+  });
+
+  let events: AGUIEvent[];
+  try {
+    events = await collectEvents(
       HashbrownOpenAI.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.openAiBaseUrl,
-        request: {
-          ...baseRequest('return structured output'),
-          responseFormat: {
-            type: 'object',
-            properties: {
-              text: { type: 'string' },
-              ok: { type: 'boolean' },
-            },
-            required: ['text', 'ok'],
-          },
+        model: OPENAI_MODEL,
+        input,
+        transformRequestOptions: (options) => {
+          capturedResponseFormat = options.response_format;
+          return options;
         },
       }),
-  });
+    );
+  } finally {
+    await aimock.stop();
+  }
 
-  expect(JSON.parse(streamedContent(frames))).toEqual({
+  expect(capturedResponseFormat).toEqual({
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: input.hashbrown.responseSchema,
+    },
+  });
+  expect(JSON.parse(streamedContent(events))).toEqual({
     text: 'Hello from structured aimock.',
     ok: true,
   });
 });
 
-test('OpenAI provider errors emit generation-error frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('error.json'),
-    createStream: (aimock) =>
-      HashbrownOpenAI.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.openAiBaseUrl,
-        request: baseRequest('return provider error'),
-      }),
-  });
+test('OpenAI maps complete AG-UI history without provider-specific wire keys', async () => {
+  const input = baseInput('new question');
+  input.messages = [
+    input.messages[0],
+    { id: 'user-previous', role: 'user', content: 'previous question' },
+    {
+      id: 'assistant-previous',
+      role: 'assistant',
+      toolCalls: [
+        {
+          id: 'call-previous',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"previous"}' },
+        },
+      ],
+    },
+    {
+      id: 'call-previous',
+      role: 'tool',
+      toolCallId: 'call-previous',
+      content: '{"answer":"previous result"}',
+    },
+    {
+      id: 'reasoning-previous',
+      role: 'reasoning',
+      content: 'display-only reasoning',
+    },
+    {
+      id: 'activity-previous',
+      role: 'activity',
+      activityType: 'progress',
+      content: { label: 'display-only activity' },
+    },
+    input.messages[1],
+  ];
+  let capturedMessages: OpenAI.ChatCompletionMessageParam[] | undefined;
 
-  expect(frames).toEqual([
-    { type: 'generation-start' },
+  await collectEvents(
+    HashbrownOpenAI.stream.text({
+      apiKey: 'test-not-used',
+      model: OPENAI_MODEL,
+      input,
+      transformRequestOptions: (options) => {
+        capturedMessages = options.messages;
+        throw new Error('stop after capture');
+      },
+    }),
+  );
+
+  expect(capturedMessages).toEqual([
+    {
+      role: 'system',
+      content: 'You are a deterministic test assistant.',
+    },
+    { role: 'user', content: 'previous question' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call-previous',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"query":"previous"}' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      tool_call_id: 'call-previous',
+      content: '{"answer":"previous result"}',
+    },
+    { role: 'user', content: 'new question' },
+  ]);
+});
+
+test('OpenAI provider errors terminate the AG-UI run with RUN_ERROR', async () => {
+  const events = await runFixture(
+    'error.json',
+    baseInput('return provider error'),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
     expect.objectContaining({
-      type: 'generation-error',
-      error: expect.stringContaining('Deterministic provider error'),
+      type: EventType.RUN_ERROR,
+      message: expect.stringContaining('Deterministic provider error'),
     }),
   ]);
 });
 
-test('OpenAI thread persistence wraps generation with thread frames', async () => {
-  const savedThreads: Chat.Api.Message[][] = [];
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
-      HashbrownOpenAI.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.openAiBaseUrl,
-        request: {
-          ...baseRequest('say hi briefly'),
-          threadId: 'openai-thread',
-        },
-        loadThread: async () => [
-          {
-            role: 'user',
-            content: 'previous message',
-          },
-        ],
-        saveThread: async (thread) => {
-          savedThreads.push(thread);
-          return 'openai-thread';
-        },
-      }),
+test('OpenAI cancellation stops iteration without emitting a terminal event', async () => {
+  const controller = new AbortController();
+  const input = baseInput('cancel before provider request');
+  const events = HashbrownOpenAI.stream.text({
+    apiKey: 'test-not-used',
+    model: OPENAI_MODEL,
+    input,
+    signal: controller.signal,
   });
+  const iterator = events[Symbol.asyncIterator]();
 
-  expect(frames.map((frame) => frame.type)).toEqual([
-    'thread-load-start',
-    'thread-load-success',
-    'generation-start',
-    ...generationChunks(frames).map((frame) => frame.type),
-    'generation-finish',
-    'thread-save-start',
-    'thread-save-success',
-  ]);
-  expect(savedThreads).toHaveLength(1);
-  expect(savedThreads[0].map((message) => message.content)).toContain(
-    'Hello from aimock.',
-  );
+  const started = await iterator.next();
+  controller.abort();
+  const done = await iterator.next();
+
+  expect(started).toEqual({
+    done: false,
+    value: {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
+  });
+  expect(done.done).toBe(true);
+});
+
+test('OpenAI cancellation aborts an active provider stream without a terminal event', async () => {
+  const aimock = await startAimock({
+    fixturePath: fixturePath('streaming.json'),
+  });
+  const controller = new AbortController();
+  const input = baseInput('stream deterministic text');
+  const events = HashbrownOpenAI.stream.text({
+    apiKey: 'test-not-used',
+    baseURL: aimock.openAiBaseUrl,
+    model: OPENAI_MODEL,
+    input,
+    signal: controller.signal,
+  });
+  const iterator = events[Symbol.asyncIterator]();
+
+  try {
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: EventType.RUN_STARTED },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: EventType.TEXT_MESSAGE_START },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: EventType.TEXT_MESSAGE_CONTENT },
+    });
+
+    controller.abort();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  } finally {
+    controller.abort();
+    await iterator.return?.();
+    await aimock.stop();
+  }
+});
+
+test('OpenAI cancellation between message events stops the remaining lifecycle', async () => {
+  const aimock = await startAimock({ fixturePath: fixturePath('text.json') });
+  const controller = new AbortController();
+  const input = baseInput('say hi briefly');
+  const events = HashbrownOpenAI.stream.text({
+    apiKey: 'test-not-used',
+    baseURL: aimock.openAiBaseUrl,
+    model: OPENAI_MODEL,
+    input,
+    signal: controller.signal,
+  });
+  const iterator = events[Symbol.asyncIterator]();
+
+  try {
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: EventType.RUN_STARTED },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: EventType.TEXT_MESSAGE_START },
+    });
+
+    controller.abort();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  } finally {
+    controller.abort();
+    await iterator.return?.();
+    await aimock.stop();
+  }
+});
+
+test('OpenAI cancellation after a message ends does not finish the run', async () => {
+  const aimock = await startAimock({ fixturePath: fixturePath('text.json') });
+  const controller = new AbortController();
+  const input = baseInput('say hi briefly');
+  const events = HashbrownOpenAI.stream.text({
+    apiKey: 'test-not-used',
+    baseURL: aimock.openAiBaseUrl,
+    model: OPENAI_MODEL,
+    input,
+    signal: controller.signal,
+  });
+  const iterator = events[Symbol.asyncIterator]();
+
+  try {
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: EventType.RUN_STARTED },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: EventType.TEXT_MESSAGE_START },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: EventType.TEXT_MESSAGE_CONTENT },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: EventType.TEXT_MESSAGE_END },
+    });
+
+    controller.abort();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  } finally {
+    controller.abort();
+    await iterator.return?.();
+    await aimock.stop();
+  }
 });

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -1,273 +1,111 @@
 import {
-  Chat,
-  encodeFrame,
-  Frame,
-  mergeMessagesForThread,
-  updateAssistantMessage,
-} from '@hashbrownai/core';
+  type AGUIEvent,
+  EventType,
+  type Message,
+  type RunAgentInput,
+} from '@ag-ui/core';
 import OpenAI from 'openai';
-import { FunctionParameters } from 'openai/resources/shared';
+import type { FunctionParameters } from 'openai/resources/shared';
 
-type BaseOpenAITextStreamOptions = {
+/**
+ * Hashbrown extensions accepted alongside a standard AG-UI run input.
+ *
+ * @public
+ */
+export interface OpenAIHashbrownRunAgentInput extends RunAgentInput {
+  hashbrown?: {
+    responseSchema?: object;
+    ui?: boolean;
+  };
+}
+
+/**
+ * Options for streaming an AG-UI run from OpenAI.
+ *
+ * @public
+ */
+export interface OpenAITextStreamOptions {
+  /** OpenAI API key. */
   apiKey: string;
+  /** Optional OpenAI-compatible API base URL. */
   baseURL?: string;
-  request: Chat.Api.CompletionCreateParams;
+  /** Model selected by the server for this endpoint. */
+  model: string;
+  /** Standard AG-UI run input plus optional Hashbrown semantics. */
+  input: OpenAIHashbrownRunAgentInput;
+  /** Cancels the provider request when the HTTP request is abandoned. */
+  signal?: AbortSignal;
+  /** Customize the OpenAI request after AG-UI input has been mapped. */
   transformRequestOptions?: (
     options: OpenAI.Chat.ChatCompletionCreateParamsStreaming,
   ) =>
     | OpenAI.Chat.ChatCompletionCreateParamsStreaming
     | Promise<OpenAI.Chat.ChatCompletionCreateParamsStreaming>;
-};
+}
 
-type ThreadPersistenceOptions = {
-  loadThread: (threadId: string) => Promise<Chat.Api.Message[]>;
-  saveThread: (
-    thread: Chat.Api.Message[],
-    threadId?: string,
-  ) => Promise<string>;
-};
+interface PendingToolCall {
+  readonly index: number;
+  readonly id?: string;
+  readonly name?: string;
+  readonly pendingArguments: string;
+  readonly started: boolean;
+}
 
-type ThreadlessOptions = BaseOpenAITextStreamOptions & {
-  loadThread?: undefined;
-  saveThread?: undefined;
-};
-
-type ThreadfulOptions = BaseOpenAITextStreamOptions & ThreadPersistenceOptions;
-
-export type OpenAITextStreamOptions = ThreadlessOptions | ThreadfulOptions;
-
-export function text(options: ThreadfulOptions): AsyncIterable<Uint8Array>;
-export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
-
-export async function* text(
-  options: OpenAITextStreamOptions,
-): AsyncIterable<Uint8Array> {
-  const {
-    apiKey,
-    baseURL,
-    request,
-    transformRequestOptions,
-    loadThread,
-    saveThread,
-  } = options;
-  const {
-    model,
-    tools,
-    responseFormat,
-    responseFormatMode,
-    toolChoice,
-    system,
-  } = request;
-  const threadId = request.threadId;
-  let loadedThread: Chat.Api.Message[] = [];
-  let effectiveThreadId = threadId;
-
-  const openai = new OpenAI({
-    apiKey,
-    baseURL: baseURL,
-  });
-
-  // Thread loading (both load-thread op and generate op with threadId)
-  const shouldLoadThread = Boolean(request.threadId);
-  const shouldHydrateThreadOnTheClient = Boolean(
-    request.operation === 'load-thread',
-  );
-
-  if (shouldLoadThread) {
-    yield encodeFrame({ type: 'thread-load-start' });
-
-    if (!loadThread) {
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: 'Thread loading is not available for this transport.',
-      });
-      return;
-    }
-
-    const loadFn = loadThread;
-    try {
-      loadedThread = await loadFn(request.threadId as string);
-      if (shouldHydrateThreadOnTheClient) {
-        yield encodeFrame({
-          type: 'thread-load-success',
-          thread: loadedThread,
-        });
-      } else {
-        yield encodeFrame({
-          type: 'thread-load-success',
-        });
-      }
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
-  }
-
-  if (request.operation === 'load-thread') {
-    return;
-  }
-
-  const mergedMessages =
-    request.threadId && shouldLoadThread
-      ? mergeMessagesForThread(loadedThread, request.messages ?? [])
-      : (request.messages ?? []);
-  let assistantMessage: Chat.Api.AssistantMessage | null = null;
-
-  try {
-    const baseOptions: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
-      stream: true,
-      model: model as string,
-      messages: [
-        {
-          role: 'system',
-          content: system,
-        },
-        ...mergedMessages.map((message): OpenAI.ChatCompletionMessageParam => {
-          if (message.role === 'user') {
-            return {
-              role: message.role,
-              content: message.content,
-            };
-          }
-          if (message.role === 'assistant') {
-            return {
-              role: message.role,
-              content:
-                message.content && typeof message.content !== 'string'
-                  ? JSON.stringify(message.content)
-                  : message.content,
-              tool_calls:
-                message.toolCalls && message.toolCalls.length > 0
-                  ? message.toolCalls.map((toolCall) => ({
-                      ...toolCall,
-                      type: 'function',
-                      function: {
-                        ...toolCall.function,
-                        arguments: JSON.stringify(toolCall.function.arguments),
-                      },
-                    }))
-                  : undefined,
-            };
-          }
-          if (message.role === 'tool') {
-            return {
-              role: message.role,
-              content: JSON.stringify(message.content),
-              tool_call_id: message.toolCallId,
-            };
-          }
-
-          throw new Error(`Invalid message role`);
-        }),
-      ],
-      tools:
-        tools && tools.length > 0
-          ? tools.map((tool) => ({
-              type: 'function',
-              function: {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters as FunctionParameters,
-                strict: true,
-              },
-            }))
-          : undefined,
-      tool_choice: toolChoice,
-      response_format: createResponseFormat(responseFormatMode, responseFormat),
-    };
-
-    const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =
-      transformRequestOptions
-        ? await transformRequestOptions(baseOptions)
-        : baseOptions;
-
-    const stream = openai.chat.completions.stream(resolvedOptions);
-
-    yield encodeFrame({ type: 'generation-start' });
-
-    for await (const chunk of stream) {
-      const chunkMessage: Chat.Api.CompletionChunk = {
-        choices: chunk.choices.map(
-          (
-            choice: OpenAI.Chat.Completions.ChatCompletionChunk.Choice,
-          ): Chat.Api.CompletionChunkChoice => ({
-            index: choice.index,
-            delta: {
-              content: choice.delta.content,
-              role: choice.delta.role,
-              toolCalls: choice.delta.tool_calls,
-            },
-            finishReason: choice.finish_reason,
-          }),
-        ),
+function mapMessage(
+  message: Message,
+): OpenAI.ChatCompletionMessageParam | undefined {
+  switch (message.role) {
+    case 'developer':
+    case 'system':
+      return {
+        role: message.role,
+        content: message.content,
       };
-
-      const frame: Frame = {
-        type: 'generation-chunk',
-        chunk: chunkMessage,
-      };
-
-      assistantMessage = updateAssistantMessage(assistantMessage, chunkMessage);
-
-      yield encodeFrame(frame);
-    }
-
-    yield encodeFrame({ type: 'generation-finish' });
-  } catch (error: unknown) {
-    const { message, stack } = normalizeError(error);
-    const frame: Frame = {
-      type: 'generation-error',
-      error: message,
-      stacktrace: stack,
-    };
-    yield encodeFrame(frame);
-
-    return;
-  }
-
-  if (saveThread) {
-    const threadToSave = mergeMessagesForThread(mergedMessages, [
-      ...(assistantMessage ? [assistantMessage] : []),
-    ]);
-    yield encodeFrame({ type: 'thread-save-start' });
-    try {
-      const savedThreadId = await saveThread(threadToSave, effectiveThreadId);
-      if (effectiveThreadId && savedThreadId !== effectiveThreadId) {
-        throw new Error(
-          'Save returned a different threadId than the existing thread',
-        );
+    case 'user':
+      if (typeof message.content !== 'string') {
+        throw new Error('OpenAI provider currently requires text user content');
       }
-      effectiveThreadId = savedThreadId;
-      yield encodeFrame({
-        type: 'thread-save-success',
-        threadId: savedThreadId,
-      });
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-save-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
+
+      return {
+        role: 'user',
+        content: message.content,
+      };
+    case 'assistant':
+      return {
+        role: 'assistant',
+        content: message.content ?? null,
+        tool_calls: message.toolCalls?.map((toolCall) => ({
+          id: toolCall.id,
+          type: 'function',
+          function: {
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments,
+          },
+        })),
+      };
+    case 'tool':
+      return {
+        role: 'tool',
+        content: message.content,
+        tool_call_id: message.toolCallId,
+      };
+    case 'activity':
+    case 'reasoning':
+      return undefined;
   }
 }
 
-function createResponseFormat(
-  responseFormatMode: Chat.Api.ResponseFormatMode | undefined,
-  responseFormat: object | undefined,
-): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
-  if (responseFormatMode === 'json') {
-    return { type: 'json_object' };
-  }
+function mapMessages(messages: Message[]): OpenAI.ChatCompletionMessageParam[] {
+  return messages.flatMap((message) => {
+    const mapped = mapMessage(message);
+    return mapped ? [mapped] : [];
+  });
+}
 
-  if (!responseFormat) {
+function createResponseFormat(
+  responseSchema: object | undefined,
+): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
+  if (!responseSchema) {
     return undefined;
   }
 
@@ -277,14 +115,223 @@ function createResponseFormat(
       strict: true,
       name: 'schema',
       description: '',
-      schema: responseFormat as Record<string, unknown>,
+      schema: responseSchema as Record<string, unknown>,
     },
   };
 }
 
-function normalizeError(error: unknown): { message: string; stack?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, stack: error.stack };
+function mergeToolCall(
+  current: PendingToolCall | undefined,
+  delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall,
+): PendingToolCall {
+  return {
+    index: delta.index,
+    id: delta.id ?? current?.id,
+    name: delta.function?.name ?? current?.name,
+    pendingArguments:
+      current?.started === true
+        ? (delta.function?.arguments ?? '')
+        : `${current?.pendingArguments ?? ''}${delta.function?.arguments ?? ''}`,
+    started: current?.started ?? false,
+  };
+}
+
+function startToolCall(
+  toolCall: PendingToolCall,
+): PendingToolCall & { id: string; name: string } {
+  if (!toolCall.id || !toolCall.name) {
+    throw new Error(
+      `OpenAI returned incomplete metadata for tool call at index ${toolCall.index}`,
+    );
   }
-  return { message: String(error) };
+
+  return {
+    ...toolCall,
+    id: toolCall.id,
+    name: toolCall.name,
+    pendingArguments: '',
+    started: true,
+  };
+}
+
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Streams canonical AG-UI events from an OpenAI chat completion.
+ *
+ * @public
+ */
+export async function* text(
+  options: OpenAITextStreamOptions,
+): AsyncIterable<AGUIEvent> {
+  const { apiKey, baseURL, model, input, signal, transformRequestOptions } =
+    options;
+  const { threadId, runId } = input;
+  const messageId = `${runId}:assistant`;
+  let textStarted = false;
+  let providerStream: ReturnType<
+    OpenAI['chat']['completions']['stream']
+  > | null = null;
+  const toolCalls = new Map<number, PendingToolCall>();
+
+  yield { type: EventType.RUN_STARTED, threadId, runId };
+  if (signal?.aborted) {
+    return;
+  }
+
+  try {
+    const baseOptions: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
+      stream: true,
+      model,
+      messages: mapMessages(input.messages),
+      tools:
+        input.tools.length > 0
+          ? input.tools.map((tool) => ({
+              type: 'function',
+              function: {
+                name: tool.name,
+                description: tool.description,
+                parameters: tool.parameters as FunctionParameters,
+                strict: true,
+              },
+            }))
+          : undefined,
+      response_format: createResponseFormat(input.hashbrown?.responseSchema),
+    };
+    const requestOptions = transformRequestOptions
+      ? await transformRequestOptions(baseOptions)
+      : baseOptions;
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    const openai = new OpenAI({ apiKey, baseURL });
+    providerStream = openai.chat.completions.stream(requestOptions, { signal });
+
+    for await (const chunk of providerStream) {
+      if (signal?.aborted) {
+        return;
+      }
+
+      for (const choice of chunk.choices) {
+        if (choice.index !== 0) {
+          continue;
+        }
+
+        const content = choice.delta.content;
+        if (content) {
+          if (!textStarted) {
+            textStarted = true;
+            yield {
+              type: EventType.TEXT_MESSAGE_START,
+              messageId,
+              role: 'assistant',
+            };
+            if (signal?.aborted) {
+              return;
+            }
+          }
+
+          yield {
+            type: EventType.TEXT_MESSAGE_CONTENT,
+            messageId,
+            delta: content,
+          };
+          if (signal?.aborted) {
+            return;
+          }
+        }
+
+        for (const delta of choice.delta.tool_calls ?? []) {
+          let toolCall = mergeToolCall(toolCalls.get(delta.index), delta);
+
+          if (!toolCall.started && toolCall.id && toolCall.name) {
+            const pendingArguments = toolCall.pendingArguments;
+            const startedToolCall = startToolCall(toolCall);
+            yield {
+              type: EventType.TOOL_CALL_START,
+              toolCallId: startedToolCall.id,
+              toolCallName: startedToolCall.name,
+              parentMessageId: messageId,
+            };
+            if (signal?.aborted) {
+              return;
+            }
+            if (pendingArguments) {
+              yield {
+                type: EventType.TOOL_CALL_ARGS,
+                toolCallId: startedToolCall.id,
+                delta: pendingArguments,
+              };
+              if (signal?.aborted) {
+                return;
+              }
+            }
+            toolCall = startedToolCall;
+          } else if (toolCall.started && toolCall.pendingArguments) {
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: toolCall.id as string,
+              delta: toolCall.pendingArguments,
+            };
+            if (signal?.aborted) {
+              return;
+            }
+            toolCall = { ...toolCall, pendingArguments: '' };
+          }
+
+          toolCalls.set(delta.index, toolCall);
+        }
+      }
+    }
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    if (textStarted) {
+      yield { type: EventType.TEXT_MESSAGE_END, messageId };
+      if (signal?.aborted) {
+        return;
+      }
+    }
+
+    for (const pendingToolCall of toolCalls.values()) {
+      const toolCall = pendingToolCall.started
+        ? pendingToolCall
+        : startToolCall(pendingToolCall);
+      if (toolCall.pendingArguments) {
+        yield {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: toolCall.id as string,
+          delta: toolCall.pendingArguments,
+        };
+        if (signal?.aborted) {
+          return;
+        }
+      }
+      yield {
+        type: EventType.TOOL_CALL_END,
+        toolCallId: toolCall.id as string,
+      };
+      if (signal?.aborted) {
+        return;
+      }
+    }
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    yield { type: EventType.RUN_FINISHED, threadId, runId };
+  } catch (error: unknown) {
+    if (!signal?.aborted) {
+      yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
+    }
+  } finally {
+    providerStream?.abort();
+  }
 }

--- a/samples/fast-food/angular/functions/api/chat.ts
+++ b/samples/fast-food/angular/functions/api/chat.ts
@@ -1,4 +1,5 @@
-import type { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 type Env = Record<string, string | undefined>;
@@ -31,28 +32,44 @@ const handlePost = async ({
     );
   }
 
-  const body = (await request.json()) as Chat.Api.CompletionCreateParams;
+  const input = (await request.json()) as RunAgentInput;
   const stream = HashbrownOpenAI.stream.text({
     apiKey,
-    request: body,
+    baseURL: getEnv(env, 'OPENAI_BASE_URL'),
+    model: getEnv(env, 'OPENAI_MODEL') ?? 'gpt-5-nano',
+    input,
+    signal: request.signal,
   });
+  const eventEncoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
+  const iterator = stream[Symbol.asyncIterator]();
 
   const readable = new ReadableStream<Uint8Array>({
-    async start(controller) {
+    async pull(controller) {
       try {
-        for await (const chunk of stream) {
-          controller.enqueue(
-            typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk,
-          );
+        const next = await iterator.next();
+        if (next.done) {
+          controller.close();
+          return;
         }
-      } finally {
-        controller.close();
+
+        controller.enqueue(
+          textEncoder.encode(eventEncoder.encodeSSE(next.value)),
+        );
+      } catch (error) {
+        controller.error(error);
       }
+    },
+    async cancel() {
+      await iterator.return?.();
     },
   });
 
   return new Response(readable, {
-    headers: { 'Content-Type': 'application/octet-stream' },
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Type': eventEncoder.getContentType(),
+    },
   });
 };
 

--- a/samples/fast-food/server/src/app.ts
+++ b/samples/fast-food/server/src/app.ts
@@ -1,4 +1,5 @@
-import { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import express from 'express';
 // import { INGREDIENTS } from './ingredients';
@@ -7,6 +8,8 @@ export function createApi() {
   const app = express();
 
   const OPENAI_API_KEY = process.env['OPENAI_API_KEY'];
+  const OPENAI_BASE_URL = process.env['OPENAI_BASE_URL'];
+  const OPENAI_MODEL = process.env['OPENAI_MODEL'] ?? 'gpt-5-nano';
 
   app.use(express.json());
 
@@ -16,19 +19,32 @@ export function createApi() {
         throw new Error('OPENAI_API_KEY is not set');
       }
 
-      const request = req.body as Chat.Api.CompletionCreateParams;
+      const abortController = new AbortController();
+      req.once('aborted', () => abortController.abort());
+      res.once('close', () => abortController.abort());
+
+      const input = req.body as RunAgentInput;
       const stream = HashbrownOpenAI.stream.text({
         apiKey: OPENAI_API_KEY,
-        request,
+        baseURL: OPENAI_BASE_URL,
+        model: OPENAI_MODEL,
+        input,
+        signal: abortController.signal,
       });
+      const encoder = new EventEncoder();
 
-      res.header('Content-Type', 'application/octet-stream');
+      res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.header('Content-Type', encoder.getContentType());
+      res.header('Connection', 'keep-alive');
+      res.flushHeaders();
 
-      for await (const chunk of stream) {
-        res.write(chunk);
+      for await (const event of stream) {
+        res.write(encoder.encodeSSE(event));
       }
 
-      res.end();
+      if (!res.writableEnded) {
+        res.end();
+      }
     } catch (error) {
       console.error('Chat API error:', error);
       res.status(500).json({

--- a/samples/finance/angular/functions/api/chat.ts
+++ b/samples/finance/angular/functions/api/chat.ts
@@ -1,4 +1,5 @@
-import type { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 type Env = Record<string, string | undefined>;
@@ -31,28 +32,44 @@ const handlePost = async ({
     );
   }
 
-  const body = (await request.json()) as Chat.Api.CompletionCreateParams;
+  const input = (await request.json()) as RunAgentInput;
   const stream = HashbrownOpenAI.stream.text({
     apiKey,
-    request: body,
+    baseURL: getEnv(env, 'OPENAI_BASE_URL'),
+    model: getEnv(env, 'OPENAI_MODEL') ?? 'gpt-5-nano',
+    input,
+    signal: request.signal,
   });
+  const eventEncoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
+  const iterator = stream[Symbol.asyncIterator]();
 
   const readable = new ReadableStream<Uint8Array>({
-    async start(controller) {
+    async pull(controller) {
       try {
-        for await (const chunk of stream) {
-          controller.enqueue(
-            typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk,
-          );
+        const next = await iterator.next();
+        if (next.done) {
+          controller.close();
+          return;
         }
-      } finally {
-        controller.close();
+
+        controller.enqueue(
+          textEncoder.encode(eventEncoder.encodeSSE(next.value)),
+        );
+      } catch (error) {
+        controller.error(error);
       }
+    },
+    async cancel() {
+      await iterator.return?.();
     },
   });
 
   return new Response(readable, {
-    headers: { 'Content-Type': 'application/octet-stream' },
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Type': eventEncoder.getContentType(),
+    },
   });
 };
 

--- a/samples/finance/server/src/app.ts
+++ b/samples/finance/server/src/app.ts
@@ -1,4 +1,5 @@
-import { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import express from 'express';
 // import { INGREDIENTS } from './ingredients';
@@ -7,6 +8,8 @@ export function createApi() {
   const app = express();
 
   const OPENAI_API_KEY = process.env['OPENAI_API_KEY'];
+  const OPENAI_BASE_URL = process.env['OPENAI_BASE_URL'];
+  const OPENAI_MODEL = process.env['OPENAI_MODEL'] ?? 'gpt-5-nano';
 
   app.use(express.json());
 
@@ -16,19 +19,32 @@ export function createApi() {
         throw new Error('OPENAI_API_KEY is not set');
       }
 
-      const request = req.body as Chat.Api.CompletionCreateParams;
+      const abortController = new AbortController();
+      req.once('aborted', () => abortController.abort());
+      res.once('close', () => abortController.abort());
+
+      const input = req.body as RunAgentInput;
       const stream = HashbrownOpenAI.stream.text({
         apiKey: OPENAI_API_KEY,
-        request,
+        baseURL: OPENAI_BASE_URL,
+        model: OPENAI_MODEL,
+        input,
+        signal: abortController.signal,
       });
+      const encoder = new EventEncoder();
 
-      res.header('Content-Type', 'application/octet-stream');
+      res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      res.header('Content-Type', encoder.getContentType());
+      res.header('Connection', 'keep-alive');
+      res.flushHeaders();
 
-      for await (const chunk of stream) {
-        res.write(chunk);
+      for await (const event of stream) {
+        res.write(encoder.encodeSSE(event));
       }
 
-      res.end();
+      if (!res.writableEnded) {
+        res.end();
+      }
     } catch (error) {
       console.error('Chat API error:', error);
       res.status(500).json({

--- a/samples/kitchen-sink/server/src/main.ts
+++ b/samples/kitchen-sink/server/src/main.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { Chat, KnownModelIds } from '@hashbrownai/core';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
@@ -13,6 +15,8 @@ const host = process.env.HOST ?? '0.0.0.0';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 const OPENAI_API_KEY = process.env['OPENAI_API_KEY'] ?? '';
+const OPENAI_BASE_URL = process.env['OPENAI_BASE_URL'];
+const OPENAI_MODEL = process.env['OPENAI_MODEL'] ?? 'gpt-5-nano';
 const AZURE_API_KEY = process.env['AZURE_API_KEY'] ?? '';
 const AZURE_ENDPOINT = process.env['AZURE_ENDPOINT'] ?? '';
 const GOOGLE_API_KEY = process.env['GOOGLE_API_KEY'] ?? '';
@@ -27,31 +31,6 @@ const KNOWN_GOOGLE_MODEL_NAMES: KnownModelIds[] = [
   'gemini-1.5-flash',
   'gemini-1.5-flash-8b',
   'gemini-1.5-pro',
-];
-
-const KNOWN_OPENAI_MODEL_NAMES: KnownModelIds[] = [
-  'gpt-3.5',
-  'gpt-4',
-  'gpt-4o',
-  'gpt-4o-mini',
-  'o1-mini',
-  'o1',
-  'o1-pro',
-  'o3-mini',
-  'o3-mini-high',
-  'o3',
-  'o3-pro',
-  'o4-mini',
-  'o4-mini-high',
-  'gpt-4.1',
-  'gpt-4.1-mini',
-  'gpt-4.1-nano',
-  'gpt-4.5',
-  'gpt-5-mini',
-  'gpt-5-nano',
-  'gpt-5-pro',
-  'gpt-5',
-  'gpt-5.1',
 ];
 
 const KNOWN_WRITER_MODEL_NAMES: KnownModelIds[] = [
@@ -90,7 +69,34 @@ app.listen(port, host, () => {
   console.log(`[ ready ] http://${host}:${port}`);
 });
 
-app.post('/chat', async (req, res, next) => {
+app.post('/chat', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
+  const stream = HashbrownOpenAI.stream.text({
+    apiKey: OPENAI_API_KEY,
+    baseURL: OPENAI_BASE_URL,
+    model: OPENAI_MODEL,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
+  });
+  const encoder = new EventEncoder();
+
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
+  }
+
+  if (!res.writableEnded) {
+    res.end();
+  }
+});
+
+app.post('/legacy/chat', async (req, res) => {
   const request = req.body as Chat.Api.CompletionCreateParams;
 
   const modelName = request.model;
@@ -99,11 +105,6 @@ app.post('/chat', async (req, res, next) => {
   if (KNOWN_GOOGLE_MODEL_NAMES.includes(modelName as KnownModelIds)) {
     stream = HashbrownGoogle.stream.text({
       apiKey: GOOGLE_API_KEY,
-      request,
-    });
-  } else if (KNOWN_OPENAI_MODEL_NAMES.includes(modelName as KnownModelIds)) {
-    stream = HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
       request,
     });
   } else if (KNOWN_WRITER_MODEL_NAMES.includes(modelName as KnownModelIds)) {

--- a/samples/lambda-chat/src/chat.ts
+++ b/samples/lambda-chat/src/chat.ts
@@ -1,7 +1,10 @@
-import { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL;
+const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-5-nano';
 
 if (!OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY is not set');
@@ -11,30 +14,40 @@ export const handler = awslambda.streamifyResponse(
   async (event, responseStream) => {
     console.log({ event: JSON.stringify(event) });
 
+    const encoder = new EventEncoder();
     responseStream = awslambda.HttpResponseStream.from(responseStream, {
       statusCode: 200,
       headers: {
         // Prevent intermediaries from buffering.  Given the small size of each chunk,
         // this should make streaming smoother at the network level.
         'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Content-Type': 'text/event-stream',
+        'Content-Type': encoder.getContentType(),
         Connection: 'keep-alive',
       },
     });
+    const abortController = new AbortController();
+    const abort = () => abortController.abort();
+    responseStream.once('close', abort);
 
-    const completionParams = JSON.parse(
-      event.body,
-    ) as Chat.Api.CompletionCreateParams;
+    try {
+      const input = JSON.parse(event.body) as RunAgentInput;
+      const response = HashbrownOpenAI.stream.text({
+        apiKey: OPENAI_API_KEY,
+        baseURL: OPENAI_BASE_URL,
+        model: OPENAI_MODEL,
+        input,
+        signal: abortController.signal,
+      });
 
-    const response = HashbrownOpenAI.stream.text({
-      apiKey: OPENAI_API_KEY,
-      request: completionParams,
-    });
+      for await (const event of response) {
+        responseStream.write(encoder.encodeSSE(event));
+      }
+    } finally {
+      responseStream.off('close', abort);
 
-    for await (const chunk of response) {
-      responseStream.write(chunk);
+      if (!responseStream.destroyed && !responseStream.writableEnded) {
+        responseStream.end();
+      }
     }
-
-    responseStream.end(); // Always end the stream
   },
 );

--- a/samples/smart-home/angular/functions/api/chat.ts
+++ b/samples/smart-home/angular/functions/api/chat.ts
@@ -1,4 +1,5 @@
-import type { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 type Env = Record<string, string | undefined>;
@@ -13,7 +14,6 @@ const getEnv = (env: Env | undefined, key: string): string | undefined => {
   const value =
     env?.[key] ??
     (globalThis as { process?: { env?: Env } }).process?.env?.[key];
-  console.log(value);
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 };
 
@@ -32,33 +32,48 @@ const handlePost = async ({
     );
   }
 
-  const body = (await request.json()) as Chat.Api.CompletionCreateParams;
+  const input = (await request.json()) as RunAgentInput;
   const stream = HashbrownOpenAI.stream.text({
     apiKey,
-    request: body,
+    baseURL: getEnv(env, 'OPENAI_BASE_URL'),
+    model: getEnv(env, 'OPENAI_MODEL') ?? 'gpt-5-nano',
+    input,
+    signal: request.signal,
     transformRequestOptions: (options) => ({
       ...options,
-      model: 'gpt-5-nano',
       reasoning_effort: 'low',
     }),
   });
+  const eventEncoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
+  const iterator = stream[Symbol.asyncIterator]();
 
   const readable = new ReadableStream<Uint8Array>({
-    async start(controller) {
+    async pull(controller) {
       try {
-        for await (const chunk of stream) {
-          controller.enqueue(
-            typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk,
-          );
+        const next = await iterator.next();
+        if (next.done) {
+          controller.close();
+          return;
         }
-      } finally {
-        controller.close();
+
+        controller.enqueue(
+          textEncoder.encode(eventEncoder.encodeSSE(next.value)),
+        );
+      } catch (error) {
+        controller.error(error);
       }
+    },
+    async cancel() {
+      await iterator.return?.();
     },
   });
 
   return new Response(readable, {
-    headers: { 'Content-Type': 'application/octet-stream' },
+    headers: {
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Type': eventEncoder.getContentType(),
+    },
   });
 };
 

--- a/samples/smart-home/server/src/main.ts
+++ b/samples/smart-home/server/src/main.ts
@@ -1,12 +1,15 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import express from 'express';
 import cors from 'cors';
-import { Chat } from '@hashbrownai/core';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL;
+const OPENAI_MODEL = process.env.OPENAI_MODEL ?? 'gpt-5-nano';
 if (!OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY is not set');
 }
@@ -17,20 +20,31 @@ app.use(cors());
 app.use(express.json());
 
 app.post('/api/chat', async (req, res) => {
-  const completionParams = req.body as Chat.Api.CompletionCreateParams;
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
 
   const response = HashbrownOpenAI.stream.text({
     apiKey: OPENAI_API_KEY,
-    request: completionParams,
+    baseURL: OPENAI_BASE_URL,
+    model: OPENAI_MODEL,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of response) {
-    res.write(chunk);
+  for await (const event of response) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(port, host, () => {

--- a/samples/spotify/server/src/main.ts
+++ b/samples/spotify/server/src/main.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { EventEncoder } from '@ag-ui/encoder';
 import express from 'express';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -283,18 +284,31 @@ app.get('/lyrics', async (req, res) => {
 });
 
 app.post('/chat', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
+
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body,
+    baseURL: process.env.OPENAI_BASE_URL,
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: req.body,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk);
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(port, host, () => {

--- a/tools/runtime-smoke/e2e/harness/openai-route.spec.ts
+++ b/tools/runtime-smoke/e2e/harness/openai-route.spec.ts
@@ -1,0 +1,191 @@
+/* eslint-disable @nx/enforce-module-boundaries -- Route smoke tests exercise application entry points directly. */
+import { type AGUIEvent, EventType, type RunAgentInput } from '@ag-ui/core';
+import { createHttpTransport, type TransportRequest } from '@hashbrownai/core';
+import { startAimock } from '@hashbrownai/testing/aimock';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { resolve } from 'node:path';
+import { onRequest as handleWorkerRequest } from '../../../../samples/fast-food/angular/functions/api/chat';
+import { createApi } from '../../../../samples/fast-food/server/src/app';
+
+jest.mock('express', () => ({
+  __esModule: true,
+  default: jest.requireActual('express'),
+}));
+
+function fixturePath(name: string): string {
+  return resolve(process.cwd(), 'tools/testing/aimock/fixtures', name);
+}
+
+function createInput(): RunAgentInput {
+  return {
+    threadId: 'express-thread',
+    runId: 'express-run',
+    messages: [
+      {
+        id: 'express-system',
+        role: 'system',
+        content: 'You are a deterministic test assistant.',
+      },
+      {
+        id: 'express-user',
+        role: 'user',
+        content: 'say hi briefly',
+      },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  };
+}
+
+async function collectEvents(
+  events: AsyncIterable<AGUIEvent>,
+): Promise<AGUIEvent[]> {
+  const collected: AGUIEvent[] = [];
+
+  for await (const event of events) {
+    collected.push(event);
+  }
+
+  return collected;
+}
+
+test('OpenAI Express route streams canonical AG-UI SSE to HttpTransport', async () => {
+  const previousApiKey = process.env['OPENAI_API_KEY'];
+  const previousBaseUrl = process.env['OPENAI_BASE_URL'];
+  const previousModel = process.env['OPENAI_MODEL'];
+  const aimock = await startAimock({ fixturePath: fixturePath('text.json') });
+  process.env['OPENAI_API_KEY'] = 'test-not-used';
+  process.env['OPENAI_BASE_URL'] = aimock.openAiBaseUrl;
+  process.env['OPENAI_MODEL'] = 'gpt-4.1-mini';
+  let server: Server | undefined;
+
+  try {
+    server = createApi().listen(0, '127.0.0.1');
+    await new Promise<void>((resolveListening, reject) => {
+      server?.once('listening', resolveListening);
+      server?.once('error', reject);
+    });
+    const address = server.address() as AddressInfo;
+    let observedContentType: string | null = null;
+    const transport = createHttpTransport({
+      baseUrl: `http://127.0.0.1:${address.port}/api/chat`,
+      fetchImpl: async (input, init) => {
+        const response = await fetch(input, init);
+        observedContentType = response.headers.get('content-type');
+        return response;
+      },
+    });
+    const request: TransportRequest = {
+      input: createInput(),
+      signal: new AbortController().signal,
+      attempt: 1,
+      maxAttempts: 1,
+      requestId: 'express-request',
+    };
+
+    const response = await transport.send(request);
+    const events = await collectEvents(response.events);
+    await response.dispose?.();
+
+    expect(observedContentType).toMatch(/^text\/event-stream(?:;|$)/);
+    expect(events).toEqual([
+      {
+        type: EventType.RUN_STARTED,
+        threadId: 'express-thread',
+        runId: 'express-run',
+      },
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: 'express-run:assistant',
+        role: 'assistant',
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: 'express-run:assistant',
+        delta: 'Hello from aimock.',
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: 'express-run:assistant',
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: 'express-thread',
+        runId: 'express-run',
+      },
+    ]);
+  } finally {
+    if (server) {
+      await new Promise<void>((resolveClosed, reject) => {
+        server?.close((error) => (error ? reject(error) : resolveClosed()));
+      });
+    }
+    await aimock.stop();
+    if (previousApiKey === undefined) {
+      delete process.env['OPENAI_API_KEY'];
+    } else {
+      process.env['OPENAI_API_KEY'] = previousApiKey;
+    }
+    if (previousBaseUrl === undefined) {
+      delete process.env['OPENAI_BASE_URL'];
+    } else {
+      process.env['OPENAI_BASE_URL'] = previousBaseUrl;
+    }
+    if (previousModel === undefined) {
+      delete process.env['OPENAI_MODEL'];
+    } else {
+      process.env['OPENAI_MODEL'] = previousModel;
+    }
+  }
+});
+
+test('OpenAI worker route streams canonical AG-UI SSE to HttpTransport', async () => {
+  const aimock = await startAimock({ fixturePath: fixturePath('text.json') });
+  let observedContentType: string | null = null;
+  const transport = createHttpTransport({
+    baseUrl: 'https://worker.example/api/chat',
+    fetchImpl: async (input, init) => {
+      const response = await handleWorkerRequest({
+        request: new Request(input, init),
+        env: {
+          OPENAI_API_KEY: 'test-not-used',
+          OPENAI_BASE_URL: aimock.openAiBaseUrl,
+          OPENAI_MODEL: 'gpt-4.1-mini',
+        },
+      });
+      observedContentType = response.headers.get('content-type');
+      return response;
+    },
+  });
+  const request: TransportRequest = {
+    input: createInput(),
+    signal: new AbortController().signal,
+    attempt: 1,
+    maxAttempts: 1,
+    requestId: 'worker-request',
+  };
+
+  try {
+    const response = await transport.send(request);
+    const events = await collectEvents(response.events);
+    await response.dispose?.();
+
+    expect(observedContentType).toMatch(/^text\/event-stream(?:;|$)/);
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(events.at(2)).toMatchObject({
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      delta: 'Hello from aimock.',
+    });
+  } finally {
+    await aimock.stop();
+  }
+});

--- a/www/analog/package.json
+++ b/www/analog/package.json
@@ -2,6 +2,8 @@
   "name": "@hashbrownai/www",
   "type": "module",
   "dependencies": {
+    "@ag-ui/core": "0.0.58",
+    "@ag-ui/encoder": "0.0.58",
     "@hashbrownai/core": "file:../../packages/core",
     "@hashbrownai/openai": "file:../../packages/openai",
     "@angular/common": "22.1.1",

--- a/www/analog/src/server/routes/_/chat.post.ts
+++ b/www/analog/src/server/routes/_/chat.post.ts
@@ -1,4 +1,7 @@
 import 'dotenv/config';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { HashbrownOpenAI } from '@hashbrownai/openai';
 import {
   defineEventHandler,
   type H3Event,
@@ -6,7 +9,6 @@ import {
   sendStream,
   setResponseHeader,
 } from 'h3';
-import { HashbrownOpenAI } from '@hashbrownai/openai';
 
 type Env = Record<string, string | undefined>;
 
@@ -18,26 +20,35 @@ type CloudflareContext = {
   };
 };
 
-const getApiKey = (event: H3Event): string | undefined => {
+const getEnv = (event: H3Event, key: string): string | undefined => {
   const context = event.context as CloudflareContext;
-  const value =
-    context._platform?.cloudflare?.env?.['OPENAI_API_KEY'] ??
-    process.env.OPENAI_API_KEY;
+  const value = context._platform?.cloudflare?.env?.[key] ?? process.env[key];
 
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 };
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event);
+  const input = await readBody<RunAgentInput>(event);
 
-  const apiKey = getApiKey(event);
+  const apiKey = getEnv(event, 'OPENAI_API_KEY');
   if (!apiKey) {
     throw new Error('OPENAI_API_KEY environment variable is required');
   }
 
+  const abortController = new AbortController();
+  const abort = () => abortController.abort();
+  if (event.req.signal.aborted) {
+    abort();
+  } else {
+    event.req.signal.addEventListener('abort', abort, { once: true });
+  }
+  const cleanup = () => event.req.signal.removeEventListener('abort', abort);
   const stream = HashbrownOpenAI.stream.text({
     apiKey,
-    request: body,
+    baseURL: getEnv(event, 'OPENAI_BASE_URL'),
+    model: getEnv(event, 'OPENAI_MODEL') ?? 'gpt-5-nano',
+    input,
+    signal: abortController.signal,
     transformRequestOptions: (options) => {
       return {
         ...options,
@@ -45,20 +56,39 @@ export default defineEventHandler(async (event) => {
       };
     },
   });
+  const eventEncoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
+  const iterator = stream[Symbol.asyncIterator]();
 
-  setResponseHeader(event, 'Content-Type', 'application/octet-stream');
-  setResponseHeader(event, 'Cache-Control', 'no-cache');
+  setResponseHeader(event, 'Content-Type', eventEncoder.getContentType());
+  setResponseHeader(
+    event,
+    'Cache-Control',
+    'no-cache, no-store, must-revalidate',
+  );
 
-  const readableStream = new ReadableStream({
-    async start(controller) {
+  const readableStream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
       try {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
+        const next = await iterator.next();
+        if (next.done) {
+          cleanup();
+          controller.close();
+          return;
         }
-        controller.close();
+
+        controller.enqueue(
+          textEncoder.encode(eventEncoder.encodeSSE(next.value)),
+        );
       } catch (error) {
+        cleanup();
         controller.error(error);
       }
+    },
+    async cancel() {
+      abort();
+      cleanup();
+      await iterator.return?.();
     },
   });
 


### PR DESCRIPTION
## Summary

- Replace the OpenAI frame-based streaming API with direct AG-UI run inputs and events.
- Map message history, tools, native structured output, errors, and cancellation to OpenAI chat completions.
- Convert retained OpenAI-backed routes to standards-compliant HTTP SSE using `@ag-ui/encoder`.
- Keep model selection and provider credentials under server control.
- Add deterministic aimock coverage and smoke tests through real Express and worker HTTP boundaries.

## Breaking Changes

- `HashbrownOpenAI.stream.text()` now consumes an AG-UI-compatible run input and returns `AsyncIterable<AGUIEvent>`.
- OpenAI routes now accept AG-UI requests and return `text/event-stream` instead of binary Hashbrown frames.
- The model is configured by the server and is no longer selected through run input.
- Structured output is configured through the optional top-level `hashbrown.responseSchema` extension.
- AG-UI `activity` and `reasoning` transcript records are ignored when constructing OpenAI history.
- This text API currently rejects multimodal user content.
- Existing frame-based clients and servers must be upgraded together.

## Testing

- OpenAI aimock E2E: 10 tests passed
- Runtime transport smoke: 24 tests passed
- Angular and React browser smoke: 22 tests passed
- Core regression suite: 478 tests passed
- All provider fixture suites passed
- OpenAI build, lint, API report, source typecheck, and test typecheck passed
- Lambda handler source typecheck and lint passed
- Angular and React runtime application typechecks passed
- Runtime harness typecheck passed
- Website build, lint, and tests passed
- Converted sample server and worker builds passed
- Formatting and dependency validation passed

## Scope

- Breaking-change documentation is intentionally deferred to a dedicated documentation slice.
- No release is included.
