### PR TITLE
feat: add native AG-UI reasoning and Anthropic streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "@angular/build": "22.1.3",
         "@angular/compiler-cli": "22.1.1",
         "@angular/ssr": "22.1.3",
-        "@anthropic-ai/sdk": "^0.24.3",
+        "@anthropic-ai/sdk": "0.122.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
         "@babel/core": "^7.29.7",
         "@babel/preset-react": "^7.29.7",
@@ -5384,38 +5384,26 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.24.3.tgz",
-      "integrity": "sha512-916wJXO6T6k8R6BAAcLhLPv/pnLGy7YSEBZXZ1XTFbLcTZE8oTy3oDW9WJf9KKZwMvVcePIfoTSvzXHRcGxkQQ==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+      "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "11.9.3",
@@ -19399,6 +19387,13 @@
       "integrity": "sha512-JUaebva3Ohwo5I5tuTqyW/FKGOMbb40YevJMySAOINRxP7qQ/AMjBzfJx0zeO6yS+wAPfQSoGNsZaUggHw8vsA==",
       "license": "Apache"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stackblitz/sdk": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@stackblitz/sdk/-/sdk-1.11.1.tgz",
@@ -21083,17 +21078,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/parse-json": {
@@ -23380,19 +23364,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -30073,6 +30044,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -30868,37 +30846,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -32235,16 +32182,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -35348,6 +35285,30 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-to-ts/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -48667,6 +48628,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -50774,6 +50746,13 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.58",
-        "@ag-ui/core": "0.0.58",
-        "@ag-ui/encoder": "0.0.58",
+        "@ag-ui/client": "0.0.59",
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/encoder": "0.0.59",
         "@analogjs/content": "3.0.0-alpha.64",
         "@analogjs/router": "3.0.0-alpha.64",
         "@angular/animations": "22.1.1",
@@ -219,14 +219,14 @@
       "license": "MIT"
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.58.tgz",
-      "integrity": "sha512-9tAUJ6Ot0y2f5Va7xGFhUSO5OPAjilMsPdmKNmAUR774LKWcvNpriJ6mqH3p/ewUue1zfoUo4vpX+9Xo/zsuzA==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.59.tgz",
+      "integrity": "sha512-d7++r8sBAq6z9G/D/WKrMznQ1Mdvew14pCqOVATReFIvl06mCi1BPqTwmos3zCDGAIiSgcvxc/8m472rYQgFFQ==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.58",
-        "@ag-ui/encoder": "0.0.58",
-        "@ag-ui/proto": "0.0.58",
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/encoder": "0.0.59",
+        "@ag-ui/proto": "0.0.59",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -246,31 +246,31 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.58.tgz",
-      "integrity": "sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.59.tgz",
+      "integrity": "sha512-hDgy4ipTqXieT8YG8Mr917Y+FD/f11VK1GefZ5CwTDCuNqS/oTwjJ5l/DZkicThgS8hQW/Y7wPylPBMBJ8BkUg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.58.tgz",
-      "integrity": "sha512-eMfjJbfAGTQECgNX3QO0Mt0V5OrIViowSPmGLzdO92q2x506K2hRs2VBlfEuAzpDFp6Eq23Q/vjNHFzv37StZw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.59.tgz",
+      "integrity": "sha512-wQCzBsStyZMm8nzhTdTx1G0B1C8yv5rbzZLnz1ka/l5LcJEsK3KTounU8CR9l+7QtcpOUUDJKd0xAbyI6gNcSw==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.58",
-        "@ag-ui/proto": "0.0.58"
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/proto": "0.0.59"
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.58.tgz",
-      "integrity": "sha512-fErOnFPfpZlNSreeOEdUVuCzTQI463JoUo1DNx4grAvSZPOg4tVgqvG2s82qJE9pZoh48VSUqk6hyV82GT/wIA==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.59.tgz",
+      "integrity": "sha512-X+uvDaegLEHw5kJu8tv2eSqHH8ouat+JCfFokGV1uuMquY8qCEQSlGsM7xzexwX9fujuxgHOWumg5kJDqa0+RA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.58",
+        "@ag-ui/core": "0.0.59",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     ]
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.58",
-    "@ag-ui/core": "0.0.58",
-    "@ag-ui/encoder": "0.0.58",
+    "@ag-ui/client": "0.0.59",
+    "@ag-ui/core": "0.0.59",
+    "@ag-ui/encoder": "0.0.59",
     "@analogjs/content": "3.0.0-alpha.64",
     "@analogjs/router": "3.0.0-alpha.64",
     "@angular/animations": "22.1.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@angular/build": "22.1.3",
     "@angular/compiler-cli": "22.1.1",
     "@angular/ssr": "22.1.3",
-    "@anthropic-ai/sdk": "^0.24.3",
+    "@anthropic-ai/sdk": "0.122.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
     "@babel/core": "^7.29.7",
     "@babel/preset-react": "^7.29.7",

--- a/packages/anthropic/jest.config.ts
+++ b/packages/anthropic/jest.config.ts
@@ -7,5 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/anthropic',
-  testPathIgnorePatterns: ['(?!.*integration).*\\.ts$'],
+  testPathIgnorePatterns: ['/integration\\.spec\\.ts$'],
 };

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -12,7 +12,7 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@ag-ui/core": "0.0.58",
+    "@ag-ui/core": "0.0.59",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -13,7 +13,6 @@
   "types": "./src/index.d.ts",
   "dependencies": {
     "@ag-ui/core": "0.0.58",
-    "@hashbrownai/core": "0.5.0",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -16,7 +16,7 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "^0.24.3"
+    "@anthropic-ai/sdk": "0.122.0"
   },
   "sideEffects": false,
   "publishConfig": {
@@ -30,6 +30,6 @@
     "typescript"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -12,8 +12,9 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.0",
-    "@hashbrownai/core": "0.5.0"
+    "@ag-ui/core": "0.0.58",
+    "@hashbrownai/core": "0.5.0",
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.24.3"

--- a/packages/anthropic/project.json
+++ b/packages/anthropic/project.json
@@ -40,7 +40,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "packages/anthropic/jest.config.ts",
-        "passWithNoTests": true
+        "passWithNoTests": false
       }
     },
     "e2e": {

--- a/packages/anthropic/src/index.ts
+++ b/packages/anthropic/src/index.ts
@@ -1,10 +1,23 @@
+import type { AGUIEvent } from '@ag-ui/core';
 import { text } from './stream/text.fn';
+import type { AnthropicTextStreamOptions } from './stream/types';
+
+export type {
+  AnthropicHashbrownRunAgentInput,
+  AnthropicTextStreamOptions,
+} from './stream/types';
 
 /**
  * Hashbrown adapter for Anthropic.
  * @public
  */
-export const HashbrownAnthropic = {
+export const HashbrownAnthropic: {
+  readonly stream: {
+    readonly text: (
+      options: AnthropicTextStreamOptions,
+    ) => AsyncIterable<AGUIEvent>;
+  };
+} = {
   stream: {
     text,
   },

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -1,7 +1,9 @@
 import { resolve } from 'node:path';
-import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
-import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { runProviderAGUIWithAimock } from '@hashbrownai/testing/aimock';
+import type Anthropic from '@anthropic-ai/sdk';
 import { HashbrownAnthropic } from './index';
+import type { AnthropicHashbrownRunAgentInput } from './stream/types';
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5-20251001';
 
@@ -9,179 +11,479 @@ function fixturePath(name: string): string {
   return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
 }
 
-function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
-  return frames.filter(
-    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
-  );
-}
-
-function streamedContent(frames: Frame[]): string {
-  return generationChunks(frames)
-    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
-    .join('');
-}
-
-function baseRequest(
-  userMessage: string,
-): Chat.Api.CompletionCreateParams {
+function baseInput(userMessage: string): AnthropicHashbrownRunAgentInput {
   return {
-    operation: 'generate',
-    model: ANTHROPIC_MODEL,
-    system: 'You are a deterministic test assistant.',
-    messages: [{ role: 'user', content: userMessage }],
+    threadId: 'thread-anthropic',
+    runId: 'run-anthropic',
+    messages: [
+      {
+        id: 'system-anthropic',
+        role: 'system',
+        content: 'You are a deterministic test assistant.',
+      },
+      {
+        id: 'user-anthropic',
+        role: 'user',
+        content: userMessage,
+      },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   };
 }
 
-test('Anthropic text streaming emits Hashbrown generation frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+async function runFixture(
+  fixtureName: string,
+  input: AnthropicHashbrownRunAgentInput,
+): Promise<AGUIEvent[]> {
+  return runProviderAGUIWithAimock({
+    fixturePath: fixturePath(fixtureName),
+    createStream: (aimock, signal) =>
       HashbrownAnthropic.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.anthropicBaseUrl,
-        request: baseRequest('say hi briefly'),
+        model: ANTHROPIC_MODEL,
+        input,
+        signal,
       }),
   });
+}
 
-  expect(frames[0].type).toBe('generation-start');
-  expect(frames.at(-1)?.type).toBe('generation-finish');
-  expect(streamedContent(frames)).toBe('Hello from aimock.');
-});
-
-test('Anthropic streaming preserves chunked content across multiple frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('streaming.json'),
-    createStream: (aimock) =>
-      HashbrownAnthropic.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.anthropicBaseUrl,
-        request: baseRequest('stream deterministic text'),
-      }),
-  });
-
-  expect(generationChunks(frames).length).toBeGreaterThan(1);
-  expect(streamedContent(frames)).toContain(
-    'Streaming fixture response with enough text',
+function contentEvents(events: AGUIEvent[]) {
+  return events.filter(
+    (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
   );
+}
+
+function streamedContent(events: AGUIEvent[]): string {
+  return contentEvents(events)
+    .map((event) => event.delta)
+    .join('');
+}
+
+function expectNoTerminalEvents(events: AGUIEvent[]): void {
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.RUN_ERROR }),
+      expect.objectContaining({ type: EventType.RUN_FINISHED }),
+    ]),
+  );
+}
+
+test('Anthropic consumes AG-UI input and emits a canonical text run', async () => {
+  const events = await runFixture('text.json', baseInput('say hi briefly'));
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-anthropic',
+      runId: 'run-anthropic',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-anthropic:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-anthropic:assistant',
+      delta: 'Hello from aimock.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-anthropic:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-anthropic',
+      runId: 'run-anthropic',
+    },
+  ]);
 });
 
-test('Anthropic tool calling emits tool call deltas', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('tool-call.json'),
-    createStream: (aimock) =>
+test('Anthropic preserves deterministic multi-chunk AG-UI text', async () => {
+  const events = await runFixture(
+    'streaming.json',
+    baseInput('stream deterministic text'),
+  );
+
+  expect(contentEvents(events).length).toBeGreaterThan(1);
+  expect(streamedContent(events)).toBe(
+    'Streaming fixture response with enough text to cross several deterministic chunk boundaries.',
+  );
+  expect(events.at(-1)).toEqual({
+    type: EventType.RUN_FINISHED,
+    threadId: 'thread-anthropic',
+    runId: 'run-anthropic',
+  });
+});
+
+test('Anthropic emits complete tool events with streamed arguments', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
+
+  const events = await runFixture('tool-call.json', input);
+  const toolEvents = events.filter((event) =>
+    [
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+    ].includes(event.type),
+  );
+  const start = toolEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
+  );
+  const args = toolEvents
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+  const end = toolEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_END,
+  );
+
+  expect(start).toEqual({
+    type: EventType.TOOL_CALL_START,
+    toolCallId: 'call_lookup_fixture',
+    toolCallName: 'lookup',
+    parentMessageId: 'run-anthropic:assistant',
+  });
+  expect(args).toBe('{"query":"hashbrown"}');
+  expect(end).toEqual({
+    type: EventType.TOOL_CALL_END,
+    toolCallId: 'call_lookup_fixture',
+  });
+  expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
+});
+
+test('Anthropic streams structured-output JSON without hidden emulation', async () => {
+  const input = baseInput('return structured output');
+  input.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        ok: { type: 'boolean' },
+      },
+      required: ['text', 'ok'],
+    },
+    ui: true,
+  };
+  let capturedOptions:
+    Anthropic.Messages.MessageCreateParamsStreaming | undefined;
+
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('structured-output.json'),
+    createStream: (aimock, signal) =>
       HashbrownAnthropic.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.anthropicBaseUrl,
-        request: {
-          ...baseRequest('call the lookup tool'),
-          tools: [
-            {
-              name: 'lookup',
-              description: 'Lookup deterministic fixture data.',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
-              },
-            },
-          ],
-          toolChoice: 'required',
+        model: ANTHROPIC_MODEL,
+        input,
+        signal,
+        transformRequestOptions: (options) => {
+          capturedOptions = options;
+          return options;
         },
       }),
   });
 
-  const toolCallDeltas = generationChunks(frames).flatMap(
-    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
-  );
-
-  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
-  expect(
-    toolCallDeltas.some(
-      (toolCall) => toolCall.function?.name === 'lookup',
-    ),
-  ).toBe(true);
-  expect(
-    toolCallDeltas
-      .map((toolCall) => toolCall.function?.arguments ?? '')
-      .join(''),
-  ).toContain('"query":"hashbrown"');
-});
-
-test('Anthropic structured output fixture emits JSON text content', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('structured-output.json'),
-    createStream: (aimock) =>
-      HashbrownAnthropic.stream.text({
-        apiKey: 'test-not-used',
-        baseURL: aimock.anthropicBaseUrl,
-        request: baseRequest('return structured output'),
-      }),
+  expect(capturedOptions).toEqual({
+    stream: true,
+    model: ANTHROPIC_MODEL,
+    max_tokens: 4096,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: 'return structured output' }],
   });
-
-  expect(JSON.parse(streamedContent(frames))).toEqual({
+  expect(capturedOptions).not.toHaveProperty('response_format');
+  expect(capturedOptions?.tools).toBeUndefined();
+  expect(JSON.parse(streamedContent(events))).toEqual({
     text: 'Hello from structured aimock.',
     ok: true,
   });
 });
 
-test('Anthropic provider errors emit generation-error frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('error.json'),
-    createStream: (aimock) =>
+test('Anthropic maps complete AG-UI request history for aimock', async () => {
+  const input = baseInput('say hi briefly');
+  input.messages = [
+    {
+      id: 'system-history',
+      role: 'system',
+      content: 'System instruction.',
+    },
+    {
+      id: 'developer-history',
+      role: 'developer',
+      content: 'Developer instruction.',
+    },
+    { id: 'user-history', role: 'user', content: 'Previous question.' },
+    {
+      id: 'assistant-history',
+      role: 'assistant',
+      content: 'I will look it up.',
+      toolCalls: [
+        {
+          id: 'call-history',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: '{"query":"previous"}',
+          },
+        },
+      ],
+    },
+    {
+      id: 'tool-history',
+      role: 'tool',
+      toolCallId: 'call-history',
+      content: '{"answer":"previous result"}',
+    },
+    {
+      id: 'reasoning-history',
+      role: 'reasoning',
+      content: 'Display-only reasoning.',
+    },
+    {
+      id: 'activity-history',
+      role: 'activity',
+      activityType: 'progress',
+      content: { label: 'Display-only activity.' },
+    },
+    { id: 'user-anthropic', role: 'user', content: 'say hi briefly' },
+  ];
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
+  input.forwardedProps = { model: 'client-selected-model' };
+  input.hashbrown = {
+    responseSchema: { type: 'object' },
+    ui: true,
+  };
+  let capturedOptions:
+    Anthropic.Messages.MessageCreateParamsStreaming | undefined;
+
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('text.json'),
+    createStream: (aimock, signal) =>
       HashbrownAnthropic.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.anthropicBaseUrl,
-        request: baseRequest('return provider error'),
+        model: ANTHROPIC_MODEL,
+        input,
+        signal,
+        transformRequestOptions: async (options) => {
+          await Promise.resolve();
+          capturedOptions = options;
+          return options;
+        },
       }),
   });
 
-  expect(frames).toEqual([
-    { type: 'generation-start' },
+  expect(capturedOptions).toEqual({
+    stream: true,
+    model: ANTHROPIC_MODEL,
+    max_tokens: 4096,
+    system: 'System instruction.\n\nDeveloper instruction.',
+    messages: [
+      { role: 'user', content: 'Previous question.' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will look it up.' },
+          {
+            type: 'tool_use',
+            id: 'call-history',
+            name: 'lookup',
+            input: { query: 'previous' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call-history',
+            content: '{"answer":"previous result"}',
+          },
+        ],
+      },
+      { role: 'user', content: 'say hi briefly' },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup deterministic fixture data.',
+        input_schema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+  });
+  expect(capturedOptions).not.toHaveProperty('response_format');
+  expect(capturedOptions?.tools?.some((tool) => tool.name === 'output')).toBe(
+    false,
+  );
+  expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
+});
+
+test('Anthropic provider errors terminate with RUN_ERROR', async () => {
+  const input = baseInput('return provider error');
+
+  const events = await runFixture('error.json', input);
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
     expect.objectContaining({
-      type: 'generation-error',
-      error: expect.stringContaining('Deterministic provider error'),
+      type: EventType.RUN_ERROR,
+      message: expect.stringContaining('Deterministic provider error'),
     }),
   ]);
 });
 
-test('Anthropic thread persistence wraps generation with thread frames', async () => {
-  const savedThreads: Chat.Api.Message[][] = [];
-  const frames = await runProviderTextWithAimock({
+test('Anthropic abort after RUN_STARTED stops at RUN_STARTED', async () => {
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+    chunkSize: 1,
+    createStream: (aimock, signal) =>
       HashbrownAnthropic.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.anthropicBaseUrl,
-        request: {
-          ...baseRequest('say hi briefly'),
-          threadId: 'anthropic-thread',
-        },
-        loadThread: async () => [
-          {
-            role: 'user',
-            content: 'previous message',
-          },
-        ],
-        saveThread: async (thread) => {
-          savedThreads.push(thread);
-          return 'anthropic-thread';
-        },
+        model: ANTHROPIC_MODEL,
+        input: baseInput('say hi briefly'),
+        signal,
       }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.RUN_STARTED) {
+        controls.abort();
+      }
+    },
   });
 
-  expect(frames.map((frame) => frame.type)).toEqual([
-    'thread-load-start',
-    'thread-load-success',
-    'generation-start',
-    ...generationChunks(frames).map((frame) => frame.type),
-    'generation-finish',
-    'thread-save-start',
-    'thread-save-success',
+  expect(events.map((event) => event.type)).toEqual([EventType.RUN_STARTED]);
+  expectNoTerminalEvents(events);
+});
+
+test('Anthropic abort during first text content stops at that content', async () => {
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    chunkSize: 4,
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input: baseInput('stream deterministic text'),
+        signal,
+      }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+        controls.abort();
+      }
+    },
+  });
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
   ]);
-  expect(savedThreads).toHaveLength(1);
-  expect(savedThreads[0].map((message) => message.content)).toContain(
-    'Hello from aimock.',
+  expectNoTerminalEvents(events);
+});
+
+test('Anthropic abort between tool events suppresses args and end', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: { type: 'object', properties: {} },
+    },
+  ];
+
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('tool-call.json'),
+    chunkSize: 2,
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input,
+        signal,
+      }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.TOOL_CALL_START) {
+        controls.abort();
+      }
+    },
+  });
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TOOL_CALL_START,
+  ]);
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.TOOL_CALL_ARGS }),
+      expect.objectContaining({ type: EventType.TOOL_CALL_END }),
+    ]),
   );
+  expectNoTerminalEvents(events);
+});
+
+test('Anthropic abort after TEXT_MESSAGE_END suppresses RUN_FINISHED', async () => {
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('text.json'),
+    chunkSize: 1,
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input: baseInput('say hi briefly'),
+        signal,
+      }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.TEXT_MESSAGE_END) {
+        controls.abort();
+      }
+    },
+  });
+
+  expect(events[0]?.type).toBe(EventType.RUN_STARTED);
+  expect(events[1]?.type).toBe(EventType.TEXT_MESSAGE_START);
+  expect(
+    events
+      .slice(2, -1)
+      .every((event) => event.type === EventType.TEXT_MESSAGE_CONTENT),
+  ).toBe(true);
+  expect(streamedContent(events)).toBe('Hello from aimock.');
+  expect(events.at(-1)?.type).toBe(EventType.TEXT_MESSAGE_END);
+  expectNoTerminalEvents(events);
 });

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -205,6 +205,19 @@ test('Anthropic streams structured-output JSON without hidden emulation', async 
     max_tokens: 4096,
     system: 'You are a deterministic test assistant.',
     messages: [{ role: 'user', content: 'return structured output' }],
+    output_config: {
+      format: {
+        type: 'json_schema',
+        schema: {
+          type: 'object',
+          properties: {
+            text: { type: 'string' },
+            ok: { type: 'boolean' },
+          },
+          required: ['text', 'ok'],
+        },
+      },
+    },
   });
   expect(capturedOptions).not.toHaveProperty('response_format');
   expect(capturedOptions?.tools).toBeUndefined();
@@ -303,6 +316,9 @@ test('Anthropic maps complete AG-UI request history for aimock', async () => {
     model: ANTHROPIC_MODEL,
     max_tokens: 4096,
     system: 'System instruction.\n\nDeveloper instruction.',
+    output_config: {
+      format: { type: 'json_schema', schema: { type: 'object' } },
+    },
     messages: [
       { role: 'user', content: 'Previous question.' },
       {

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -351,7 +351,7 @@ test('Anthropic maps complete AG-UI request history for aimock', async () => {
 test('Anthropic provider errors terminate with RUN_ERROR', async () => {
   const input = baseInput('return provider error');
 
-  const events = await runFixture('error.json', input);
+  const events = await runFixture('anthropic-error.json', input);
 
   expect(events).toEqual([
     {

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -342,9 +342,11 @@ test('Anthropic maps complete AG-UI request history for aimock', async () => {
     ],
   });
   expect(capturedOptions).not.toHaveProperty('response_format');
-  expect(capturedOptions?.tools?.some((tool) => tool.name === 'output')).toBe(
-    false,
-  );
+  expect(
+    capturedOptions?.tools?.some(
+      (tool) => 'name' in tool && tool.name === 'output',
+    ),
+  ).toBe(false);
   expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
 });
 

--- a/packages/anthropic/src/integration.spec.ts
+++ b/packages/anthropic/src/integration.spec.ts
@@ -72,6 +72,13 @@ function expectNoTerminalEvents(events: AGUIEvent[]): void {
   );
 }
 
+function reasoningContent(events: AGUIEvent[]): string {
+  return events
+    .filter((event) => event.type === EventType.REASONING_MESSAGE_CONTENT)
+    .map((event) => event.delta)
+    .join('');
+}
+
 test('Anthropic consumes AG-UI input and emits a canonical text run', async () => {
   const events = await runFixture('text.json', baseInput('say hi briefly'));
 
@@ -118,6 +125,259 @@ test('Anthropic preserves deterministic multi-chunk AG-UI text', async () => {
     threadId: 'thread-anthropic',
     runId: 'run-anthropic',
   });
+});
+
+test('Anthropic emits balanced reasoning before assistant text', async () => {
+  const input = baseInput('reason before answering');
+
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('anthropic/reasoning.json'),
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input,
+        signal,
+        transformRequestOptions: (options) => ({
+          ...options,
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+        }),
+      }),
+  });
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: 'run-anthropic:assistant:reasoning:0',
+      role: 'reasoning',
+      metadata: { anthropic: { blockType: 'thinking' } },
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: 'run-anthropic:assistant:reasoning:0',
+      delta: 'I will answer deterministically.',
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: 'run-anthropic:assistant:reasoning:0',
+      encryptedValue: 'signature_reasoning_fixture',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: 'run-anthropic:assistant:reasoning:0',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-anthropic:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-anthropic:assistant',
+      delta: 'Reasoned answer from aimock.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-anthropic:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
+  ]);
+});
+
+test('Anthropic replays signed reasoning before a tool on continuation', async () => {
+  const fixture = fixturePath('anthropic/reasoning-tool-call.json');
+  const firstInput = baseInput('reason before calling lookup');
+  firstInput.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
+  let firstRequest: Anthropic.Messages.MessageCreateParamsStreaming | undefined;
+
+  const firstEvents = await runProviderAGUIWithAimock({
+    fixturePath: fixture,
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input: firstInput,
+        signal,
+        transformRequestOptions: (options) => {
+          firstRequest = {
+            ...options,
+            thinking: { type: 'enabled', budget_tokens: 1024 },
+          };
+          return firstRequest;
+        },
+      }),
+  });
+  const reasoningStart = firstEvents.find(
+    (event) => event.type === EventType.REASONING_MESSAGE_START,
+  );
+  const reasoningEncryptedValue = firstEvents.find(
+    (event) => event.type === EventType.REASONING_ENCRYPTED_VALUE,
+  );
+  const toolStart = firstEvents.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
+  );
+  const toolArguments = firstEvents
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+
+  expect(firstRequest).toEqual({
+    stream: true,
+    model: ANTHROPIC_MODEL,
+    max_tokens: 4096,
+    system: 'You are a deterministic test assistant.',
+    messages: [{ role: 'user', content: 'reason before calling lookup' }],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup deterministic fixture data.',
+        input_schema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    thinking: { type: 'enabled', budget_tokens: 1024 },
+  });
+  expect(firstEvents.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.REASONING_MESSAGE_START,
+    EventType.REASONING_MESSAGE_CONTENT,
+    EventType.REASONING_ENCRYPTED_VALUE,
+    EventType.REASONING_MESSAGE_END,
+    EventType.TOOL_CALL_START,
+    EventType.TOOL_CALL_ARGS,
+    EventType.TOOL_CALL_END,
+    EventType.RUN_FINISHED,
+  ]);
+  expect(reasoningStart).toBeDefined();
+  expect(reasoningEncryptedValue).toBeDefined();
+  expect(toolStart).toBeDefined();
+  if (
+    reasoningStart?.type !== EventType.REASONING_MESSAGE_START ||
+    reasoningEncryptedValue?.type !== EventType.REASONING_ENCRYPTED_VALUE ||
+    toolStart?.type !== EventType.TOOL_CALL_START
+  ) {
+    throw new Error('Expected reasoning and tool events from the first run.');
+  }
+
+  const secondInput: AnthropicHashbrownRunAgentInput = {
+    ...firstInput,
+    runId: 'run-anthropic-continuation',
+    messages: [
+      ...firstInput.messages,
+      {
+        id: reasoningStart.messageId,
+        role: 'reasoning',
+        content: reasoningContent(firstEvents),
+        encryptedValue: reasoningEncryptedValue.encryptedValue,
+        metadata: reasoningStart.metadata,
+      },
+      {
+        id: 'run-anthropic:assistant',
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: toolStart.toolCallId,
+            type: 'function',
+            function: {
+              name: toolStart.toolCallName,
+              arguments: toolArguments,
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-result-reasoning-fixture',
+        role: 'tool',
+        toolCallId: toolStart.toolCallId,
+        content: '{"answer":"fixture continuation result"}',
+      },
+    ],
+  };
+  let secondRequest:
+    Anthropic.Messages.MessageCreateParamsStreaming | undefined;
+
+  const secondEvents = await runProviderAGUIWithAimock({
+    fixturePath: fixture,
+    createStream: (aimock, signal) =>
+      HashbrownAnthropic.stream.text({
+        apiKey: 'test-not-used',
+        baseURL: aimock.anthropicBaseUrl,
+        model: ANTHROPIC_MODEL,
+        input: secondInput,
+        signal,
+        transformRequestOptions: (options) => {
+          secondRequest = {
+            ...options,
+            thinking: { type: 'enabled', budget_tokens: 1024 },
+          };
+          return secondRequest;
+        },
+      }),
+  });
+
+  expect(secondRequest?.messages).toEqual([
+    { role: 'user', content: 'reason before calling lookup' },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'thinking',
+          thinking: 'I need the lookup result.',
+          signature: 'signature_tool_fixture',
+        },
+        {
+          type: 'tool_use',
+          id: 'call_reasoning_lookup_fixture',
+          name: 'lookup',
+          input: { query: 'hashbrown' },
+        },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'call_reasoning_lookup_fixture',
+          content: '{"answer":"fixture continuation result"}',
+        },
+      ],
+    },
+  ]);
+  expect(secondEvents.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+    EventType.TEXT_MESSAGE_END,
+    EventType.RUN_FINISHED,
+  ]);
+  expect(streamedContent(secondEvents)).toBe('Continued answer from aimock.');
 });
 
 test('Anthropic emits complete tool events with streamed arguments', async () => {

--- a/packages/anthropic/src/stream/anthropic-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-events.spec.ts
@@ -1,0 +1,786 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+import { mapAnthropicEvents } from './anthropic-events';
+
+type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+
+function messageStart(): RawEvent {
+  return {
+    type: 'message_start',
+    message: {
+      id: 'anthropic-message-1',
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model: 'claude-test',
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 0 },
+    },
+  };
+}
+
+function messageDelta(): RawEvent {
+  return {
+    type: 'message_delta',
+    delta: { stop_reason: 'end_turn', stop_sequence: null },
+    usage: { output_tokens: 1 },
+  };
+}
+
+function messageStop(): RawEvent {
+  return { type: 'message_stop' };
+}
+
+function textStart(index: number, text = ''): RawEvent {
+  return {
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'text', text },
+  };
+}
+
+function toolStart(
+  index: number,
+  id: string,
+  name: string,
+  input: unknown,
+): RawEvent {
+  return {
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'tool_use', id, name, input },
+  };
+}
+
+function textDelta(index: number, text: string): RawEvent {
+  return {
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'text_delta', text },
+  };
+}
+
+function inputJsonDelta(index: number, partialJson: string): RawEvent {
+  return {
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'input_json_delta', partial_json: partialJson },
+  };
+}
+
+function contentStop(index: number): RawEvent {
+  return { type: 'content_block_stop', index };
+}
+
+async function* toAsyncIterable(
+  events: readonly RawEvent[],
+): AsyncIterable<RawEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+async function collectEvents(
+  events: readonly RawEvent[],
+  signal?: AbortSignal,
+): Promise<AGUIEvent[]> {
+  const result: AGUIEvent[] = [];
+
+  for await (const event of mapAnthropicEvents({
+    events: toAsyncIterable(events),
+    messageId: 'assistant-message-1',
+    signal,
+  })) {
+    result.push(event);
+  }
+
+  return result;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object') {
+    for (const nestedValue of Object.values(value)) {
+      deepFreeze(nestedValue);
+    }
+    Object.freeze(value);
+  }
+
+  return value;
+}
+
+function createTrackedSource(events: readonly RawEvent[]) {
+  const state = {
+    nextCalls: 0,
+    returnCalls: 0,
+    returnCompleted: false,
+  };
+  let index = 0;
+  const iterable: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<RawEvent>> {
+          state.nextCalls += 1;
+          if (index >= events.length) {
+            return { done: true, value: undefined };
+          }
+
+          const value = events[index];
+          index += 1;
+          return { done: false, value };
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          state.returnCalls += 1;
+          await Promise.resolve();
+          state.returnCompleted = true;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  return { iterable, state };
+}
+
+test('maps one text block to one AG-UI text lifecycle', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    textDelta(0, 'Hello'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'Hello',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('emits no text lifecycle for an empty text block without deltas', async () => {
+  const events = [messageStart(), textStart(0), contentStop(0), messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([]);
+});
+
+test('emits nonempty initial text before later text deltas', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, 'Hello'),
+    textDelta(0, ', '),
+    textDelta(0, 'world'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'Hello',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: ', ',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'world',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('shares one AG-UI text lifecycle across multiple text blocks', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, 'First'),
+    contentStop(0),
+    textStart(1),
+    textDelta(1, ' second'),
+    contentStop(1),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'First',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: ' second',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('maps streamed tool arguments to an AG-UI tool lifecycle', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {}),
+    inputJsonDelta(0, '{"query":'),
+    inputJsonDelta(0, '"hashbrown"}'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{"query":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '"hashbrown"}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('emits initial tool input as fallback when no deltas arrive', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', { query: 'initial' }),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{"query":"initial"}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('emits an empty initial tool input as fallback', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {}),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('uses streamed tool deltas instead of initial input without duplication', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', { query: 'initial' }),
+    inputJsonDelta(0, '{"query":'),
+    inputJsonDelta(0, '"streamed"}'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+  const argumentsValue = result
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+
+  expect(argumentsValue).toBe('{"query":"streamed"}');
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{"query":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '"streamed"}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('maps interleaved text and multiple tools by content index', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, 'A'),
+    toolStart(1, 'tool-1', 'first', {}),
+    toolStart(2, 'tool-2', 'second', {}),
+    inputJsonDelta(2, '{"second":true}'),
+    textDelta(0, 'B'),
+    inputJsonDelta(1, '{"first":true}'),
+    contentStop(1),
+    contentStop(0),
+    contentStop(2),
+    messageDelta(),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'A',
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'first',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-2',
+      toolCallName: 'second',
+      parentMessageId: 'assistant-message-1',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-2',
+      delta: '{"second":true}',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'B',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'tool-1',
+      delta: '{"first":true}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-2' },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('does not mutate source events or nested content blocks', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {
+      query: 'hashbrown',
+      filters: { active: true },
+    }),
+    inputJsonDelta(0, '{"query":"streamed"}'),
+    contentStop(0),
+    messageStop(),
+  ];
+  const expected = structuredClone(events);
+  deepFreeze(events);
+
+  await collectEvents(events);
+
+  expect(events).toEqual(expected);
+});
+
+test('allows multiple message_delta events when no content block is open', async () => {
+  const events = [
+    messageStart(),
+    messageDelta(),
+    messageDelta(),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([]);
+});
+
+test('rejects an event before message_start', async () => {
+  const events = [textStart(0), messageStart(), contentStop(0), messageStop()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic event content_block_start received before message_start',
+  );
+});
+
+test('rejects duplicate message_start events', async () => {
+  const events = [messageStart(), messageStart(), messageStop()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic stream received duplicate message_start',
+  );
+});
+
+test('rejects an event after message_stop', async () => {
+  const events = [messageStart(), messageStop(), messageDelta()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic event message_delta received after message_stop',
+  );
+});
+
+test('rejects a duplicate active content index', async () => {
+  const events = [messageStart(), textStart(0), textStart(0)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content index 0 started more than once',
+  );
+});
+
+test('rejects a reused stopped content index', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    contentStop(0),
+    toolStart(0, 'tool-1', 'search', {}),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content index 0 started more than once',
+  );
+});
+
+test('rejects a delta for an unknown content index', async () => {
+  const events = [messageStart(), textDelta(3, 'unknown')];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_delta references unknown or stopped index 3',
+  );
+});
+
+test('rejects a stop for an unknown content index', async () => {
+  const events = [messageStart(), contentStop(3)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_stop references unknown or stopped index 3',
+  );
+});
+
+test('rejects a delta for an already-stopped content index', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    contentStop(0),
+    textDelta(0, 'late'),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_delta references unknown or stopped index 0',
+  );
+});
+
+test('rejects a second stop for an already-stopped content index', async () => {
+  const events = [messageStart(), textStart(0), contentStop(0), contentStop(0)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_stop references unknown or stopped index 0',
+  );
+});
+
+test('rejects text deltas for tool blocks', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {}),
+    textDelta(0, 'wrong'),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool block at index 0 cannot receive text_delta',
+  );
+});
+
+test('rejects input JSON deltas for text blocks', async () => {
+  const events = [messageStart(), textStart(0), inputJsonDelta(0, '{}')];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic text block at index 0 cannot receive input_json_delta',
+  );
+});
+
+test('rejects tool blocks with an empty ID', async () => {
+  const events = [messageStart(), toolStart(0, '', 'search', {})];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool block at index 0 has an empty id',
+  );
+});
+
+test('rejects tool blocks with an empty name', async () => {
+  const events = [messageStart(), toolStart(0, 'tool-1', '', {})];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool block at index 0 has an empty name',
+  );
+});
+
+test('rejects message_delta while a content block is open', async () => {
+  const events = [messageStart(), textStart(0), messageDelta()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic message_delta received while content blocks are open',
+  );
+});
+
+test('rejects message_stop while a content block is open', async () => {
+  const events = [messageStart(), textStart(0), messageStop()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic message_stop received while content blocks are open',
+  );
+});
+
+test('rejects stream completion with an open content block', async () => {
+  const events = [messageStart(), textStart(0)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic stream ended with open content blocks',
+  );
+});
+
+test('rejects stream completion without message_stop', async () => {
+  const events = [messageStart(), messageDelta()];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic stream ended before message_stop',
+  );
+});
+
+test('rejects stream completion without message_start', async () => {
+  const events: RawEvent[] = [];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic stream ended before message_start',
+  );
+});
+
+test('returns quietly without requesting source events when already aborted', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const source = createTrackedSource([messageStart(), messageStop()]);
+
+  const result: AGUIEvent[] = [];
+  for await (const event of mapAnthropicEvents({
+    events: source.iterable,
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })) {
+    result.push(event);
+  }
+
+  expect(result).toEqual([]);
+  expect(source.state).toEqual({
+    nextCalls: 0,
+    returnCalls: 1,
+    returnCompleted: true,
+  });
+});
+
+test('aborts after text start without emitting initial content or an end event', async () => {
+  const controller = new AbortController();
+  const source = createTrackedSource([
+    messageStart(),
+    textStart(0, 'must not be emitted'),
+    contentStop(0),
+    messageStop(),
+  ]);
+  const iterator = mapAnthropicEvents({
+    events: source.iterable,
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const first = await iterator.next();
+  controller.abort();
+  const second = await iterator.next();
+
+  expect(first).toEqual({
+    done: false,
+    value: {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+  });
+  expect(second).toEqual({ done: true, value: undefined });
+  expect(source.state).toEqual({
+    nextCalls: 2,
+    returnCalls: 1,
+    returnCompleted: true,
+  });
+});
+
+test('aborts after tool arguments without emitting later tool or text ends', async () => {
+  const controller = new AbortController();
+  const source = createTrackedSource([
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {}),
+    inputJsonDelta(0, '{}'),
+    contentStop(0),
+    messageStop(),
+  ]);
+  const iterator = mapAnthropicEvents({
+    events: source.iterable,
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  const args = await iterator.next();
+  controller.abort();
+  const end = await iterator.next();
+
+  expect(start.value).toEqual({
+    type: EventType.TOOL_CALL_START,
+    toolCallId: 'tool-1',
+    toolCallName: 'search',
+    parentMessageId: 'assistant-message-1',
+  });
+  expect(args.value).toEqual({
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId: 'tool-1',
+    delta: '{}',
+  });
+  expect(end).toEqual({ done: true, value: undefined });
+  expect(source.state).toEqual({
+    nextCalls: 3,
+    returnCalls: 1,
+    returnCompleted: true,
+  });
+});
+
+test('awaits source iterator closure when the consumer returns early', async () => {
+  const source = createTrackedSource([
+    messageStart(),
+    textStart(0, 'Hello'),
+    contentStop(0),
+    messageStop(),
+  ]);
+  const iterator = mapAnthropicEvents({
+    events: source.iterable,
+    messageId: 'assistant-message-1',
+  })[Symbol.asyncIterator]();
+
+  const first = await iterator.next();
+  const returned = await iterator.return?.();
+
+  expect(first.done).toBe(false);
+  expect(returned).toEqual({ done: true, value: undefined });
+  expect(source.state.returnCalls).toBe(1);
+  expect(source.state.returnCompleted).toBe(true);
+});

--- a/packages/anthropic/src/stream/anthropic-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-events.spec.ts
@@ -53,9 +53,21 @@ function messageStart(): RawEvent {
       role: 'assistant',
       content: [],
       model: 'claude-test',
+      container: null,
       stop_reason: null,
       stop_sequence: null,
-      usage: { input_tokens: 1, output_tokens: 0 },
+      stop_details: null,
+      usage: {
+        cache_creation: null,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        inference_geo: null,
+        input_tokens: 1,
+        output_tokens: 0,
+        output_tokens_details: null,
+        server_tool_use: null,
+        service_tier: null,
+      },
     },
   };
 }
@@ -63,8 +75,20 @@ function messageStart(): RawEvent {
 function messageDelta(): RawEvent {
   return {
     type: 'message_delta',
-    delta: { stop_reason: 'end_turn', stop_sequence: null },
-    usage: { output_tokens: 1 },
+    delta: {
+      container: null,
+      stop_details: null,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+    },
+    usage: {
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      input_tokens: null,
+      output_tokens: 1,
+      output_tokens_details: null,
+      server_tool_use: null,
+    },
   };
 }
 
@@ -76,7 +100,7 @@ function textStart(index: number, text = ''): RawEvent {
   return {
     type: 'content_block_start',
     index,
-    content_block: { type: 'text', text },
+    content_block: { type: 'text', text, citations: null },
   };
 }
 
@@ -89,7 +113,13 @@ function toolStart(
   return {
     type: 'content_block_start',
     index,
-    content_block: { type: 'tool_use', id, name, input },
+    content_block: {
+      type: 'tool_use',
+      id,
+      name,
+      input,
+      caller: { type: 'direct' },
+    },
   };
 }
 

--- a/packages/anthropic/src/stream/anthropic-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-events.spec.ts
@@ -1,8 +1,16 @@
 import { type AGUIEvent, EventType } from '@ag-ui/core';
-import Anthropic from '@anthropic-ai/sdk';
 import { mapAnthropicEvents } from './anthropic-events';
-
-type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+import {
+  collectEvents,
+  collectIterable,
+  contentStop,
+  deepFreeze,
+  messageDelta,
+  messageStart,
+  messageStop,
+  rawEvent,
+  type RawEvent,
+} from './anthropic-events.test-utils';
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -19,10 +27,6 @@ function createDeferred<T>(): Deferred<T> {
   });
 
   return { promise, reject, resolve };
-}
-
-function rawEvent(value: unknown): RawEvent {
-  return value as RawEvent;
 }
 
 function withFailureTimeout<T>(promise: Promise<T>): Promise<T> {
@@ -42,58 +46,6 @@ function withFailureTimeout<T>(promise: Promise<T>): Promise<T> {
       },
     );
   });
-}
-
-function messageStart(): RawEvent {
-  return {
-    type: 'message_start',
-    message: {
-      id: 'anthropic-message-1',
-      type: 'message',
-      role: 'assistant',
-      content: [],
-      model: 'claude-test',
-      container: null,
-      stop_reason: null,
-      stop_sequence: null,
-      stop_details: null,
-      usage: {
-        cache_creation: null,
-        cache_creation_input_tokens: null,
-        cache_read_input_tokens: null,
-        inference_geo: null,
-        input_tokens: 1,
-        output_tokens: 0,
-        output_tokens_details: null,
-        server_tool_use: null,
-        service_tier: null,
-      },
-    },
-  };
-}
-
-function messageDelta(): RawEvent {
-  return {
-    type: 'message_delta',
-    delta: {
-      container: null,
-      stop_details: null,
-      stop_reason: 'end_turn',
-      stop_sequence: null,
-    },
-    usage: {
-      cache_creation_input_tokens: null,
-      cache_read_input_tokens: null,
-      input_tokens: null,
-      output_tokens: 1,
-      output_tokens_details: null,
-      server_tool_use: null,
-    },
-  };
-}
-
-function messageStop(): RawEvent {
-  return { type: 'message_stop' };
 }
 
 function textStart(index: number, text = ''): RawEvent {
@@ -137,53 +89,6 @@ function inputJsonDelta(index: number, partialJson: string): RawEvent {
     index,
     delta: { type: 'input_json_delta', partial_json: partialJson },
   };
-}
-
-function contentStop(index: number): RawEvent {
-  return { type: 'content_block_stop', index };
-}
-
-async function* toAsyncIterable(
-  events: readonly RawEvent[],
-): AsyncIterable<RawEvent> {
-  for (const event of events) {
-    yield event;
-  }
-}
-
-async function collectEvents(
-  events: readonly RawEvent[],
-  signal?: AbortSignal,
-): Promise<AGUIEvent[]> {
-  return collectIterable(toAsyncIterable(events), signal);
-}
-
-async function collectIterable(
-  events: AsyncIterable<RawEvent>,
-  signal?: AbortSignal,
-): Promise<AGUIEvent[]> {
-  const result: AGUIEvent[] = [];
-
-  for await (const event of mapAnthropicEvents({
-    events,
-    messageId: 'assistant-message-1',
-    signal,
-  })) {
-    result.push(event);
-  }
-
-  return result;
-}
-
-function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === 'object') {
-    for (const nestedValue of Object.values(value)) {
-      deepFreeze(nestedValue);
-    }
-    Object.freeze(value);
-  }
-
-  return value;
 }
 
 function createTrackedSource(events: readonly RawEvent[]) {

--- a/packages/anthropic/src/stream/anthropic-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-events.spec.ts
@@ -4,6 +4,46 @@ import { mapAnthropicEvents } from './anthropic-events';
 
 type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
 
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly reject: (reason?: unknown) => void;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise;
+    resolve = resolvePromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function rawEvent(value: unknown): RawEvent {
+  return value as RawEvent;
+}
+
+function withFailureTimeout<T>(promise: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for deterministic test operation'));
+    }, 1000);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
 function messageStart(): RawEvent {
   return {
     type: 'message_start',
@@ -85,10 +125,17 @@ async function collectEvents(
   events: readonly RawEvent[],
   signal?: AbortSignal,
 ): Promise<AGUIEvent[]> {
+  return collectIterable(toAsyncIterable(events), signal);
+}
+
+async function collectIterable(
+  events: AsyncIterable<RawEvent>,
+  signal?: AbortSignal,
+): Promise<AGUIEvent[]> {
   const result: AGUIEvent[] = [];
 
   for await (const event of mapAnthropicEvents({
-    events: toAsyncIterable(events),
+    events,
     messageId: 'assistant-message-1',
     signal,
   })) {
@@ -783,4 +830,427 @@ test('awaits source iterator closure when the consumer returns early', async () 
   expect(returned).toEqual({ done: true, value: undefined });
   expect(source.state.returnCalls).toBe(1);
   expect(source.state.returnCompleted).toBe(true);
+});
+
+test('cancels a permanently pending source read and awaits iterator closure', async () => {
+  const controller = new AbortController();
+  const nextStarted = createDeferred<void>();
+  const pendingNext = createDeferred<IteratorResult<RawEvent>>();
+  const returnStarted = createDeferred<void>();
+  const releaseReturn = createDeferred<void>();
+  const state = { returnCalls: 0, returnCompleted: false };
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<RawEvent>> {
+          nextStarted.resolve(undefined);
+          return pendingNext.promise;
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          state.returnCalls += 1;
+          returnStarted.resolve(undefined);
+          await releaseReturn.promise;
+          state.returnCompleted = true;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source, controller.signal);
+  await withFailureTimeout(nextStarted.promise);
+  controller.abort();
+  await withFailureTimeout(returnStarted.promise);
+  let settled = false;
+  void act.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  await Promise.resolve();
+  const settledBeforeRelease = settled;
+  releaseReturn.resolve(undefined);
+  const result = await withFailureTimeout(act);
+
+  expect(settledBeforeRelease).toBe(false);
+  expect(result).toEqual([]);
+  expect(state).toEqual({ returnCalls: 1, returnCompleted: true });
+});
+
+test('consumes a late rejection from a source read that loses cancellation', async () => {
+  const controller = new AbortController();
+  const nextStarted = createDeferred<void>();
+  const pendingNext = createDeferred<IteratorResult<RawEvent>>();
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<RawEvent>> {
+          nextStarted.resolve(undefined);
+          return pendingNext.promise;
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source, controller.signal);
+  await withFailureTimeout(nextStarted.promise);
+  controller.abort();
+  await withFailureTimeout(act);
+  pendingNext.reject(new Error('late source rejection'));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  expect(controller.signal.aborted).toBe(true);
+});
+
+test('rejects a non-object stream event with a contextual error', async () => {
+  const events = [messageStart(), rawEvent(null)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow('Anthropic stream event must be an object');
+});
+
+test('rejects an unsupported stream event type', async () => {
+  const events = [messageStart(), rawEvent({ type: 'ping' })];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic stream received unsupported event type "ping"',
+  );
+});
+
+test('rejects a negative content block start index', async () => {
+  const events = [messageStart(), textStart(-1)];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_start has invalid content index -1',
+  );
+});
+
+test('rejects a noninteger content block delta index', async () => {
+  const events = [messageStart(), textStart(0), textDelta(0.5, 'invalid')];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_delta has invalid content index 0.5',
+  );
+});
+
+test('rejects a nonnumeric content block stop index', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    rawEvent({ type: 'content_block_stop', index: '0' }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content_block_stop has invalid content index "0"',
+  );
+});
+
+test('rejects a non-object content block with index context', async () => {
+  const events = [
+    messageStart(),
+    rawEvent({ type: 'content_block_start', index: 0, content_block: null }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content block at index 0 must be an object',
+  );
+});
+
+test('rejects an unsupported content block discriminant', async () => {
+  const events = [
+    messageStart(),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'image' },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content block at index 0 has unsupported type "image"',
+  );
+});
+
+test('rejects a text block with non-string text', async () => {
+  const events = [
+    messageStart(),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: 42 },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic text block at index 0 has non-string text',
+  );
+});
+
+test('rejects a tool block with a non-string ID', async () => {
+  const events = [
+    messageStart(),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: 42, name: 'search', input: {} },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool block at index 0 has a non-string id',
+  );
+});
+
+test('rejects a tool block with a non-string name', async () => {
+  const events = [
+    messageStart(),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: 'tool-1', name: 42, input: {} },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool block at index 0 has a non-string name',
+  );
+});
+
+test('rejects duplicate tool IDs across content indexes', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'first', {}),
+    contentStop(0),
+    toolStart(1, 'tool-1', 'second', {}),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic tool id "tool-1" started more than once at index 1',
+  );
+});
+
+test('rejects a non-object content delta with index context', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    rawEvent({ type: 'content_block_delta', index: 0, delta: null }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic content delta at index 0 must be an object',
+  );
+});
+
+test('rejects a text delta with non-string text', async () => {
+  const events = [
+    messageStart(),
+    textStart(0),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 42 },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic text_delta at index 0 has non-string text',
+  );
+});
+
+test('rejects an input JSON delta with non-string partial JSON', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', {}),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: 42 },
+    }),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic input_json_delta at index 0 has non-string partial_json',
+  );
+});
+
+test('treats an empty input JSON delta as authoritative', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', { query: 'initial' }),
+    inputJsonDelta(0, ''),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    { type: EventType.TOOL_CALL_ARGS, toolCallId: 'tool-1', delta: '' },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('allows content blocks after message_delta', async () => {
+  const events = [
+    messageStart(),
+    messageDelta(),
+    textStart(0, 'after delta'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'after delta',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('wraps circular initial tool input serialization errors with context', async () => {
+  const input: { self?: unknown } = {};
+  input.self = input;
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', input),
+    contentStop(0),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toMatchObject({
+    message:
+      'Anthropic tool "tool-1" at index 0 has non-serializable initial input',
+    cause: expect.any(TypeError),
+  });
+});
+
+test('wraps BigInt initial tool input serialization errors with context', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0, 'tool-1', 'search', { value: BigInt(1) }),
+    contentStop(0),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toMatchObject({
+    message:
+      'Anthropic tool "tool-1" at index 0 has non-serializable initial input',
+    cause: expect.any(TypeError),
+  });
+});
+
+test('preserves a primary mapping error when iterator cleanup rejects', async () => {
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<RawEvent>> {
+          return { done: false, value: messageDelta() };
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          throw new Error('cleanup failed');
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic event message_delta received before message_start',
+  );
+});
+
+test('preserves a primary source error when iterator cleanup rejects', async () => {
+  const sourceError = new Error('source failed');
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<RawEvent>> {
+          throw sourceError;
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          throw new Error('cleanup failed');
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source);
+
+  await expect(act).rejects.toBe(sourceError);
+});
+
+test('surfaces iterator cleanup rejection when there is no primary error', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const cleanupError = new Error('cleanup failed');
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<RawEvent>> {
+          return { done: true, value: undefined };
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          throw cleanupError;
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source, controller.signal);
+
+  await expect(act).rejects.toBe(cleanupError);
 });

--- a/packages/anthropic/src/stream/anthropic-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-events.spec.ts
@@ -880,6 +880,42 @@ test('cancels a permanently pending source read and awaits iterator closure', as
   expect(state).toEqual({ returnCalls: 1, returnCompleted: true });
 });
 
+test('returns quietly when the pending source rejects from its abort listener', async () => {
+  const controller = new AbortController();
+  const nextStarted = createDeferred<void>();
+  const state = { returnCalls: 0, returnCompleted: false };
+  const source: AsyncIterable<RawEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<RawEvent>> {
+          nextStarted.resolve(undefined);
+          return new Promise<IteratorResult<RawEvent>>((_, reject) => {
+            controller.signal.addEventListener(
+              'abort',
+              () => reject(new Error('source aborted pending read')),
+              { once: true },
+            );
+          });
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          state.returnCalls += 1;
+          await Promise.resolve();
+          state.returnCompleted = true;
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  const act = collectIterable(source, controller.signal);
+  await withFailureTimeout(nextStarted.promise);
+  controller.abort();
+  const result = await withFailureTimeout(act);
+
+  expect(result).toEqual([]);
+  expect(state).toEqual({ returnCalls: 1, returnCompleted: true });
+});
+
 test('consumes a late rejection from a source read that loses cancellation', async () => {
   const controller = new AbortController();
   const nextStarted = createDeferred<void>();

--- a/packages/anthropic/src/stream/anthropic-events.test-utils.ts
+++ b/packages/anthropic/src/stream/anthropic-events.test-utils.ts
@@ -1,0 +1,118 @@
+import { type AGUIEvent, EventSchemas } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+import { mapAnthropicEvents } from './anthropic-events';
+
+/** Raw Anthropic stream event used at the mapper test boundary. */
+export type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+
+/** Casts intentionally malformed values into the native event test boundary. */
+export function rawEvent(value: unknown): RawEvent {
+  return value as RawEvent;
+}
+
+/** Creates a complete native message-start fixture. */
+export function messageStart(): RawEvent {
+  return {
+    type: 'message_start',
+    message: {
+      id: 'anthropic-message-1',
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model: 'claude-test',
+      container: null,
+      stop_reason: null,
+      stop_sequence: null,
+      stop_details: null,
+      usage: {
+        cache_creation: null,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        inference_geo: null,
+        input_tokens: 1,
+        output_tokens: 0,
+        output_tokens_details: null,
+        server_tool_use: null,
+        service_tier: null,
+      },
+    },
+  };
+}
+
+/** Creates a complete native message-delta fixture. */
+export function messageDelta(): RawEvent {
+  return {
+    type: 'message_delta',
+    delta: {
+      container: null,
+      stop_details: null,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+    },
+    usage: {
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      input_tokens: null,
+      output_tokens: 1,
+      output_tokens_details: null,
+      server_tool_use: null,
+    },
+  };
+}
+
+/** Creates a native message-stop fixture. */
+export function messageStop(): RawEvent {
+  return { type: 'message_stop' };
+}
+
+/** Creates a native content-block-stop fixture. */
+export function contentStop(index: number): RawEvent {
+  return { type: 'content_block_stop', index };
+}
+
+/** Exposes a deterministic array as an asynchronous native event source. */
+export async function* toAsyncIterable(
+  events: readonly RawEvent[],
+): AsyncIterable<RawEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/** Collects and validates mapped AG-UI events from native fixtures. */
+export async function collectEvents(
+  events: readonly RawEvent[],
+  signal?: AbortSignal,
+): Promise<AGUIEvent[]> {
+  return collectIterable(toAsyncIterable(events), signal);
+}
+
+/** Collects and validates mapped AG-UI events from a custom native source. */
+export async function collectIterable(
+  events: AsyncIterable<RawEvent>,
+  signal?: AbortSignal,
+): Promise<AGUIEvent[]> {
+  const result: AGUIEvent[] = [];
+
+  for await (const event of mapAnthropicEvents({
+    events,
+    messageId: 'assistant-message-1',
+    signal,
+  })) {
+    result.push(EventSchemas.parse(event));
+  }
+
+  return result;
+}
+
+/** Recursively freezes JSON-like fixtures to detect source mutation. */
+export function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object') {
+    for (const nestedValue of Object.values(value)) {
+      deepFreeze(nestedValue);
+    }
+    Object.freeze(value);
+  }
+
+  return value;
+}

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -14,7 +14,23 @@ interface ToolBlockState {
   readonly receivedDelta: boolean;
 }
 
-type ContentBlockState = TextBlockState | ToolBlockState;
+interface ThinkingBlockState {
+  readonly kind: 'thinking';
+  readonly messageId: string;
+  readonly initialSignature: string;
+  readonly signatureDelta: string | undefined;
+}
+
+interface RedactedThinkingBlockState {
+  readonly kind: 'redacted_thinking';
+  readonly messageId: string;
+}
+
+type ContentBlockState =
+  | TextBlockState
+  | ToolBlockState
+  | ThinkingBlockState
+  | RedactedThinkingBlockState;
 type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -173,7 +189,9 @@ export async function* mapAnthropicEvents(
   const activeBlocks = new Map<number, ContentBlockState>();
   let messageStarted = false;
   let messageStopped = false;
+  let nativeTextBlockStarted = false;
   let textStarted = false;
+  let clientToolStarted = false;
   let sourceCompleted = false;
   let hasPrimaryError = false;
 
@@ -239,7 +257,12 @@ export async function* mapAnthropicEvents(
           }
 
           const blockType = contentBlock['type'];
-          if (blockType !== 'text' && blockType !== 'tool_use') {
+          if (
+            blockType !== 'text' &&
+            blockType !== 'tool_use' &&
+            blockType !== 'thinking' &&
+            blockType !== 'redacted_thinking'
+          ) {
             throw new Error(
               `Anthropic content block at index ${index} has unsupported type ` +
                 formatDiagnosticValue(blockType),
@@ -247,6 +270,98 @@ export async function* mapAnthropicEvents(
           }
 
           seenIndexes.add(index);
+          if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+            if (nativeTextBlockStarted || clientToolStarted) {
+              throw new Error(
+                `Anthropic reasoning block at index ${index} cannot start ` +
+                  'after assistant text or a client tool block',
+              );
+            }
+
+            const messageId = `${options.messageId}:reasoning:${index}`;
+            if (blockType === 'thinking') {
+              const thinking = contentBlock['thinking'];
+              if (typeof thinking !== 'string') {
+                throw new Error(
+                  `Anthropic thinking block at index ${index} has ` +
+                    'non-string thinking',
+                );
+              }
+
+              const signature = contentBlock['signature'];
+              if (typeof signature !== 'string') {
+                throw new Error(
+                  `Anthropic thinking block at index ${index} has ` +
+                    'non-string signature',
+                );
+              }
+
+              activeBlocks.set(index, {
+                kind: 'thinking',
+                messageId,
+                initialSignature: signature,
+                signatureDelta: undefined,
+              });
+              yield {
+                type: EventType.REASONING_MESSAGE_START,
+                messageId,
+                role: 'reasoning',
+                metadata: { anthropic: { blockType: 'thinking' } },
+              };
+              if (options.signal?.aborted) {
+                return;
+              }
+
+              if (thinking.length > 0) {
+                yield {
+                  type: EventType.REASONING_MESSAGE_CONTENT,
+                  messageId,
+                  delta: thinking,
+                };
+                if (options.signal?.aborted) {
+                  return;
+                }
+              }
+              break;
+            }
+
+            const data = contentBlock['data'];
+            if (typeof data !== 'string') {
+              throw new Error(
+                `Anthropic redacted_thinking block at index ${index} has ` +
+                  'non-string data',
+              );
+            }
+            if (data.length === 0) {
+              throw new Error(
+                `Anthropic redacted_thinking block at index ${index} has ` +
+                  'empty data',
+              );
+            }
+
+            activeBlocks.set(index, { kind: 'redacted_thinking', messageId });
+            yield {
+              type: EventType.REASONING_MESSAGE_START,
+              messageId,
+              role: 'reasoning',
+              metadata: { anthropic: { blockType: 'redacted_thinking' } },
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+
+            yield {
+              type: EventType.REASONING_ENCRYPTED_VALUE,
+              subtype: 'message',
+              entityId: messageId,
+              encryptedValue: data,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
           if (blockType === 'text') {
             const text = contentBlock['text'];
             if (typeof text !== 'string') {
@@ -255,6 +370,7 @@ export async function* mapAnthropicEvents(
               );
             }
 
+            nativeTextBlockStarted = true;
             activeBlocks.set(index, { kind: 'text' });
             if (text.length === 0) {
               break;
@@ -313,6 +429,7 @@ export async function* mapAnthropicEvents(
           }
 
           seenToolIds.add(id);
+          clientToolStarted = true;
           activeBlocks.set(index, {
             kind: 'tool',
             id,
@@ -350,7 +467,12 @@ export async function* mapAnthropicEvents(
           }
 
           const deltaType = delta['type'];
-          if (deltaType !== 'text_delta' && deltaType !== 'input_json_delta') {
+          if (
+            deltaType !== 'text_delta' &&
+            deltaType !== 'input_json_delta' &&
+            deltaType !== 'thinking_delta' &&
+            deltaType !== 'signature_delta'
+          ) {
             throw new Error(
               `Anthropic content delta at index ${index} has unsupported type ` +
                 formatDiagnosticValue(deltaType),
@@ -398,33 +520,92 @@ export async function* mapAnthropicEvents(
             break;
           }
 
-          if (deltaType !== 'input_json_delta') {
+          if (block.kind === 'tool') {
+            if (deltaType !== 'input_json_delta') {
+              throw new Error(
+                `Anthropic tool block at index ${index} cannot receive ` +
+                  deltaType,
+              );
+            }
+
+            const partialJson = delta['partial_json'];
+            if (typeof partialJson !== 'string') {
+              throw new Error(
+                `Anthropic input_json_delta at index ${index} has ` +
+                  'non-string partial_json',
+              );
+            }
+
+            activeBlocks.set(index, {
+              ...block,
+              receivedDelta: true,
+            });
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: block.id,
+              delta: partialJson,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (block.kind === 'redacted_thinking') {
             throw new Error(
-              `Anthropic tool block at index ${index} cannot receive ` +
+              `Anthropic redacted_thinking block at index ${index} cannot ` +
+                `receive ${deltaType}`,
+            );
+          }
+
+          if (deltaType === 'thinking_delta') {
+            const thinking = delta['thinking'];
+            if (typeof thinking !== 'string') {
+              throw new Error(
+                `Anthropic thinking_delta at index ${index} has ` +
+                  'non-string thinking',
+              );
+            }
+            if (thinking.length === 0) {
+              break;
+            }
+
+            yield {
+              type: EventType.REASONING_MESSAGE_CONTENT,
+              messageId: block.messageId,
+              delta: thinking,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (deltaType !== 'signature_delta') {
+            throw new Error(
+              `Anthropic thinking block at index ${index} cannot receive ` +
                 deltaType,
             );
           }
 
-          const partialJson = delta['partial_json'];
-          if (typeof partialJson !== 'string') {
+          const signature = delta['signature'];
+          if (typeof signature !== 'string') {
             throw new Error(
-              `Anthropic input_json_delta at index ${index} has ` +
-                'non-string partial_json',
+              `Anthropic signature_delta at index ${index} has ` +
+                'non-string signature',
+            );
+          }
+          if (block.signatureDelta !== undefined) {
+            throw new Error(
+              `Anthropic thinking block at index ${index} received more than ` +
+                'one signature_delta',
             );
           }
 
           activeBlocks.set(index, {
             ...block,
-            receivedDelta: true,
+            signatureDelta: signature,
           });
-          yield {
-            type: EventType.TOOL_CALL_ARGS,
-            toolCallId: block.id,
-            delta: partialJson,
-          };
-          if (options.signal?.aborted) {
-            return;
-          }
           break;
         }
 
@@ -440,6 +621,46 @@ export async function* mapAnthropicEvents(
 
           activeBlocks.delete(index);
           if (block.kind === 'text') {
+            break;
+          }
+
+          if (block.kind === 'thinking') {
+            const signature = block.signatureDelta ?? block.initialSignature;
+            if (signature.length === 0) {
+              throw new Error(
+                `Anthropic thinking block at index ${index} has an empty ` +
+                  'final signature',
+              );
+            }
+
+            yield {
+              type: EventType.REASONING_ENCRYPTED_VALUE,
+              subtype: 'message',
+              entityId: block.messageId,
+              encryptedValue: signature,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+
+            yield {
+              type: EventType.REASONING_MESSAGE_END,
+              messageId: block.messageId,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (block.kind === 'redacted_thinking') {
+            yield {
+              type: EventType.REASONING_MESSAGE_END,
+              messageId: block.messageId,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
             break;
           }
 

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -1,0 +1,307 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+
+interface TextBlockState {
+  readonly kind: 'text';
+}
+
+interface ToolBlockState {
+  readonly kind: 'tool';
+  readonly id: string;
+  readonly initialInput: unknown;
+  readonly receivedDelta: boolean;
+}
+
+type ContentBlockState = TextBlockState | ToolBlockState;
+
+/**
+ * Options for mapping a raw Anthropic message stream to AG-UI events.
+ *
+ * @internal
+ */
+export interface MapAnthropicEventsOptions {
+  readonly events: AsyncIterable<Anthropic.Messages.RawMessageStreamEvent>;
+  readonly messageId: string;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Maps raw Anthropic message events to canonical AG-UI message and tool events.
+ *
+ * @param options - Raw event source, stable assistant message ID, and cancellation
+ * signal.
+ * @returns An asynchronous stream of AG-UI message and tool events.
+ *
+ * @internal
+ */
+export async function* mapAnthropicEvents(
+  options: MapAnthropicEventsOptions,
+): AsyncIterable<AGUIEvent> {
+  const iterator = options.events[Symbol.asyncIterator]();
+  const seenIndexes = new Set<number>();
+  const activeBlocks = new Map<number, ContentBlockState>();
+  let messageStarted = false;
+  let messageStopped = false;
+  let textStarted = false;
+  let sourceCompleted = false;
+
+  try {
+    while (true) {
+      if (options.signal?.aborted) {
+        return;
+      }
+
+      const result = await iterator.next();
+      if (result.done) {
+        sourceCompleted = true;
+        if (options.signal?.aborted) {
+          return;
+        }
+        break;
+      }
+
+      if (options.signal?.aborted) {
+        return;
+      }
+
+      const event = result.value;
+      if (messageStopped) {
+        throw new Error(
+          `Anthropic event ${event.type} received after message_stop`,
+        );
+      }
+
+      if (event.type === 'message_start') {
+        if (messageStarted) {
+          throw new Error('Anthropic stream received duplicate message_start');
+        }
+
+        messageStarted = true;
+        continue;
+      }
+
+      if (!messageStarted) {
+        throw new Error(
+          `Anthropic event ${event.type} received before message_start`,
+        );
+      }
+
+      switch (event.type) {
+        case 'content_block_start': {
+          if (seenIndexes.has(event.index)) {
+            throw new Error(
+              `Anthropic content index ${event.index} started more than once`,
+            );
+          }
+
+          seenIndexes.add(event.index);
+          if (event.content_block.type === 'text') {
+            activeBlocks.set(event.index, { kind: 'text' });
+            if (event.content_block.text.length === 0) {
+              break;
+            }
+
+            if (!textStarted) {
+              textStarted = true;
+              yield {
+                type: EventType.TEXT_MESSAGE_START,
+                messageId: options.messageId,
+                role: 'assistant',
+              };
+              if (options.signal?.aborted) {
+                return;
+              }
+            }
+
+            yield {
+              type: EventType.TEXT_MESSAGE_CONTENT,
+              messageId: options.messageId,
+              delta: event.content_block.text,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (event.content_block.id.length === 0) {
+            throw new Error(
+              `Anthropic tool block at index ${event.index} has an empty id`,
+            );
+          }
+          if (event.content_block.name.length === 0) {
+            throw new Error(
+              `Anthropic tool block at index ${event.index} has an empty name`,
+            );
+          }
+
+          activeBlocks.set(event.index, {
+            kind: 'tool',
+            id: event.content_block.id,
+            initialInput: event.content_block.input,
+            receivedDelta: false,
+          });
+          yield {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: event.content_block.id,
+            toolCallName: event.content_block.name,
+            parentMessageId: options.messageId,
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+          break;
+        }
+
+        case 'content_block_delta': {
+          const block = activeBlocks.get(event.index);
+          if (!block) {
+            throw new Error(
+              'Anthropic content_block_delta references unknown or stopped ' +
+                `index ${event.index}`,
+            );
+          }
+
+          if (block.kind === 'text') {
+            if (event.delta.type !== 'text_delta') {
+              throw new Error(
+                `Anthropic text block at index ${event.index} cannot receive ` +
+                  event.delta.type,
+              );
+            }
+            if (event.delta.text.length === 0) {
+              break;
+            }
+
+            if (!textStarted) {
+              textStarted = true;
+              yield {
+                type: EventType.TEXT_MESSAGE_START,
+                messageId: options.messageId,
+                role: 'assistant',
+              };
+              if (options.signal?.aborted) {
+                return;
+              }
+            }
+
+            yield {
+              type: EventType.TEXT_MESSAGE_CONTENT,
+              messageId: options.messageId,
+              delta: event.delta.text,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (event.delta.type !== 'input_json_delta') {
+            throw new Error(
+              `Anthropic tool block at index ${event.index} cannot receive ` +
+                event.delta.type,
+            );
+          }
+
+          activeBlocks.set(event.index, {
+            ...block,
+            receivedDelta: true,
+          });
+          yield {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: block.id,
+            delta: event.delta.partial_json,
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+          break;
+        }
+
+        case 'content_block_stop': {
+          const block = activeBlocks.get(event.index);
+          if (!block) {
+            throw new Error(
+              'Anthropic content_block_stop references unknown or stopped ' +
+                `index ${event.index}`,
+            );
+          }
+
+          activeBlocks.delete(event.index);
+          if (block.kind === 'text') {
+            break;
+          }
+
+          if (!block.receivedDelta) {
+            const initialInput = JSON.stringify(block.initialInput);
+            if (initialInput === undefined) {
+              throw new Error(
+                `Anthropic tool block at index ${event.index} has ` +
+                  'non-serializable initial input',
+              );
+            }
+
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: block.id,
+              delta: initialInput,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+          }
+
+          yield {
+            type: EventType.TOOL_CALL_END,
+            toolCallId: block.id,
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+          break;
+        }
+
+        case 'message_delta':
+          if (activeBlocks.size > 0) {
+            throw new Error(
+              'Anthropic message_delta received while content blocks are open',
+            );
+          }
+          break;
+
+        case 'message_stop':
+          if (activeBlocks.size > 0) {
+            throw new Error(
+              'Anthropic message_stop received while content blocks are open',
+            );
+          }
+
+          messageStopped = true;
+          if (textStarted) {
+            yield {
+              type: EventType.TEXT_MESSAGE_END,
+              messageId: options.messageId,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+          }
+          break;
+      }
+    }
+
+    if (!messageStarted) {
+      throw new Error('Anthropic stream ended before message_start');
+    }
+    if (activeBlocks.size > 0) {
+      throw new Error('Anthropic stream ended with open content blocks');
+    }
+    if (!messageStopped) {
+      throw new Error('Anthropic stream ended before message_stop');
+    }
+  } finally {
+    if (!sourceCompleted) {
+      await iterator.return?.();
+    }
+  }
+}

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -1,6 +1,8 @@
 import { type AGUIEvent, EventType } from '@ag-ui/core';
 import Anthropic from '@anthropic-ai/sdk';
 
+const ABORTED = Symbol('aborted');
+
 interface TextBlockState {
   readonly kind: 'text';
 }
@@ -13,6 +15,122 @@ interface ToolBlockState {
 }
 
 type ContentBlockState = TextBlockState | ToolBlockState;
+type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function formatDiagnosticValue(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isRawEventType(value: unknown): value is RawEvent['type'] {
+  return (
+    value === 'message_start' ||
+    value === 'message_delta' ||
+    value === 'message_stop' ||
+    value === 'content_block_start' ||
+    value === 'content_block_delta' ||
+    value === 'content_block_stop'
+  );
+}
+
+function readRawEvent(value: unknown): RawEvent {
+  if (!isRecord(value)) {
+    throw new Error('Anthropic stream event must be an object');
+  }
+
+  const type = value['type'];
+  if (!isRawEventType(type)) {
+    throw new Error(
+      'Anthropic stream received unsupported event type ' +
+        formatDiagnosticValue(type),
+    );
+  }
+
+  return value as unknown as RawEvent;
+}
+
+function readContentIndex(event: RawEvent): number {
+  const eventRecord = event as unknown as Record<string, unknown>;
+  const index = eventRecord['index'];
+  if (typeof index !== 'number' || !Number.isInteger(index) || index < 0) {
+    throw new Error(
+      `Anthropic ${event.type} has invalid content index ` +
+        formatDiagnosticValue(index),
+    );
+  }
+
+  return index;
+}
+
+async function nextWithCancellation(
+  iterator: AsyncIterator<RawEvent>,
+  signal: AbortSignal | undefined,
+): Promise<IteratorResult<RawEvent> | typeof ABORTED> {
+  const nextPromise = iterator.next();
+  void nextPromise.catch(() => undefined);
+  if (!signal) {
+    return nextPromise;
+  }
+  if (signal.aborted) {
+    return ABORTED;
+  }
+
+  let handleAbort!: () => void;
+  const abortPromise = new Promise<typeof ABORTED>((resolve) => {
+    handleAbort = () => resolve(ABORTED);
+    signal.addEventListener('abort', handleAbort, { once: true });
+    if (signal.aborted) {
+      handleAbort();
+    }
+  });
+
+  try {
+    return await Promise.race([nextPromise, abortPromise]);
+  } finally {
+    signal.removeEventListener('abort', handleAbort);
+  }
+}
+
+async function closeIterator(
+  iterator: AsyncIterator<RawEvent>,
+  suppressError: boolean,
+): Promise<void> {
+  try {
+    await iterator.return?.();
+  } catch (error) {
+    if (!suppressError) {
+      throw error;
+    }
+  }
+}
+
+function serializeInitialInput(block: ToolBlockState, index: number): string {
+  const message =
+    `Anthropic tool "${block.id}" at index ${index} has ` +
+    'non-serializable initial input';
+  let result: string | undefined;
+
+  try {
+    result = JSON.stringify(block.initialInput);
+  } catch (cause) {
+    const error = new Error(message);
+    Object.defineProperty(error, 'cause', { configurable: true, value: cause });
+    throw error;
+  }
+
+  if (result === undefined) {
+    throw new Error(message);
+  }
+
+  return result;
+}
 
 /**
  * Options for mapping a raw Anthropic message stream to AG-UI events.
@@ -39,11 +157,13 @@ export async function* mapAnthropicEvents(
 ): AsyncIterable<AGUIEvent> {
   const iterator = options.events[Symbol.asyncIterator]();
   const seenIndexes = new Set<number>();
+  const seenToolIds = new Set<string>();
   const activeBlocks = new Map<number, ContentBlockState>();
   let messageStarted = false;
   let messageStopped = false;
   let textStarted = false;
   let sourceCompleted = false;
+  let hasPrimaryError = false;
 
   try {
     while (true) {
@@ -51,7 +171,10 @@ export async function* mapAnthropicEvents(
         return;
       }
 
-      const result = await iterator.next();
+      const result = await nextWithCancellation(iterator, options.signal);
+      if (result === ABORTED) {
+        return;
+      }
       if (result.done) {
         sourceCompleted = true;
         if (options.signal?.aborted) {
@@ -64,7 +187,7 @@ export async function* mapAnthropicEvents(
         return;
       }
 
-      const event = result.value;
+      const event = readRawEvent(result.value);
       if (messageStopped) {
         throw new Error(
           `Anthropic event ${event.type} received after message_stop`,
@@ -88,16 +211,40 @@ export async function* mapAnthropicEvents(
 
       switch (event.type) {
         case 'content_block_start': {
-          if (seenIndexes.has(event.index)) {
+          const index = readContentIndex(event);
+          if (seenIndexes.has(index)) {
             throw new Error(
-              `Anthropic content index ${event.index} started more than once`,
+              `Anthropic content index ${index} started more than once`,
             );
           }
 
-          seenIndexes.add(event.index);
-          if (event.content_block.type === 'text') {
-            activeBlocks.set(event.index, { kind: 'text' });
-            if (event.content_block.text.length === 0) {
+          const eventRecord = event as unknown as Record<string, unknown>;
+          const contentBlock = eventRecord['content_block'];
+          if (!isRecord(contentBlock)) {
+            throw new Error(
+              `Anthropic content block at index ${index} must be an object`,
+            );
+          }
+
+          const blockType = contentBlock['type'];
+          if (blockType !== 'text' && blockType !== 'tool_use') {
+            throw new Error(
+              `Anthropic content block at index ${index} has unsupported type ` +
+                formatDiagnosticValue(blockType),
+            );
+          }
+
+          seenIndexes.add(index);
+          if (blockType === 'text') {
+            const text = contentBlock['text'];
+            if (typeof text !== 'string') {
+              throw new Error(
+                `Anthropic text block at index ${index} has non-string text`,
+              );
+            }
+
+            activeBlocks.set(index, { kind: 'text' });
+            if (text.length === 0) {
               break;
             }
 
@@ -116,7 +263,7 @@ export async function* mapAnthropicEvents(
             yield {
               type: EventType.TEXT_MESSAGE_CONTENT,
               messageId: options.messageId,
-              delta: event.content_block.text,
+              delta: text,
             };
             if (options.signal?.aborted) {
               return;
@@ -124,27 +271,46 @@ export async function* mapAnthropicEvents(
             break;
           }
 
-          if (event.content_block.id.length === 0) {
+          const id = contentBlock['id'];
+          if (typeof id !== 'string') {
             throw new Error(
-              `Anthropic tool block at index ${event.index} has an empty id`,
+              `Anthropic tool block at index ${index} has a non-string id`,
             );
           }
-          if (event.content_block.name.length === 0) {
+          if (id.length === 0) {
             throw new Error(
-              `Anthropic tool block at index ${event.index} has an empty name`,
+              `Anthropic tool block at index ${index} has an empty id`,
             );
           }
 
-          activeBlocks.set(event.index, {
+          const name = contentBlock['name'];
+          if (typeof name !== 'string') {
+            throw new Error(
+              `Anthropic tool block at index ${index} has a non-string name`,
+            );
+          }
+          if (name.length === 0) {
+            throw new Error(
+              `Anthropic tool block at index ${index} has an empty name`,
+            );
+          }
+          if (seenToolIds.has(id)) {
+            throw new Error(
+              `Anthropic tool id "${id}" started more than once at index ${index}`,
+            );
+          }
+
+          seenToolIds.add(id);
+          activeBlocks.set(index, {
             kind: 'tool',
-            id: event.content_block.id,
-            initialInput: event.content_block.input,
+            id,
+            initialInput: contentBlock['input'],
             receivedDelta: false,
           });
           yield {
             type: EventType.TOOL_CALL_START,
-            toolCallId: event.content_block.id,
-            toolCallName: event.content_block.name,
+            toolCallId: id,
+            toolCallName: name,
             parentMessageId: options.messageId,
           };
           if (options.signal?.aborted) {
@@ -154,22 +320,46 @@ export async function* mapAnthropicEvents(
         }
 
         case 'content_block_delta': {
-          const block = activeBlocks.get(event.index);
+          const index = readContentIndex(event);
+          const block = activeBlocks.get(index);
           if (!block) {
             throw new Error(
               'Anthropic content_block_delta references unknown or stopped ' +
-                `index ${event.index}`,
+                `index ${index}`,
+            );
+          }
+
+          const eventRecord = event as unknown as Record<string, unknown>;
+          const delta = eventRecord['delta'];
+          if (!isRecord(delta)) {
+            throw new Error(
+              `Anthropic content delta at index ${index} must be an object`,
+            );
+          }
+
+          const deltaType = delta['type'];
+          if (deltaType !== 'text_delta' && deltaType !== 'input_json_delta') {
+            throw new Error(
+              `Anthropic content delta at index ${index} has unsupported type ` +
+                formatDiagnosticValue(deltaType),
             );
           }
 
           if (block.kind === 'text') {
-            if (event.delta.type !== 'text_delta') {
+            if (deltaType !== 'text_delta') {
               throw new Error(
-                `Anthropic text block at index ${event.index} cannot receive ` +
-                  event.delta.type,
+                `Anthropic text block at index ${index} cannot receive ` +
+                  deltaType,
               );
             }
-            if (event.delta.text.length === 0) {
+
+            const text = delta['text'];
+            if (typeof text !== 'string') {
+              throw new Error(
+                `Anthropic text_delta at index ${index} has non-string text`,
+              );
+            }
+            if (text.length === 0) {
               break;
             }
 
@@ -188,7 +378,7 @@ export async function* mapAnthropicEvents(
             yield {
               type: EventType.TEXT_MESSAGE_CONTENT,
               messageId: options.messageId,
-              delta: event.delta.text,
+              delta: text,
             };
             if (options.signal?.aborted) {
               return;
@@ -196,21 +386,29 @@ export async function* mapAnthropicEvents(
             break;
           }
 
-          if (event.delta.type !== 'input_json_delta') {
+          if (deltaType !== 'input_json_delta') {
             throw new Error(
-              `Anthropic tool block at index ${event.index} cannot receive ` +
-                event.delta.type,
+              `Anthropic tool block at index ${index} cannot receive ` +
+                deltaType,
             );
           }
 
-          activeBlocks.set(event.index, {
+          const partialJson = delta['partial_json'];
+          if (typeof partialJson !== 'string') {
+            throw new Error(
+              `Anthropic input_json_delta at index ${index} has ` +
+                'non-string partial_json',
+            );
+          }
+
+          activeBlocks.set(index, {
             ...block,
             receivedDelta: true,
           });
           yield {
             type: EventType.TOOL_CALL_ARGS,
             toolCallId: block.id,
-            delta: event.delta.partial_json,
+            delta: partialJson,
           };
           if (options.signal?.aborted) {
             return;
@@ -219,32 +417,25 @@ export async function* mapAnthropicEvents(
         }
 
         case 'content_block_stop': {
-          const block = activeBlocks.get(event.index);
+          const index = readContentIndex(event);
+          const block = activeBlocks.get(index);
           if (!block) {
             throw new Error(
               'Anthropic content_block_stop references unknown or stopped ' +
-                `index ${event.index}`,
+                `index ${index}`,
             );
           }
 
-          activeBlocks.delete(event.index);
+          activeBlocks.delete(index);
           if (block.kind === 'text') {
             break;
           }
 
           if (!block.receivedDelta) {
-            const initialInput = JSON.stringify(block.initialInput);
-            if (initialInput === undefined) {
-              throw new Error(
-                `Anthropic tool block at index ${event.index} has ` +
-                  'non-serializable initial input',
-              );
-            }
-
             yield {
               type: EventType.TOOL_CALL_ARGS,
               toolCallId: block.id,
-              delta: initialInput,
+              delta: serializeInitialInput(block, index),
             };
             if (options.signal?.aborted) {
               return;
@@ -299,9 +490,12 @@ export async function* mapAnthropicEvents(
     if (!messageStopped) {
       throw new Error('Anthropic stream ended before message_stop');
     }
+  } catch (error) {
+    hasPrimaryError = true;
+    throw error;
   } finally {
     if (!sourceCompleted) {
-      await iterator.return?.();
+      await closeIterator(iterator, hasPrimaryError);
     }
   }
 }

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -29,6 +29,13 @@ function formatDiagnosticValue(value: unknown): string {
   }
 }
 
+function assertNever(value: never): never {
+  throw new Error(
+    'Anthropic stream received an unhandled event ' +
+      formatDiagnosticValue(value),
+  );
+}
+
 function isRawEventType(value: unknown): value is RawEvent['type'] {
   return (
     value === 'message_start' ||
@@ -483,6 +490,9 @@ export async function* mapAnthropicEvents(
             }
           }
           break;
+
+        default:
+          assertNever(event);
       }
     }
 

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -26,12 +26,39 @@ interface RedactedThinkingBlockState {
   readonly messageId: string;
 }
 
+interface ServerToolBlockState {
+  readonly kind: 'server_tool';
+}
+
+type RawTerminalBlockType =
+  | 'web_search_tool_result'
+  | 'web_fetch_tool_result'
+  | 'code_execution_tool_result'
+  | 'bash_code_execution_tool_result'
+  | 'text_editor_code_execution_tool_result'
+  | 'tool_search_tool_result'
+  | 'container_upload';
+
+interface RawTerminalBlockState {
+  readonly kind: 'raw_terminal';
+  readonly nativeType: RawTerminalBlockType;
+}
+
 type ContentBlockState =
   | TextBlockState
   | ToolBlockState
   | ThinkingBlockState
-  | RedactedThinkingBlockState;
+  | RedactedThinkingBlockState
+  | ServerToolBlockState
+  | RawTerminalBlockState;
 type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+type NativeContentBlock =
+  Anthropic.Messages.RawContentBlockStartEvent['content_block'];
+type NativeContentDelta = Anthropic.Messages.RawContentBlockDeltaEvent['delta'];
+type RawTerminalBlock = Extract<
+  NativeContentBlock,
+  { type: RawTerminalBlockType }
+>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -49,6 +76,108 @@ function assertNever(value: never): never {
   throw new Error(
     'Anthropic stream received an unhandled event ' +
       formatDiagnosticValue(value),
+  );
+}
+
+function assertUnsupportedContentBlock(value: never, index: number): never {
+  const record = value as unknown as Record<string, unknown>;
+  throw new Error(
+    `Anthropic content block at index ${index} has unsupported type ` +
+      formatDiagnosticValue(record['type']),
+  );
+}
+
+function assertUnsupportedContentDelta(value: never, index: number): never {
+  const record = value as unknown as Record<string, unknown>;
+  throw new Error(
+    `Anthropic content delta at index ${index} has unsupported type ` +
+      formatDiagnosticValue(record['type']),
+  );
+}
+
+function readContentBlock(
+  event: Anthropic.Messages.RawContentBlockStartEvent,
+  index: number,
+): NativeContentBlock {
+  const eventRecord = event as unknown as Record<string, unknown>;
+  if (!isRecord(eventRecord['content_block'])) {
+    throw new Error(
+      `Anthropic content block at index ${index} must be an object`,
+    );
+  }
+
+  const contentBlock = event.content_block;
+  switch (contentBlock.type) {
+    case 'text':
+    case 'tool_use':
+    case 'thinking':
+    case 'redacted_thinking':
+    case 'server_tool_use':
+    case 'web_search_tool_result':
+    case 'web_fetch_tool_result':
+    case 'code_execution_tool_result':
+    case 'bash_code_execution_tool_result':
+    case 'text_editor_code_execution_tool_result':
+    case 'tool_search_tool_result':
+    case 'container_upload':
+      return contentBlock;
+    default:
+      return assertUnsupportedContentBlock(contentBlock, index);
+  }
+}
+
+function readContentDelta(
+  event: Anthropic.Messages.RawContentBlockDeltaEvent,
+  index: number,
+): NativeContentDelta {
+  const eventRecord = event as unknown as Record<string, unknown>;
+  if (!isRecord(eventRecord['delta'])) {
+    throw new Error(
+      `Anthropic content delta at index ${index} must be an object`,
+    );
+  }
+
+  const delta = event.delta;
+  switch (delta.type) {
+    case 'text_delta':
+    case 'input_json_delta':
+    case 'citations_delta':
+    case 'thinking_delta':
+    case 'signature_delta':
+      return delta;
+    default:
+      return assertUnsupportedContentDelta(delta, index);
+  }
+}
+
+function rawEvent(event: RawEvent): AGUIEvent {
+  let clonedEvent: RawEvent;
+  try {
+    clonedEvent = structuredClone(event);
+  } catch (cause) {
+    const error = new Error('Failed to clone Anthropic native stream event');
+    Object.defineProperty(error, 'cause', { configurable: true, value: cause });
+    throw error;
+  }
+
+  return {
+    type: EventType.RAW,
+    source: 'anthropic',
+    event: clonedEvent,
+  };
+}
+
+function isRawTerminalBlock(
+  value: NativeContentBlock,
+): value is RawTerminalBlock {
+  return (
+    value.type === 'web_search_tool_result' ||
+    value.type === 'web_fetch_tool_result' ||
+    value.type === 'code_execution_tool_result' ||
+    value.type === 'bash_code_execution_tool_result' ||
+    value.type === 'text_editor_code_execution_tool_result' ||
+    value.type === 'tool_search_tool_result' ||
+    value.type === 'container_upload'
   );
 }
 
@@ -248,26 +377,8 @@ export async function* mapAnthropicEvents(
             );
           }
 
-          const eventRecord = event as unknown as Record<string, unknown>;
-          const contentBlock = eventRecord['content_block'];
-          if (!isRecord(contentBlock)) {
-            throw new Error(
-              `Anthropic content block at index ${index} must be an object`,
-            );
-          }
-
-          const blockType = contentBlock['type'];
-          if (
-            blockType !== 'text' &&
-            blockType !== 'tool_use' &&
-            blockType !== 'thinking' &&
-            blockType !== 'redacted_thinking'
-          ) {
-            throw new Error(
-              `Anthropic content block at index ${index} has unsupported type ` +
-                formatDiagnosticValue(blockType),
-            );
-          }
+          const contentBlock = readContentBlock(event, index);
+          const blockType = contentBlock.type;
 
           seenIndexes.add(index);
           if (blockType === 'thinking' || blockType === 'redacted_thinking') {
@@ -372,27 +483,56 @@ export async function* mapAnthropicEvents(
 
             nativeTextBlockStarted = true;
             activeBlocks.set(index, { kind: 'text' });
-            if (text.length === 0) {
-              break;
-            }
+            if (text.length > 0) {
+              if (!textStarted) {
+                textStarted = true;
+                yield {
+                  type: EventType.TEXT_MESSAGE_START,
+                  messageId: options.messageId,
+                  role: 'assistant',
+                };
+                if (options.signal?.aborted) {
+                  return;
+                }
+              }
 
-            if (!textStarted) {
-              textStarted = true;
               yield {
-                type: EventType.TEXT_MESSAGE_START,
+                type: EventType.TEXT_MESSAGE_CONTENT,
                 messageId: options.messageId,
-                role: 'assistant',
+                delta: text,
               };
               if (options.signal?.aborted) {
                 return;
               }
             }
 
-            yield {
-              type: EventType.TEXT_MESSAGE_CONTENT,
-              messageId: options.messageId,
-              delta: text,
-            };
+            if (
+              Array.isArray(contentBlock.citations) &&
+              contentBlock.citations.length > 0
+            ) {
+              yield rawEvent(event);
+              if (options.signal?.aborted) {
+                return;
+              }
+            }
+            break;
+          }
+
+          if (blockType === 'server_tool_use') {
+            activeBlocks.set(index, { kind: 'server_tool' });
+            yield rawEvent(event);
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (isRawTerminalBlock(contentBlock)) {
+            activeBlocks.set(index, {
+              kind: 'raw_terminal',
+              nativeType: contentBlock.type,
+            });
+            yield rawEvent(event);
             if (options.signal?.aborted) {
               return;
             }
@@ -458,28 +598,18 @@ export async function* mapAnthropicEvents(
             );
           }
 
-          const eventRecord = event as unknown as Record<string, unknown>;
-          const delta = eventRecord['delta'];
-          if (!isRecord(delta)) {
-            throw new Error(
-              `Anthropic content delta at index ${index} must be an object`,
-            );
-          }
-
-          const deltaType = delta['type'];
-          if (
-            deltaType !== 'text_delta' &&
-            deltaType !== 'input_json_delta' &&
-            deltaType !== 'thinking_delta' &&
-            deltaType !== 'signature_delta'
-          ) {
-            throw new Error(
-              `Anthropic content delta at index ${index} has unsupported type ` +
-                formatDiagnosticValue(deltaType),
-            );
-          }
+          const delta = readContentDelta(event, index);
+          const deltaType = delta.type;
 
           if (block.kind === 'text') {
+            if (deltaType === 'citations_delta') {
+              yield rawEvent(event);
+              if (options.signal?.aborted) {
+                return;
+              }
+              break;
+            }
+
             if (deltaType !== 'text_delta') {
               throw new Error(
                 `Anthropic text block at index ${index} cannot receive ` +
@@ -549,6 +679,36 @@ export async function* mapAnthropicEvents(
               return;
             }
             break;
+          }
+
+          if (block.kind === 'server_tool') {
+            if (deltaType !== 'input_json_delta') {
+              throw new Error(
+                `Anthropic server_tool_use block at index ${index} cannot ` +
+                  `receive ${deltaType}`,
+              );
+            }
+
+            const partialJson = delta['partial_json'];
+            if (typeof partialJson !== 'string') {
+              throw new Error(
+                `Anthropic input_json_delta at index ${index} has ` +
+                  'non-string partial_json',
+              );
+            }
+
+            yield rawEvent(event);
+            if (options.signal?.aborted) {
+              return;
+            }
+            break;
+          }
+
+          if (block.kind === 'raw_terminal') {
+            throw new Error(
+              `Anthropic ${block.nativeType} block at index ${index} cannot ` +
+                `receive ${deltaType}`,
+            );
           }
 
           if (block.kind === 'redacted_thinking') {
@@ -621,6 +781,14 @@ export async function* mapAnthropicEvents(
 
           activeBlocks.delete(index);
           if (block.kind === 'text') {
+            break;
+          }
+
+          if (block.kind === 'server_tool' || block.kind === 'raw_terminal') {
+            yield rawEvent(event);
+            if (options.signal?.aborted) {
+              return;
+            }
             break;
           }
 

--- a/packages/anthropic/src/stream/anthropic-events.ts
+++ b/packages/anthropic/src/stream/anthropic-events.ts
@@ -93,6 +93,11 @@ async function nextWithCancellation(
 
   try {
     return await Promise.race([nextPromise, abortPromise]);
+  } catch (error) {
+    if (signal.aborted) {
+      return ABORTED;
+    }
+    throw error;
   } finally {
     signal.removeEventListener('abort', handleAbort);
   }

--- a/packages/anthropic/src/stream/anthropic-raw-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-raw-events.spec.ts
@@ -1,0 +1,414 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import { mapAnthropicEvents } from './anthropic-events';
+import {
+  collectEvents,
+  contentStop,
+  deepFreeze,
+  messageStart,
+  messageStop,
+  rawEvent,
+  type RawEvent,
+  toAsyncIterable,
+} from './anthropic-events.test-utils';
+
+const RAW_TERMINAL_BLOCK_TYPES = [
+  'web_search_tool_result',
+  'web_fetch_tool_result',
+  'code_execution_tool_result',
+  'bash_code_execution_tool_result',
+  'text_editor_code_execution_tool_result',
+  'tool_search_tool_result',
+  'container_upload',
+] as const;
+
+type RawTerminalBlockType = (typeof RAW_TERMINAL_BLOCK_TYPES)[number];
+
+function textStartWithCitations(index: number, text: string): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: 'text',
+      text,
+      citations: [
+        {
+          type: 'char_location',
+          cited_text: 'source',
+          document_index: 0,
+          document_title: 'Reference',
+          start_char_index: 0,
+          end_char_index: 6,
+        },
+      ],
+    },
+  });
+}
+
+function citationsDelta(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: {
+      type: 'citations_delta',
+      citation: {
+        type: 'char_location',
+        cited_text: 'source',
+        document_index: 0,
+        document_title: 'Reference',
+        start_char_index: 0,
+        end_char_index: 6,
+      },
+    },
+  });
+}
+
+function textDelta(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'text_delta', text: 'text' },
+  });
+}
+
+function inputJsonDelta(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'input_json_delta', partial_json: '{"query":"test"}' },
+  });
+}
+
+function thinkingDelta(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'thinking_delta', thinking: 'thinking' },
+  });
+}
+
+function signatureDelta(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'signature_delta', signature: 'signature' },
+  });
+}
+
+function serverToolStart(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: 'server_tool_use',
+      id: `server-tool-${index}`,
+      name: 'web_search',
+      input: {},
+      caller: { type: 'direct' },
+    },
+  });
+}
+
+function clientToolStart(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: 'tool_use',
+      id: `client-tool-${index}`,
+      name: 'search',
+      input: {},
+      caller: { type: 'direct' },
+    },
+  });
+}
+
+function thinkingStart(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: 'thinking',
+      thinking: '',
+      signature: 'initial-signature',
+    },
+  });
+}
+
+function redactedThinkingStart(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'redacted_thinking', data: 'redacted-data' },
+  });
+}
+
+function terminalBlockStart(
+  index: number,
+  blockType: RawTerminalBlockType,
+): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: blockType,
+      tool_use_id: `server-tool-${index}`,
+      file_id: `file-${index}`,
+      content: { type: 'fixture-result', nested: { value: 'original' } },
+    },
+  });
+}
+
+function rawAGUIEvent(event: RawEvent): AGUIEvent {
+  return {
+    type: EventType.RAW,
+    source: 'anthropic',
+    event: structuredClone(event),
+  };
+}
+
+test('emits canonical text before a raw citation-bearing start frame', async () => {
+  const start = textStartWithCitations(0, 'Hello');
+  const events = [messageStart(), start, contentStop(0), messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'assistant-message-1',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'assistant-message-1',
+      delta: 'Hello',
+    },
+    rawAGUIEvent(start),
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'assistant-message-1',
+    },
+  ]);
+});
+
+test('emits citation deltas as raw events at their native position', async () => {
+  const start = rawEvent({
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'text', text: '', citations: null },
+  });
+  const delta = citationsDelta(0);
+  const events = [messageStart(), start, delta, contentStop(0), messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([rawAGUIEvent(delta)]);
+});
+
+test('emits a citation-bearing start even when its initial text is empty', async () => {
+  const start = textStartWithCitations(0, '');
+  const events = [messageStart(), start, contentStop(0), messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([rawAGUIEvent(start)]);
+});
+
+test('emits every server tool frame as raw without entering the client tool loop', async () => {
+  const start = serverToolStart(0);
+  const delta = inputJsonDelta(0);
+  const stop = contentStop(0);
+  const events = [messageStart(), start, delta, stop, messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    rawAGUIEvent(start),
+    rawAGUIEvent(delta),
+    rawAGUIEvent(stop),
+  ]);
+  expect(result).not.toContainEqual(
+    expect.objectContaining({ type: EventType.TOOL_CALL_START }),
+  );
+});
+
+test('emits start and stop raw frames for every native result and upload block', async () => {
+  const nativeFrames = RAW_TERMINAL_BLOCK_TYPES.flatMap((blockType, index) => [
+    terminalBlockStart(index, blockType),
+    contentStop(index),
+  ]);
+  const events = [messageStart(), ...nativeFrames, messageStop()];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual(nativeFrames.map(rawAGUIEvent));
+});
+
+test('raw events own deep clones of their native fixtures', async () => {
+  const start = terminalBlockStart(0, 'code_execution_tool_result');
+  const events = [messageStart(), start, contentStop(0), messageStop()];
+
+  const result: AGUIEvent[] = [];
+  for await (const event of mapAnthropicEvents({
+    events: toAsyncIterable(events),
+    messageId: 'assistant-message-1',
+  })) {
+    result.push(event);
+  }
+  const raw = result[0] as Extract<AGUIEvent, { type: EventType.RAW }>;
+  const sourceContent = (
+    start as unknown as {
+      content_block: { content: { nested: { value: string } } };
+    }
+  ).content_block.content;
+  sourceContent.nested.value = 'mutated';
+
+  expect(raw.event).not.toBe(start);
+  expect(
+    (
+      raw.event as {
+        content_block: { content: { nested: { value: string } } };
+      }
+    ).content_block.content.nested.value,
+  ).toBe('original');
+});
+
+test('raw mapping never mutates frozen native fixtures', async () => {
+  const start = terminalBlockStart(0, 'code_execution_tool_result');
+  const events = [messageStart(), start, contentStop(0), messageStop()];
+  deepFreeze(events);
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([rawAGUIEvent(start), rawAGUIEvent(contentStop(0))]);
+});
+
+test('wraps native event clone failures with context', async () => {
+  const start = rawEvent({
+    type: 'content_block_start',
+    index: 0,
+    content_block: {
+      type: 'server_tool_use',
+      id: 'server-tool-0',
+      name: 'web_search',
+      input: { callback: () => undefined },
+      caller: { type: 'direct' },
+    },
+  });
+
+  const act = collectEvents([messageStart(), start]);
+
+  await expect(act).rejects.toMatchObject({
+    message: 'Failed to clone Anthropic native stream event',
+    cause: expect.objectContaining({ name: 'DataCloneError' }),
+  });
+});
+
+test('rejects future unknown content blocks and deltas explicitly', async () => {
+  const unknownBlock = rawEvent({
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'future_block' },
+  });
+  const unknownDelta = rawEvent({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'future_delta' },
+  });
+
+  await expect(collectEvents([messageStart(), unknownBlock])).rejects.toThrow(
+    'Anthropic content block at index 0 has unsupported type "future_block"',
+  );
+  await expect(
+    collectEvents([messageStart(), serverToolStart(0), unknownDelta]),
+  ).rejects.toThrow(
+    'Anthropic content delta at index 0 has unsupported type "future_delta"',
+  );
+});
+
+test('accepts citations only on text blocks', async () => {
+  const starts = [
+    clientToolStart(0),
+    serverToolStart(0),
+    thinkingStart(0),
+    redactedThinkingStart(0),
+  ];
+  const blockTypes = [
+    'tool',
+    'server_tool_use',
+    'thinking',
+    'redacted_thinking',
+  ];
+
+  for (const [index, start] of starts.entries()) {
+    await expect(
+      collectEvents([messageStart(), start, citationsDelta(0)]),
+    ).rejects.toThrow(
+      `Anthropic ${blockTypes[index]} block at index 0 cannot receive citations_delta`,
+    );
+  }
+});
+
+test('server tool blocks accept only JSON input deltas', async () => {
+  const rejectedDeltas = [
+    ['text_delta', textDelta(0)],
+    ['citations_delta', citationsDelta(0)],
+    ['thinking_delta', thinkingDelta(0)],
+    ['signature_delta', signatureDelta(0)],
+  ] as const;
+
+  for (const [deltaType, delta] of rejectedDeltas) {
+    await expect(
+      collectEvents([messageStart(), serverToolStart(0), delta]),
+    ).rejects.toThrow(
+      `Anthropic server_tool_use block at index 0 cannot receive ${deltaType}`,
+    );
+  }
+});
+
+test('result and upload blocks reject every native delta type', async () => {
+  const deltas = [
+    ['text_delta', textDelta(0)],
+    ['input_json_delta', inputJsonDelta(0)],
+    ['citations_delta', citationsDelta(0)],
+    ['thinking_delta', thinkingDelta(0)],
+    ['signature_delta', signatureDelta(0)],
+  ] as const;
+
+  for (const blockType of RAW_TERMINAL_BLOCK_TYPES) {
+    for (const [deltaType, delta] of deltas) {
+      await expect(
+        collectEvents([
+          messageStart(),
+          terminalBlockStart(0, blockType),
+          delta,
+        ]),
+      ).rejects.toThrow(
+        `Anthropic ${blockType} block at index 0 cannot receive ${deltaType}`,
+      );
+    }
+  }
+});
+
+test('cancellation after a raw frame does not synthesize later raw frames', async () => {
+  const controller = new AbortController();
+  const start = serverToolStart(0);
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      start,
+      inputJsonDelta(0),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const first = await iterator.next();
+  controller.abort();
+  const next = await iterator.next();
+
+  expect(EventSchemas.parse(first.value)).toEqual(rawAGUIEvent(start));
+  expect(next).toEqual({ done: true, value: undefined });
+});

--- a/packages/anthropic/src/stream/anthropic-reasoning-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-reasoning-events.spec.ts
@@ -1,0 +1,813 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+import { mapAnthropicEvents } from './anthropic-events';
+
+type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+
+function rawEvent(value: unknown): RawEvent {
+  return value as RawEvent;
+}
+
+function messageStart(): RawEvent {
+  return rawEvent({ type: 'message_start' });
+}
+
+function messageDelta(): RawEvent {
+  return rawEvent({ type: 'message_delta' });
+}
+
+function messageStop(): RawEvent {
+  return rawEvent({ type: 'message_stop' });
+}
+
+function thinkingStart(
+  index: number,
+  thinking = '',
+  signature = 'initial-signature',
+): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'thinking', thinking, signature },
+  });
+}
+
+function redactedThinkingStart(
+  index: number,
+  data = 'redacted-data',
+): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'redacted_thinking', data },
+  });
+}
+
+function thinkingDelta(index: number, thinking: string): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'thinking_delta', thinking },
+  });
+}
+
+function signatureDelta(index: number, signature: string): RawEvent {
+  return rawEvent({
+    type: 'content_block_delta',
+    index,
+    delta: { type: 'signature_delta', signature },
+  });
+}
+
+function textStart(index: number, text: string): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'text', text },
+  });
+}
+
+function toolStart(index: number): RawEvent {
+  return rawEvent({
+    type: 'content_block_start',
+    index,
+    content_block: {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'search',
+      input: {},
+    },
+  });
+}
+
+function contentStop(index: number): RawEvent {
+  return rawEvent({ type: 'content_block_stop', index });
+}
+
+async function* toAsyncIterable(
+  events: readonly RawEvent[],
+): AsyncIterable<RawEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object') {
+    for (const nestedValue of Object.values(value)) {
+      deepFreeze(nestedValue);
+    }
+    Object.freeze(value);
+  }
+
+  return value;
+}
+
+async function collectEvents(
+  events: readonly RawEvent[],
+  signal?: AbortSignal,
+): Promise<AGUIEvent[]> {
+  const result: AGUIEvent[] = [];
+
+  for await (const event of mapAnthropicEvents({
+    events: toAsyncIterable(events),
+    messageId: 'assistant-message-1',
+    signal,
+  })) {
+    result.push(EventSchemas.parse(event));
+  }
+
+  return result;
+}
+
+function reasoningStartEvent(messageId: string, blockType: string): AGUIEvent {
+  return {
+    type: EventType.REASONING_MESSAGE_START,
+    messageId,
+    role: 'reasoning',
+    metadata: { anthropic: { blockType } },
+  };
+}
+
+function reasoningContentEvent(messageId: string, delta: string): AGUIEvent {
+  return {
+    type: EventType.REASONING_MESSAGE_CONTENT,
+    messageId,
+    delta,
+  };
+}
+
+function reasoningEncryptedEvent(
+  entityId: string,
+  encryptedValue: string,
+): AGUIEvent {
+  return {
+    type: EventType.REASONING_ENCRYPTED_VALUE,
+    subtype: 'message',
+    entityId,
+    encryptedValue,
+  };
+}
+
+function reasoningEndEvent(messageId: string): AGUIEvent {
+  return { type: EventType.REASONING_MESSAGE_END, messageId };
+}
+
+test('maps initial thinking and thinking deltas in arrival order', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, 'Initial'),
+    thinkingDelta(0, ' delta'),
+    thinkingDelta(0, '!'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', 'Initial'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', ' delta'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', '!'),
+    reasoningEncryptedEvent(
+      'assistant-message-1:reasoning:0',
+      'initial-signature',
+    ),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+  ]);
+});
+
+test('uses a signature delta instead of the initial signature', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, '', 'initial'),
+    signatureDelta(0, 'streamed-signature'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+    reasoningEncryptedEvent(
+      'assistant-message-1:reasoning:0',
+      'streamed-signature',
+    ),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+  ]);
+});
+
+test('rejects duplicate signature deltas', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, '', 'initial'),
+    signatureDelta(0, 'first'),
+    signatureDelta(0, 'second'),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic thinking block at index 0 received more than one signature_delta',
+  );
+});
+
+test('allows thinking deltas after signature deltas', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, 'Initial', 'initial'),
+    signatureDelta(0, 'first'),
+    thinkingDelta(0, ' later'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', 'Initial'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', ' later'),
+    reasoningEncryptedEvent('assistant-message-1:reasoning:0', 'first'),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+  ]);
+});
+
+test('uses the initial signature only when no signature deltas occur', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, '', 'initial'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+    reasoningEncryptedEvent('assistant-message-1:reasoning:0', 'initial'),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+  ]);
+});
+
+test('rejects an empty initial signature with no signature deltas', async () => {
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      thinkingStart(0, '', ''),
+      contentStop(0),
+    ]),
+    messageId: 'assistant-message-1',
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  const act = iterator.next();
+
+  expect(EventSchemas.parse(start.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+  );
+  await expect(act).rejects.toThrow(
+    'Anthropic thinking block at index 0 has an empty final signature',
+  );
+});
+
+test('rejects an empty signature assembled from signature deltas', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, '', 'initial'),
+    signatureDelta(0, ''),
+    contentStop(0),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic thinking block at index 0 has an empty final signature',
+  );
+});
+
+test('maps multiple reasoning blocks with stable IDs in source order', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(2, 'First', 'signature-1'),
+    contentStop(2),
+    thinkingStart(4, 'Second', 'signature-2'),
+    contentStop(4),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:2', 'thinking'),
+    reasoningContentEvent('assistant-message-1:reasoning:2', 'First'),
+    reasoningEncryptedEvent('assistant-message-1:reasoning:2', 'signature-1'),
+    reasoningEndEvent('assistant-message-1:reasoning:2'),
+    reasoningStartEvent('assistant-message-1:reasoning:4', 'thinking'),
+    reasoningContentEvent('assistant-message-1:reasoning:4', 'Second'),
+    reasoningEncryptedEvent('assistant-message-1:reasoning:4', 'signature-2'),
+    reasoningEndEvent('assistant-message-1:reasoning:4'),
+  ]);
+});
+
+test('maps redacted thinking through its native start-stop lifecycle', async () => {
+  const events = [
+    messageStart(),
+    redactedThinkingStart(0, 'encrypted-redacted-data'),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'redacted_thinking'),
+    reasoningEncryptedEvent(
+      'assistant-message-1:reasoning:0',
+      'encrypted-redacted-data',
+    ),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+  ]);
+});
+
+test('does not mutate frozen reasoning source events', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, 'Initial', 'signature'),
+    thinkingDelta(0, ' delta'),
+    signatureDelta(0, '-updated'),
+    contentStop(0),
+    redactedThinkingStart(1, 'encrypted'),
+    contentStop(1),
+    messageStop(),
+  ];
+  const eventSnapshot = structuredClone(events);
+
+  await collectEvents(deepFreeze(events));
+
+  expect(events).toEqual(eventSnapshot);
+});
+
+test('maps reasoning before a client tool block', async () => {
+  const events = [
+    messageStart(),
+    thinkingStart(0, 'Plan', 'signature'),
+    contentStop(0),
+    toolStart(1),
+    contentStop(1),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+    reasoningContentEvent('assistant-message-1:reasoning:0', 'Plan'),
+    reasoningEncryptedEvent('assistant-message-1:reasoning:0', 'signature'),
+    reasoningEndEvent('assistant-message-1:reasoning:0'),
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'tool-1',
+      toolCallName: 'search',
+      parentMessageId: 'assistant-message-1',
+    },
+    { type: EventType.TOOL_CALL_ARGS, toolCallId: 'tool-1', delta: '{}' },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'tool-1' },
+  ]);
+});
+
+test('rejects reasoning starts after assistant text has begun', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, 'text'),
+    contentStop(0),
+    thinkingStart(1),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic reasoning block at index 1 cannot start after assistant text or a client tool block',
+  );
+});
+
+test('rejects reasoning starts after an empty native text block', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, ''),
+    contentStop(0),
+    thinkingStart(1),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic reasoning block at index 1 cannot start after assistant text or a client tool block',
+  );
+});
+
+test('does not emit AG-UI text events for an empty native text block', async () => {
+  const events = [
+    messageStart(),
+    textStart(0, ''),
+    contentStop(0),
+    messageStop(),
+  ];
+
+  const result = await collectEvents(events);
+
+  expect(result).toEqual([]);
+});
+
+test('rejects reasoning starts after a client tool block has begun', async () => {
+  const events = [
+    messageStart(),
+    toolStart(0),
+    contentStop(0),
+    redactedThinkingStart(1),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic reasoning block at index 1 cannot start after assistant text or a client tool block',
+  );
+});
+
+test('rejects thinking and signature deltas on text blocks', async () => {
+  const thinkingEvents = [
+    messageStart(),
+    textStart(0, ''),
+    thinkingDelta(0, 'wrong'),
+  ];
+  const signatureEvents = [
+    messageStart(),
+    textStart(0, ''),
+    signatureDelta(0, 'wrong'),
+  ];
+
+  await expect(collectEvents(thinkingEvents)).rejects.toThrow(
+    'Anthropic text block at index 0 cannot receive thinking_delta',
+  );
+  await expect(collectEvents(signatureEvents)).rejects.toThrow(
+    'Anthropic text block at index 0 cannot receive signature_delta',
+  );
+});
+
+test('rejects thinking and signature deltas on tool blocks', async () => {
+  const thinkingEvents = [
+    messageStart(),
+    toolStart(0),
+    thinkingDelta(0, 'wrong'),
+  ];
+  const signatureEvents = [
+    messageStart(),
+    toolStart(0),
+    signatureDelta(0, 'wrong'),
+  ];
+
+  await expect(collectEvents(thinkingEvents)).rejects.toThrow(
+    'Anthropic tool block at index 0 cannot receive thinking_delta',
+  );
+  await expect(collectEvents(signatureEvents)).rejects.toThrow(
+    'Anthropic tool block at index 0 cannot receive signature_delta',
+  );
+});
+
+test('rejects text and input deltas on thinking blocks', async () => {
+  const textEvents = [
+    messageStart(),
+    thinkingStart(0),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'wrong' },
+    }),
+  ];
+  const inputEvents = [
+    messageStart(),
+    thinkingStart(0),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{}' },
+    }),
+  ];
+
+  await expect(collectEvents(textEvents)).rejects.toThrow(
+    'Anthropic thinking block at index 0 cannot receive text_delta',
+  );
+  await expect(collectEvents(inputEvents)).rejects.toThrow(
+    'Anthropic thinking block at index 0 cannot receive input_json_delta',
+  );
+});
+
+test('rejects text and input deltas on redacted thinking blocks', async () => {
+  const textEvents = [
+    messageStart(),
+    redactedThinkingStart(0),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'wrong' },
+    }),
+  ];
+  const inputEvents = [
+    messageStart(),
+    redactedThinkingStart(0),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: '{}' },
+    }),
+  ];
+
+  await expect(collectEvents(textEvents)).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 cannot receive text_delta',
+  );
+  await expect(collectEvents(inputEvents)).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 cannot receive input_json_delta',
+  );
+});
+
+test('rejects thinking deltas on redacted thinking blocks', async () => {
+  const events = [
+    messageStart(),
+    redactedThinkingStart(0),
+    thinkingDelta(0, 'late'),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 cannot receive thinking_delta',
+  );
+});
+
+test('rejects signature deltas on redacted thinking blocks', async () => {
+  const events = [
+    messageStart(),
+    redactedThinkingStart(0),
+    signatureDelta(0, 'late'),
+  ];
+
+  const act = collectEvents(events);
+
+  await expect(act).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 cannot receive signature_delta',
+  );
+});
+
+test('rejects malformed reasoning starts', async () => {
+  const malformedEvents = [
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'thinking', signature: 'sig' },
+    }),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'thinking', thinking: '', signature: 42 },
+    }),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'redacted_thinking', data: '' },
+    }),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'redacted_thinking' },
+    }),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'redacted_thinking', data: 42 },
+    }),
+  ];
+
+  await expect(
+    collectEvents([messageStart(), malformedEvents[0]]),
+  ).rejects.toThrow(
+    'Anthropic thinking block at index 0 has non-string thinking',
+  );
+  await expect(
+    collectEvents([messageStart(), malformedEvents[1]]),
+  ).rejects.toThrow(
+    'Anthropic thinking block at index 0 has non-string signature',
+  );
+  await expect(
+    collectEvents([messageStart(), malformedEvents[2]]),
+  ).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 has empty data',
+  );
+  await expect(
+    collectEvents([messageStart(), malformedEvents[3]]),
+  ).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 has non-string data',
+  );
+  await expect(
+    collectEvents([messageStart(), malformedEvents[4]]),
+  ).rejects.toThrow(
+    'Anthropic redacted_thinking block at index 0 has non-string data',
+  );
+});
+
+test('rejects malformed reasoning deltas', async () => {
+  const malformedThinkingDelta = rawEvent({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'thinking_delta', thinking: 42 },
+  });
+  const malformedSignatureDelta = rawEvent({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'signature_delta', signature: 42 },
+  });
+
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0), malformedThinkingDelta]),
+  ).rejects.toThrow(
+    'Anthropic thinking_delta at index 0 has non-string thinking',
+  );
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0), malformedSignatureDelta]),
+  ).rejects.toThrow(
+    'Anthropic signature_delta at index 0 has non-string signature',
+  );
+});
+
+test('rejects duplicate, stopped, and unknown reasoning lifecycles', async () => {
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0), thinkingStart(0)]),
+  ).rejects.toThrow('Anthropic content index 0 started more than once');
+  await expect(
+    collectEvents([
+      messageStart(),
+      thinkingStart(0),
+      contentStop(0),
+      signatureDelta(0, 'late'),
+    ]),
+  ).rejects.toThrow(
+    'Anthropic content_block_delta references unknown or stopped index 0',
+  );
+  await expect(
+    collectEvents([
+      messageStart(),
+      thinkingStart(0),
+      contentStop(0),
+      contentStop(0),
+    ]),
+  ).rejects.toThrow(
+    'Anthropic content_block_stop references unknown or stopped index 0',
+  );
+  await expect(collectEvents([messageStart(), contentStop(3)])).rejects.toThrow(
+    'Anthropic content_block_stop references unknown or stopped index 3',
+  );
+});
+
+test('rejects message lifecycle events and source exhaustion with active reasoning blocks', async () => {
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0), messageDelta()]),
+  ).rejects.toThrow(
+    'Anthropic message_delta received while content blocks are open',
+  );
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0), messageStop()]),
+  ).rejects.toThrow(
+    'Anthropic message_stop received while content blocks are open',
+  );
+  await expect(
+    collectEvents([messageStart(), thinkingStart(0)]),
+  ).rejects.toThrow('Anthropic stream ended with open content blocks');
+});
+
+test('does not synthesize reasoning events after cancellation following reasoning start', async () => {
+  const controller = new AbortController();
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      thinkingStart(0, 'Initial'),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const first = await iterator.next();
+  controller.abort();
+  const second = await iterator.next();
+
+  expect(EventSchemas.parse(first.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+  );
+  expect(second).toEqual({ done: true, value: undefined });
+});
+
+test('does not synthesize reasoning end after cancellation following reasoning content', async () => {
+  const controller = new AbortController();
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      thinkingStart(0, 'Initial'),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  const content = await iterator.next();
+  controller.abort();
+  const next = await iterator.next();
+
+  expect(EventSchemas.parse(start.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+  );
+  expect(EventSchemas.parse(content.value)).toEqual(
+    reasoningContentEvent('assistant-message-1:reasoning:0', 'Initial'),
+  );
+  expect(next).toEqual({ done: true, value: undefined });
+});
+
+test('does not synthesize encrypted or end events after cancellation following a redacted reasoning start', async () => {
+  const controller = new AbortController();
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      redactedThinkingStart(0, 'encrypted'),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  controller.abort();
+  const next = await iterator.next();
+
+  expect(EventSchemas.parse(start.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'redacted_thinking'),
+  );
+  expect(next).toEqual({ done: true, value: undefined });
+});
+
+test('does not synthesize reasoning end after cancellation following encrypted redacted thinking', async () => {
+  const controller = new AbortController();
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      redactedThinkingStart(0, 'encrypted'),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  const encrypted = await iterator.next();
+  controller.abort();
+  const next = await iterator.next();
+
+  expect(EventSchemas.parse(start.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'redacted_thinking'),
+  );
+  expect(EventSchemas.parse(encrypted.value)).toEqual(
+    reasoningEncryptedEvent('assistant-message-1:reasoning:0', 'encrypted'),
+  );
+  expect(next).toEqual({ done: true, value: undefined });
+});
+
+test('does not synthesize reasoning end after cancellation following a thinking encrypted value', async () => {
+  const controller = new AbortController();
+  const iterator = mapAnthropicEvents({
+    events: toAsyncIterable([
+      messageStart(),
+      thinkingStart(0, '', 'signature'),
+      contentStop(0),
+      messageStop(),
+    ]),
+    messageId: 'assistant-message-1',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  const start = await iterator.next();
+  const encrypted = await iterator.next();
+  controller.abort();
+  const next = await iterator.next();
+
+  expect(EventSchemas.parse(start.value)).toEqual(
+    reasoningStartEvent('assistant-message-1:reasoning:0', 'thinking'),
+  );
+  expect(EventSchemas.parse(encrypted.value)).toEqual(
+    reasoningEncryptedEvent('assistant-message-1:reasoning:0', 'signature'),
+  );
+  expect(next).toEqual({ done: true, value: undefined });
+});

--- a/packages/anthropic/src/stream/anthropic-reasoning-events.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-reasoning-events.spec.ts
@@ -1,24 +1,16 @@
 import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
-import Anthropic from '@anthropic-ai/sdk';
 import { mapAnthropicEvents } from './anthropic-events';
-
-type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
-
-function rawEvent(value: unknown): RawEvent {
-  return value as RawEvent;
-}
-
-function messageStart(): RawEvent {
-  return rawEvent({ type: 'message_start' });
-}
-
-function messageDelta(): RawEvent {
-  return rawEvent({ type: 'message_delta' });
-}
-
-function messageStop(): RawEvent {
-  return rawEvent({ type: 'message_stop' });
-}
+import {
+  collectEvents,
+  contentStop,
+  deepFreeze,
+  messageDelta,
+  messageStart,
+  messageStop,
+  rawEvent,
+  type RawEvent,
+  toAsyncIterable,
+} from './anthropic-events.test-utils';
 
 function thinkingStart(
   index: number,
@@ -78,46 +70,6 @@ function toolStart(index: number): RawEvent {
       input: {},
     },
   });
-}
-
-function contentStop(index: number): RawEvent {
-  return rawEvent({ type: 'content_block_stop', index });
-}
-
-async function* toAsyncIterable(
-  events: readonly RawEvent[],
-): AsyncIterable<RawEvent> {
-  for (const event of events) {
-    yield event;
-  }
-}
-
-function deepFreeze<T>(value: T): T {
-  if (value !== null && typeof value === 'object') {
-    for (const nestedValue of Object.values(value)) {
-      deepFreeze(nestedValue);
-    }
-    Object.freeze(value);
-  }
-
-  return value;
-}
-
-async function collectEvents(
-  events: readonly RawEvent[],
-  signal?: AbortSignal,
-): Promise<AGUIEvent[]> {
-  const result: AGUIEvent[] = [];
-
-  for await (const event of mapAnthropicEvents({
-    events: toAsyncIterable(events),
-    messageId: 'assistant-message-1',
-    signal,
-  })) {
-    result.push(EventSchemas.parse(event));
-  }
-
-  return result;
 }
 
 function reasoningStartEvent(messageId: string, blockType: string): AGUIEvent {

--- a/packages/anthropic/src/stream/anthropic-request-reasoning.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-request-reasoning.spec.ts
@@ -1,0 +1,209 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { createAnthropicRequestOptions } from './anthropic-request';
+
+type TestRunAgentInput = RunAgentInput & {
+  hashbrown?: {
+    responseSchema?: object;
+    ui?: boolean;
+  };
+};
+
+function createInput(
+  overrides: Partial<TestRunAgentInput> = {},
+): TestRunAgentInput {
+  return {
+    threadId: 'thread-1',
+    runId: 'run-1',
+    state: {},
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+function createClaimedReasoning(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'reasoning-1',
+    role: 'reasoning' as const,
+    content: 'Visible reasoning.',
+    encryptedValue: 'encrypted-value',
+    metadata: { anthropic: { blockType: 'thinking' } },
+    ...overrides,
+  };
+}
+
+test('replays claimed Anthropic reasoning blocks before assistant text and tool use', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'neutral-reasoning',
+        role: 'reasoning',
+        content: 'Display only.',
+      },
+      {
+        id: 'other-provider-reasoning',
+        role: 'reasoning',
+        content: 'Other provider.',
+        encryptedValue: 'other-encrypted-value',
+        metadata: { openai: { blockType: 'reasoning' } },
+      },
+      createClaimedReasoning({
+        id: 'thinking-reasoning',
+        content: '',
+        encryptedValue: 'thinking-signature',
+      }),
+      createClaimedReasoning({
+        id: 'redacted-reasoning',
+        content: '',
+        encryptedValue: 'redacted-data',
+        metadata: { anthropic: { blockType: 'redacted_thinking' } },
+      }),
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'I will use a tool.',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"hashbrown"}' },
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: '', signature: 'thinking-signature' },
+        { type: 'redacted_thinking', data: 'redacted-data' },
+        { type: 'text', text: 'I will use a tool.' },
+        {
+          type: 'tool_use',
+          id: 'tool-call-1',
+          name: 'lookup',
+          input: { query: 'hashbrown' },
+        },
+      ],
+    },
+  ]);
+});
+
+test('uses only the maximal immediately preceding reasoning run for each assistant', () => {
+  const input = createInput({
+    messages: [
+      createClaimedReasoning({
+        id: 'orphaned-reasoning',
+        metadata: { anthropic: null },
+      }),
+      { id: 'user-1', role: 'user', content: 'Interrupt the reasoning run.' },
+      createClaimedReasoning({
+        id: 'attached-reasoning',
+        content: 'Attached reasoning.',
+        encryptedValue: 'attached-signature',
+      }),
+      { id: 'assistant-1', role: 'assistant', content: 'First answer.' },
+      createClaimedReasoning({
+        id: 'trailing-reasoning',
+        content: 'No following assistant.',
+      }),
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    { role: 'user', content: 'Interrupt the reasoning run.' },
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'thinking',
+          thinking: 'Attached reasoning.',
+          signature: 'attached-signature',
+        },
+        { type: 'text', text: 'First answer.' },
+      ],
+    },
+  ]);
+});
+
+test('rejects malformed claimed Anthropic reasoning markers', () => {
+  const invalidMarkers = [
+    null,
+    [],
+    'not-an-object',
+    {},
+    { blockType: 'unknown' },
+  ];
+
+  for (const marker of invalidMarkers) {
+    const input = createInput({
+      messages: [
+        createClaimedReasoning({ metadata: { anthropic: marker } }),
+        { id: 'assistant-1', role: 'assistant', content: 'Answer.' },
+      ],
+    });
+
+    const act = () => createAnthropicRequestOptions(input, 'claude-test');
+
+    expect(act).toThrow('Anthropic reasoning message "reasoning-1"');
+  }
+});
+
+test('rejects incomplete claimed Anthropic continuation blocks', () => {
+  const invalidReasoning = [
+    createClaimedReasoning({ content: 42 }),
+    createClaimedReasoning({ encryptedValue: undefined }),
+    createClaimedReasoning({ encryptedValue: 42 }),
+    createClaimedReasoning({ encryptedValue: '' }),
+    createClaimedReasoning({
+      content: 'Redacted content is not permitted.',
+      metadata: { anthropic: { blockType: 'redacted_thinking' } },
+    }),
+  ];
+
+  for (const reasoning of invalidReasoning) {
+    const input = createInput({
+      messages: [
+        reasoning,
+        { id: 'assistant-1', role: 'assistant', content: 'Answer.' },
+      ],
+    });
+
+    const act = () => createAnthropicRequestOptions(input, 'claude-test');
+
+    expect(act).toThrow('Anthropic reasoning message "reasoning-1"');
+  }
+});
+
+test('does not mutate claimed reasoning history', () => {
+  const input = createInput({
+    messages: [
+      createClaimedReasoning({
+        content: '',
+        encryptedValue: 'thinking-signature',
+      }),
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Answer.',
+      },
+    ],
+  });
+  const snapshot = structuredClone(input);
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(input).toEqual(snapshot);
+  expect(result.messages[0]).not.toBe(input.messages[1]);
+  expect((result.messages[0]?.content as unknown[])[0]).not.toBe(
+    input.messages[0],
+  );
+});

--- a/packages/anthropic/src/stream/anthropic-request.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-request.spec.ts
@@ -1,0 +1,429 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { createAnthropicRequestOptions } from './anthropic-request';
+
+type TestRunAgentInput = RunAgentInput & {
+  hashbrown?: {
+    responseSchema?: object;
+    ui?: boolean;
+  };
+};
+
+function createInput(
+  overrides: Partial<TestRunAgentInput> = {},
+): TestRunAgentInput {
+  return {
+    threadId: 'thread-1',
+    runId: 'run-1',
+    state: {},
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+test('creates fresh streaming options with the server-owned model', () => {
+  const input = createInput({
+    messages: [{ id: 'user-1', role: 'user', content: 'Hello, Claude.' }],
+    forwardedProps: { model: 'client-model' },
+  });
+
+  const result = createAnthropicRequestOptions(input, 'server-model');
+
+  expect(result).toEqual({
+    stream: true,
+    model: 'server-model',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: 'Hello, Claude.' }],
+  });
+  expect(result).not.toBe(input);
+});
+
+test('extracts system and developer messages in transcript order', () => {
+  const input = createInput({
+    messages: [
+      { id: 'system-1', role: 'system', content: 'System one.' },
+      { id: 'user-1', role: 'user', content: 'First question.' },
+      { id: 'developer-1', role: 'developer', content: 'Developer two.' },
+      { id: 'system-2', role: 'system', content: 'System three.' },
+      { id: 'user-2', role: 'user', content: 'Second question.' },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.system).toBe('System one.\n\nDeveloper two.\n\nSystem three.');
+  expect(result.messages).toEqual([
+    { role: 'user', content: 'First question.' },
+    { role: 'user', content: 'Second question.' },
+  ]);
+});
+
+test('omits the system field when the transcript has no instructions', () => {
+  const input = createInput();
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result).not.toHaveProperty('system');
+});
+
+test('rejects structured user content', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: [{ type: 'text', text: 'Structured text.' }],
+      },
+    ],
+  });
+
+  const act = () => createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(act).toThrow(
+    'Anthropic provider currently requires text user content',
+  );
+});
+
+test('maps assistant text and tool calls to Anthropic content blocks', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'I will use two tools.',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"hashbrown"}',
+            },
+          },
+          {
+            id: 'tool-call-2',
+            type: 'function',
+            function: { name: 'broken', arguments: '{not-json' },
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'I will use two tools.' },
+        {
+          type: 'tool_use',
+          id: 'tool-call-1',
+          name: 'lookup',
+          input: { query: 'hashbrown' },
+        },
+        {
+          type: 'tool_use',
+          id: 'tool-call-2',
+          name: 'broken',
+          input: '{not-json',
+        },
+      ],
+    },
+  ]);
+});
+
+test('keeps a tool-only assistant message valid', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{}' },
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool-call-1',
+          name: 'lookup',
+          input: {},
+        },
+      ],
+    },
+  ]);
+});
+
+test('keeps an empty assistant message valid', () => {
+  const input = createInput({
+    messages: [{ id: 'assistant-1', role: 'assistant' }],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([{ role: 'assistant', content: '' }]);
+});
+
+test('maps successful AG-UI tool messages to Anthropic tool results', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'tool-1',
+        role: 'tool',
+        toolCallId: 'tool-call-1',
+        content: '{"temperature":72}',
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'tool-call-1',
+          content: '{"temperature":72}',
+        },
+      ],
+    },
+  ]);
+});
+
+test('marks AG-UI tool errors as Anthropic tool result errors', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'tool-1',
+        role: 'tool',
+        toolCallId: 'tool-call-1',
+        content: 'Lookup failed.',
+        error: '',
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'tool-call-1',
+          content: 'Lookup failed.',
+          is_error: true,
+        },
+      ],
+    },
+  ]);
+});
+
+test('filters activity and reasoning messages', () => {
+  const input = createInput({
+    messages: [
+      {
+        id: 'activity-1',
+        role: 'activity',
+        activityType: 'progress',
+        content: { label: 'Working' },
+      },
+      {
+        id: 'reasoning-1',
+        role: 'reasoning',
+        content: 'Display-only reasoning.',
+      },
+      { id: 'user-1', role: 'user', content: 'Visible message.' },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.messages).toEqual([
+    { role: 'user', content: 'Visible message.' },
+  ]);
+});
+
+test('maps tools and supplies an empty object schema when parameters are absent', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: {
+      city: { type: 'string' },
+    },
+    required: ['city'],
+  };
+  const input = createInput({
+    tools: [
+      {
+        name: 'weather',
+        description: 'Get the weather.',
+        parameters: schema,
+      },
+      {
+        name: 'clock',
+        description: 'Get the time.',
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.tools).toEqual([
+    {
+      name: 'weather',
+      description: 'Get the weather.',
+      input_schema: schema,
+    },
+    {
+      name: 'clock',
+      description: 'Get the time.',
+      input_schema: { type: 'object', properties: {} },
+    },
+  ]);
+});
+
+test('rejects null, array, and non-object tool parameters', () => {
+  const invalidParameters = [null, [], 'not-a-schema'];
+
+  const actions = invalidParameters.map(
+    (parameters) => () =>
+      createAnthropicRequestOptions(
+        createInput({
+          tools: [
+            {
+              name: 'invalid',
+              description: 'Invalid tool.',
+              parameters,
+            },
+          ],
+        }),
+        'claude-test',
+      ),
+  );
+
+  for (const act of actions) {
+    expect(act).toThrow(
+      'Anthropic tool parameters must be a non-null, non-array object',
+    );
+  }
+});
+
+test('rejects tool parameters whose root type is not object', () => {
+  const input = createInput({
+    tools: [
+      {
+        name: 'invalid',
+        description: 'Invalid tool.',
+        parameters: { type: 'array', items: { type: 'string' } },
+      },
+    ],
+  });
+
+  const act = () => createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(act).toThrow('Anthropic tool parameters must have type "object"');
+});
+
+test('does not perform full JSON Schema validation', () => {
+  const minimallyValidSchema = {
+    type: 'object' as const,
+    properties: 'Anthropic accepts this field as unknown',
+    required: 42,
+  };
+  const input = createInput({
+    tools: [
+      {
+        name: 'minimal',
+        description: 'Minimally valid root schema.',
+        parameters: minimallyValidSchema,
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result.tools?.[0]?.input_schema).toBe(minimallyValidSchema);
+});
+
+test('ignores Hashbrown response metadata without adding hidden instructions', () => {
+  const responseSchema: Record<string, unknown> = {};
+  responseSchema['self'] = responseSchema;
+  const input = createInput({
+    hashbrown: { responseSchema, ui: true },
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(result).toEqual({
+    stream: true,
+    model: 'claude-test',
+    max_tokens: 4096,
+    messages: [],
+  });
+});
+
+test('does not mutate the input, messages, tool calls, schemas, or metadata', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: { query: { type: 'string' } },
+  };
+  const responseSchema = {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+  };
+  const input = createInput({
+    messages: [
+      { id: 'system-1', role: 'system', content: 'Be concise.' },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Looking it up.',
+        toolCalls: [
+          {
+            id: 'tool-call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"query":"value"}' },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Look up a value.',
+        parameters: schema,
+      },
+    ],
+    hashbrown: { responseSchema, ui: true },
+  });
+  const snapshot = structuredClone(input);
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(input).toEqual(snapshot);
+  expect(input.tools[0]?.parameters).toBe(schema);
+  expect(input.hashbrown?.responseSchema).toBe(responseSchema);
+  expect(result.messages).not.toBe(input.messages);
+  expect(result.messages[0]).not.toBe(input.messages[1]);
+  expect(result.tools).not.toBe(input.tools);
+  expect(result.tools?.[0]).not.toBe(input.tools[0]);
+});

--- a/packages/anthropic/src/stream/anthropic-request.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-request.spec.ts
@@ -322,7 +322,7 @@ test('rejects null, array, and non-object tool parameters', () => {
 
   for (const act of actions) {
     expect(act).toThrow(
-      'Anthropic tool parameters must be a non-null, non-array object',
+      'Anthropic tool "invalid" at index 0 parameters must be a non-null, non-array object',
     );
   }
 });
@@ -340,7 +340,9 @@ test('rejects tool parameters whose root type is not object', () => {
 
   const act = () => createAnthropicRequestOptions(input, 'claude-test');
 
-  expect(act).toThrow('Anthropic tool parameters must have type "object"');
+  expect(act).toThrow(
+    'Anthropic tool "invalid" at index 0 parameters must have type "object"',
+  );
 });
 
 test('does not perform full JSON Schema validation', () => {
@@ -361,7 +363,73 @@ test('does not perform full JSON Schema validation', () => {
 
   const result = createAnthropicRequestOptions(input, 'claude-test');
 
-  expect(result.tools?.[0]?.input_schema).toBe(minimallyValidSchema);
+  expect(result.tools?.[0]?.input_schema).toEqual(minimallyValidSchema);
+  expect(result.tools?.[0]?.input_schema).not.toBe(minimallyValidSchema);
+});
+
+test('isolates mapped tool schemas from later source mutations', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: { city: { type: 'string' } },
+  };
+  const input = createInput({
+    tools: [
+      {
+        name: 'weather',
+        description: 'Get the weather.',
+        parameters: schema,
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+  const mappedSchema = result.tools?.[0]?.input_schema as typeof schema;
+  schema.properties.city.type = 'number';
+
+  expect(mappedSchema.properties.city.type).toBe('string');
+});
+
+test('isolates source tool schemas from later request mutations', () => {
+  const schema = {
+    type: 'object' as const,
+    properties: { city: { type: 'string' } },
+  };
+  const input = createInput({
+    tools: [
+      {
+        name: 'weather',
+        description: 'Get the weather.',
+        parameters: schema,
+      },
+    ],
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+  const mappedSchema = result.tools?.[0]?.input_schema as typeof schema;
+  mappedSchema.properties.city.type = 'number';
+
+  expect(schema.properties.city.type).toBe('string');
+});
+
+test('identifies the tool when its parameters cannot be cloned', () => {
+  const input = createInput({
+    tools: [
+      {
+        name: 'unclonable',
+        description: 'Contains a non-cloneable schema value.',
+        parameters: {
+          type: 'object',
+          customKeyword: () => undefined,
+        },
+      },
+    ],
+  });
+
+  const act = () => createAnthropicRequestOptions(input, 'claude-test');
+
+  expect(act).toThrow(
+    'Failed to clone parameters for Anthropic tool "unclonable" at index 0',
+  );
 });
 
 test('ignores Hashbrown response metadata without adding hidden instructions', () => {

--- a/packages/anthropic/src/stream/anthropic-request.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-request.spec.ts
@@ -447,21 +447,67 @@ test('identifies the tool when its parameters cannot be cloned', () => {
   );
 });
 
-test('ignores Hashbrown response metadata without adding hidden instructions', () => {
-  const responseSchema: Record<string, unknown> = {};
-  responseSchema['self'] = responseSchema;
+test('maps Hashbrown response metadata to native JSON schema output without changing prompts or tools', () => {
+  const responseSchema = {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+    required: ['answer'],
+  };
   const input = createInput({
+    messages: [
+      { id: 'system-1', role: 'system', content: 'Be concise.' },
+      { id: 'user-1', role: 'user', content: 'Give an answer.' },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Look up an answer.',
+        parameters: { type: 'object', properties: {} },
+      },
+    ],
     hashbrown: { responseSchema, ui: true },
   });
 
   const result = createAnthropicRequestOptions(input, 'claude-test');
 
-  expect(result).toEqual({
-    stream: true,
-    model: 'claude-test',
-    max_tokens: 4096,
-    messages: [],
+  expect(result.output_config).toEqual({
+    format: { type: 'json_schema', schema: responseSchema },
   });
+  expect(result.system).toBe('Be concise.');
+  expect(result.messages).toEqual([
+    { role: 'user', content: 'Give an answer.' },
+  ]);
+  expect(result.tools).toHaveLength(1);
+});
+
+test('isolates the native response schema from result and source mutations', () => {
+  const responseSchema = {
+    type: 'object',
+    metadata: { source: 'input' },
+    properties: { answer: { type: 'string' } },
+  };
+  const input = createInput({
+    hashbrown: { responseSchema, ui: true },
+  });
+
+  const result = createAnthropicRequestOptions(input, 'claude-test');
+  const mappedSchema = result.output_config?.format
+    ?.schema as typeof responseSchema;
+
+  expect(mappedSchema).toBeDefined();
+  if (!mappedSchema) {
+    return;
+  }
+
+  mappedSchema.properties.answer.type = 'number';
+  mappedSchema.metadata.source = 'transform';
+  expect(responseSchema.properties.answer.type).toBe('string');
+  expect(responseSchema.metadata.source).toBe('input');
+
+  responseSchema.properties.answer.type = 'boolean';
+  responseSchema.metadata.source = 'source';
+  expect(mappedSchema.properties.answer.type).toBe('number');
+  expect(mappedSchema.metadata.source).toBe('transform');
 });
 
 test('does not mutate the input, messages, tool calls, schemas, or metadata', () => {
@@ -509,4 +555,5 @@ test('does not mutate the input, messages, tool calls, schemas, or metadata', ()
   expect(result.messages[0]).not.toBe(input.messages[1]);
   expect(result.tools).not.toBe(input.tools);
   expect(result.tools?.[0]).not.toBe(input.tools[0]);
+  expect(result.output_config?.format?.schema).not.toBe(responseSchema);
 });

--- a/packages/anthropic/src/stream/anthropic-request.spec.ts
+++ b/packages/anthropic/src/stream/anthropic-request.spec.ts
@@ -1,4 +1,5 @@
 import type { RunAgentInput } from '@ag-ui/core';
+import type Anthropic from '@anthropic-ai/sdk';
 import { createAnthropicRequestOptions } from './anthropic-request';
 
 type TestRunAgentInput = RunAgentInput & {
@@ -21,6 +22,16 @@ function createInput(
     forwardedProps: {},
     ...overrides,
   };
+}
+
+function requireClientTool(
+  tool: Anthropic.Messages.ToolUnion | undefined,
+): Anthropic.Messages.Tool {
+  if (!tool || !('input_schema' in tool)) {
+    throw new Error('Expected an Anthropic client tool');
+  }
+
+  return tool;
 }
 
 test('creates fresh streaming options with the server-owned model', () => {
@@ -363,8 +374,10 @@ test('does not perform full JSON Schema validation', () => {
 
   const result = createAnthropicRequestOptions(input, 'claude-test');
 
-  expect(result.tools?.[0]?.input_schema).toEqual(minimallyValidSchema);
-  expect(result.tools?.[0]?.input_schema).not.toBe(minimallyValidSchema);
+  const mappedTool = requireClientTool(result.tools?.[0]);
+
+  expect(mappedTool.input_schema).toEqual(minimallyValidSchema);
+  expect(mappedTool.input_schema).not.toBe(minimallyValidSchema);
 });
 
 test('isolates mapped tool schemas from later source mutations', () => {
@@ -383,7 +396,8 @@ test('isolates mapped tool schemas from later source mutations', () => {
   });
 
   const result = createAnthropicRequestOptions(input, 'claude-test');
-  const mappedSchema = result.tools?.[0]?.input_schema as typeof schema;
+  const mappedSchema = requireClientTool(result.tools?.[0])
+    .input_schema as typeof schema;
   schema.properties.city.type = 'number';
 
   expect(mappedSchema.properties.city.type).toBe('string');
@@ -405,7 +419,8 @@ test('isolates source tool schemas from later request mutations', () => {
   });
 
   const result = createAnthropicRequestOptions(input, 'claude-test');
-  const mappedSchema = result.tools?.[0]?.input_schema as typeof schema;
+  const mappedSchema = requireClientTool(result.tools?.[0])
+    .input_schema as typeof schema;
   mappedSchema.properties.city.type = 'number';
 
   expect(schema.properties.city.type).toBe('string');

--- a/packages/anthropic/src/stream/anthropic-request.ts
+++ b/packages/anthropic/src/stream/anthropic-request.ts
@@ -4,6 +4,16 @@ import type { AnthropicHashbrownRunAgentInput } from './types';
 
 const DEFAULT_MAX_TOKENS = 4096;
 
+type AnthropicAssistantContentBlock =
+  | Anthropic.Messages.TextBlockParam
+  | Anthropic.Messages.ThinkingBlockParam
+  | Anthropic.Messages.RedactedThinkingBlockParam
+  | Anthropic.Messages.ToolUseBlockParam;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function parseToolArguments(argumentsValue: string): unknown {
   try {
     return JSON.parse(argumentsValue);
@@ -14,10 +24,13 @@ function parseToolArguments(argumentsValue: string): unknown {
 
 function mapAssistantMessage(
   message: Extract<Message, { role: 'assistant' }>,
+  reasoningBlocks: Array<
+    | Anthropic.Messages.ThinkingBlockParam
+    | Anthropic.Messages.RedactedThinkingBlockParam
+  > = [],
 ): Anthropic.Messages.MessageParam {
-  const content: Array<
-    Anthropic.Messages.TextBlockParam | Anthropic.Messages.ToolUseBlockParam
-  > = [
+  const content: AnthropicAssistantContentBlock[] = [
+    ...reasoningBlocks,
     ...(message.content
       ? [{ type: 'text' as const, text: message.content }]
       : []),
@@ -33,6 +46,92 @@ function mapAssistantMessage(
     role: 'assistant',
     content: content.length > 0 ? content : '',
   };
+}
+
+function mapReasoningMessage(
+  message: Extract<Message, { role: 'reasoning' }>,
+):
+  | Anthropic.Messages.ThinkingBlockParam
+  | Anthropic.Messages.RedactedThinkingBlockParam
+  | undefined {
+  const metadata = message.metadata;
+  if (
+    !isRecord(metadata) ||
+    !Object.prototype.hasOwnProperty.call(metadata, 'anthropic')
+  ) {
+    return undefined;
+  }
+
+  const marker = metadata['anthropic'];
+  const messageReference = `Anthropic reasoning message "${message.id}"`;
+  if (!isRecord(marker)) {
+    throw new Error(`${messageReference} metadata.anthropic must be an object`);
+  }
+
+  const blockType = marker['blockType'];
+  if (blockType !== 'thinking' && blockType !== 'redacted_thinking') {
+    throw new Error(
+      `${messageReference} metadata.anthropic.blockType must be "thinking" or "redacted_thinking"`,
+    );
+  }
+
+  if (typeof message.content !== 'string') {
+    throw new Error(`${messageReference} content must be a string`);
+  }
+
+  if (
+    typeof message.encryptedValue !== 'string' ||
+    message.encryptedValue.length === 0
+  ) {
+    throw new Error(
+      `${messageReference} encryptedValue must be a non-empty string`,
+    );
+  }
+
+  if (blockType === 'redacted_thinking') {
+    if (message.content !== '') {
+      throw new Error(
+        `${messageReference} redacted_thinking content must be empty`,
+      );
+    }
+
+    return { type: 'redacted_thinking', data: message.encryptedValue };
+  }
+
+  return {
+    type: 'thinking',
+    thinking: message.content,
+    signature: message.encryptedValue,
+  };
+}
+
+function mapPrecedingReasoning(
+  messages: Message[],
+  assistantIndex: number,
+): Array<
+  | Anthropic.Messages.ThinkingBlockParam
+  | Anthropic.Messages.RedactedThinkingBlockParam
+> {
+  let reasoningStart = assistantIndex;
+  while (
+    reasoningStart > 0 &&
+    messages[reasoningStart - 1]?.role === 'reasoning'
+  ) {
+    reasoningStart -= 1;
+  }
+
+  return messages
+    .slice(reasoningStart, assistantIndex)
+    .flatMap((message) =>
+      message.role === 'reasoning' ? [mapReasoningMessage(message)] : [],
+    )
+    .filter(
+      (
+        block,
+      ): block is
+        | Anthropic.Messages.ThinkingBlockParam
+        | Anthropic.Messages.RedactedThinkingBlockParam => block !== undefined,
+    );
 }
 
 function mapMessage(
@@ -133,8 +232,14 @@ export function createAnthropicRequestOptions(
       ? [message.content]
       : [],
   );
-  const messages = input.messages.flatMap((message) => {
-    const mapped = mapMessage(message);
+  const messages = input.messages.flatMap((message, index) => {
+    const mapped =
+      message.role === 'assistant'
+        ? mapAssistantMessage(
+            message,
+            mapPrecedingReasoning(input.messages, index),
+          )
+        : mapMessage(message);
     return mapped ? [mapped] : [];
   });
   const tools = input.tools.map(mapTool);

--- a/packages/anthropic/src/stream/anthropic-request.ts
+++ b/packages/anthropic/src/stream/anthropic-request.ts
@@ -73,8 +73,9 @@ function mapMessage(
   }
 }
 
-function mapTool(tool: Tool): Anthropic.Messages.Tool {
+function mapTool(tool: Tool, index: number): Anthropic.Messages.Tool {
   const parameters = tool.parameters;
+  const toolReference = `Anthropic tool "${tool.name}" at index ${index}`;
 
   if (parameters === undefined) {
     return {
@@ -90,18 +91,27 @@ function mapTool(tool: Tool): Anthropic.Messages.Tool {
     Array.isArray(parameters)
   ) {
     throw new Error(
-      'Anthropic tool parameters must be a non-null, non-array object',
+      `${toolReference} parameters must be a non-null, non-array object`,
     );
   }
 
   if (parameters['type'] !== 'object') {
-    throw new Error('Anthropic tool parameters must have type "object"');
+    throw new Error(`${toolReference} parameters must have type "object"`);
+  }
+
+  let inputSchema: Anthropic.Messages.Tool.InputSchema;
+  try {
+    inputSchema = structuredClone(
+      parameters,
+    ) as Anthropic.Messages.Tool.InputSchema;
+  } catch {
+    throw new Error(`Failed to clone parameters for ${toolReference}`);
   }
 
   return {
     name: tool.name,
     description: tool.description,
-    input_schema: parameters as Anthropic.Messages.Tool.InputSchema,
+    input_schema: inputSchema,
   };
 }
 

--- a/packages/anthropic/src/stream/anthropic-request.ts
+++ b/packages/anthropic/src/stream/anthropic-request.ts
@@ -138,6 +138,7 @@ export function createAnthropicRequestOptions(
     return mapped ? [mapped] : [];
   });
   const tools = input.tools.map(mapTool);
+  const responseSchema = input.hashbrown?.responseSchema;
 
   return {
     stream: true,
@@ -148,5 +149,17 @@ export function createAnthropicRequestOptions(
       : {}),
     messages,
     ...(tools.length > 0 ? { tools } : {}),
+    ...(responseSchema === undefined
+      ? {}
+      : {
+          output_config: {
+            format: {
+              type: 'json_schema' as const,
+              schema: structuredClone(
+                responseSchema,
+              ) as Anthropic.Messages.JSONOutputFormat['schema'],
+            },
+          },
+        }),
   };
 }

--- a/packages/anthropic/src/stream/anthropic-request.ts
+++ b/packages/anthropic/src/stream/anthropic-request.ts
@@ -1,0 +1,142 @@
+import type { Message, Tool } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+import type { AnthropicHashbrownRunAgentInput } from './types';
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+function parseToolArguments(argumentsValue: string): unknown {
+  try {
+    return JSON.parse(argumentsValue);
+  } catch {
+    return argumentsValue;
+  }
+}
+
+function mapAssistantMessage(
+  message: Extract<Message, { role: 'assistant' }>,
+): Anthropic.Messages.MessageParam {
+  const content: Array<
+    Anthropic.Messages.TextBlockParam | Anthropic.Messages.ToolUseBlockParam
+  > = [
+    ...(message.content
+      ? [{ type: 'text' as const, text: message.content }]
+      : []),
+    ...(message.toolCalls ?? []).map((toolCall) => ({
+      type: 'tool_use' as const,
+      id: toolCall.id,
+      name: toolCall.function.name,
+      input: parseToolArguments(toolCall.function.arguments),
+    })),
+  ];
+
+  return {
+    role: 'assistant',
+    content: content.length > 0 ? content : '',
+  };
+}
+
+function mapMessage(
+  message: Message,
+): Anthropic.Messages.MessageParam | undefined {
+  switch (message.role) {
+    case 'developer':
+    case 'system':
+      return undefined;
+    case 'user':
+      if (typeof message.content !== 'string') {
+        throw new Error(
+          'Anthropic provider currently requires text user content',
+        );
+      }
+
+      return {
+        role: 'user',
+        content: message.content,
+      };
+    case 'assistant':
+      return mapAssistantMessage(message);
+    case 'tool':
+      return {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: message.toolCallId,
+            content: message.content,
+            ...(message.error !== undefined ? { is_error: true } : {}),
+          },
+        ],
+      };
+    case 'activity':
+    case 'reasoning':
+      return undefined;
+  }
+}
+
+function mapTool(tool: Tool): Anthropic.Messages.Tool {
+  const parameters = tool.parameters;
+
+  if (parameters === undefined) {
+    return {
+      name: tool.name,
+      description: tool.description,
+      input_schema: { type: 'object', properties: {} },
+    };
+  }
+
+  if (
+    parameters === null ||
+    typeof parameters !== 'object' ||
+    Array.isArray(parameters)
+  ) {
+    throw new Error(
+      'Anthropic tool parameters must be a non-null, non-array object',
+    );
+  }
+
+  if (parameters['type'] !== 'object') {
+    throw new Error('Anthropic tool parameters must have type "object"');
+  }
+
+  return {
+    name: tool.name,
+    description: tool.description,
+    input_schema: parameters as Anthropic.Messages.Tool.InputSchema,
+  };
+}
+
+/**
+ * Maps an AG-UI run input to Anthropic streaming message request options.
+ *
+ * @param input - Standard AG-UI run input with optional Hashbrown metadata.
+ * @param model - Model selected by the server for this endpoint.
+ * @returns Fresh Anthropic request options that do not mutate the run input.
+ *
+ * @internal
+ */
+export function createAnthropicRequestOptions(
+  input: AnthropicHashbrownRunAgentInput,
+  model: string,
+): Anthropic.Messages.MessageCreateParamsStreaming {
+  const systemMessages = input.messages.flatMap((message) =>
+    message.role === 'system' || message.role === 'developer'
+      ? [message.content]
+      : [],
+  );
+  const messages = input.messages.flatMap((message) => {
+    const mapped = mapMessage(message);
+    return mapped ? [mapped] : [];
+  });
+  const tools = input.tools.map(mapTool);
+
+  return {
+    stream: true,
+    model,
+    max_tokens: DEFAULT_MAX_TOKENS,
+    ...(systemMessages.length > 0
+      ? { system: systemMessages.join('\n\n') }
+      : {}),
+    messages,
+    ...(tools.length > 0 ? { tools } : {}),
+  };
+}

--- a/packages/anthropic/src/stream/text.fn.spec.ts
+++ b/packages/anthropic/src/stream/text.fn.spec.ts
@@ -59,13 +59,9 @@ function createOptions(
   };
 }
 
-function rawEvent(value: unknown): RawEvent {
-  return value as RawEvent;
-}
-
 function completeTextEvents(textValue = 'Hello from Anthropic.'): RawEvent[] {
   return [
-    rawEvent({
+    {
       type: 'message_start',
       message: {
         id: 'provider-message',
@@ -73,28 +69,52 @@ function completeTextEvents(textValue = 'Hello from Anthropic.'): RawEvent[] {
         role: 'assistant',
         content: [],
         model: 'claude-server-model',
+        container: null,
         stop_reason: null,
         stop_sequence: null,
-        usage: { input_tokens: 1, output_tokens: 0 },
+        stop_details: null,
+        usage: {
+          cache_creation: null,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          inference_geo: null,
+          input_tokens: 1,
+          output_tokens: 0,
+          output_tokens_details: null,
+          server_tool_use: null,
+          service_tier: null,
+        },
       },
-    }),
-    rawEvent({
+    },
+    {
       type: 'content_block_start',
       index: 0,
-      content_block: { type: 'text', text: '' },
-    }),
-    rawEvent({
+      content_block: { type: 'text', text: '', citations: null },
+    },
+    {
       type: 'content_block_delta',
       index: 0,
       delta: { type: 'text_delta', text: textValue },
-    }),
-    rawEvent({ type: 'content_block_stop', index: 0 }),
-    rawEvent({
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
       type: 'message_delta',
-      delta: { stop_reason: 'end_turn', stop_sequence: null },
-      usage: { output_tokens: 4 },
-    }),
-    rawEvent({ type: 'message_stop' }),
+      delta: {
+        container: null,
+        stop_details: null,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+      },
+      usage: {
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        input_tokens: null,
+        output_tokens: 4,
+        output_tokens_details: null,
+        server_tool_use: null,
+      },
+    },
+    { type: 'message_stop' },
   ];
 }
 
@@ -432,7 +452,7 @@ test('cancellation after mapper content suppresses later lifecycle events', asyn
 
 test('aborts the raw provider stream after a protocol error', async () => {
   const provider = mockProvider([
-    rawEvent({
+    {
       type: 'message_start',
       message: {
         id: 'provider-message',
@@ -440,16 +460,28 @@ test('aborts the raw provider stream after a protocol error', async () => {
         role: 'assistant',
         content: [],
         model: 'claude-server-model',
+        container: null,
         stop_reason: null,
         stop_sequence: null,
-        usage: { input_tokens: 1, output_tokens: 0 },
+        stop_details: null,
+        usage: {
+          cache_creation: null,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+          inference_geo: null,
+          input_tokens: 1,
+          output_tokens: 0,
+          output_tokens_details: null,
+          server_tool_use: null,
+          service_tier: null,
+        },
       },
-    }),
-    rawEvent({
+    },
+    {
       type: 'content_block_delta',
       index: 0,
       delta: { type: 'text_delta', text: 'invalid' },
-    }),
+    },
   ]);
 
   const events = await collectEvents(createOptions());

--- a/packages/anthropic/src/stream/text.fn.spec.ts
+++ b/packages/anthropic/src/stream/text.fn.spec.ts
@@ -368,12 +368,17 @@ test('cancellation immediately after transform prevents provider and terminal ev
   expect(provider.create).not.toHaveBeenCalled();
 });
 
-test('maps provider create rejection to exactly one RUN_ERROR', async () => {
+test('maps a native structured-output provider rejection to exactly one RUN_ERROR', async () => {
   MockedAnthropic.mockReset();
   const create = jest.fn().mockRejectedValue(new Error('Provider unavailable'));
   MockedAnthropic.mockImplementation(() => ({ messages: { create } }));
+  const input = createInput({
+    hashbrown: {
+      responseSchema: { type: 'object', properties: {} },
+    },
+  });
 
-  const events = await collectEvents(createOptions());
+  const events = await collectEvents(createOptions({ input }));
 
   expect(events.map((event) => event.type)).toEqual([
     EventType.RUN_STARTED,
@@ -383,6 +388,18 @@ test('maps provider create rejection to exactly one RUN_ERROR', async () => {
     type: EventType.RUN_ERROR,
     message: 'Provider unavailable',
   });
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      output_config: {
+        format: {
+          type: 'json_schema',
+          schema: { type: 'object', properties: {} },
+        },
+      },
+    }),
+    { signal: undefined },
+  );
 });
 
 test('emits canonical mapper events followed by one RUN_FINISHED', async () => {

--- a/packages/anthropic/src/stream/text.fn.spec.ts
+++ b/packages/anthropic/src/stream/text.fn.spec.ts
@@ -1,0 +1,415 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import Anthropic from '@anthropic-ai/sdk';
+import { text } from './text.fn';
+import type {
+  AnthropicHashbrownRunAgentInput,
+  AnthropicTextStreamOptions,
+} from './types';
+
+jest.mock('@anthropic-ai/sdk', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+type RawEvent = Anthropic.Messages.RawMessageStreamEvent;
+type RequestOptions = Anthropic.Messages.MessageCreateParamsStreaming;
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+}
+
+const MockedAnthropic = Anthropic as unknown as jest.Mock;
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createInput(
+  overrides: Partial<AnthropicHashbrownRunAgentInput> = {},
+): AnthropicHashbrownRunAgentInput {
+  return {
+    threadId: 'thread-anthropic',
+    runId: 'run-anthropic',
+    messages: [
+      { id: 'user-anthropic', role: 'user', content: 'Hello, Claude.' },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+function createOptions(
+  overrides: Partial<AnthropicTextStreamOptions> = {},
+): AnthropicTextStreamOptions {
+  return {
+    apiKey: 'test-api-key',
+    baseURL: 'https://anthropic.test',
+    model: 'claude-server-model',
+    input: createInput(),
+    ...overrides,
+  };
+}
+
+function rawEvent(value: unknown): RawEvent {
+  return value as RawEvent;
+}
+
+function completeTextEvents(textValue = 'Hello from Anthropic.'): RawEvent[] {
+  return [
+    rawEvent({
+      type: 'message_start',
+      message: {
+        id: 'provider-message',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-server-model',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }),
+    rawEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    }),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: textValue },
+    }),
+    rawEvent({ type: 'content_block_stop', index: 0 }),
+    rawEvent({
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    }),
+    rawEvent({ type: 'message_stop' }),
+  ];
+}
+
+function createProviderStream(events: readonly RawEvent[]) {
+  const abort = jest.fn();
+  let index = 0;
+  const stream = {
+    controller: { abort },
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<RawEvent>> {
+          const value = events[index];
+          index += 1;
+
+          return value === undefined
+            ? { done: true, value: undefined }
+            : { done: false, value };
+        },
+        async return(): Promise<IteratorResult<RawEvent>> {
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  return { abort, stream };
+}
+
+function mockProvider(events: readonly RawEvent[] = completeTextEvents()) {
+  MockedAnthropic.mockReset();
+  const providerStream = createProviderStream(events);
+  const create = jest.fn().mockResolvedValue(providerStream.stream);
+  MockedAnthropic.mockImplementation(() => ({ messages: { create } }));
+
+  return { ...providerStream, create };
+}
+
+async function collectEvents(
+  options: AnthropicTextStreamOptions,
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of text(options)) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  return events;
+}
+
+test('emits RUN_STARTED before mapping and maps mapping failures to RUN_ERROR', async () => {
+  const provider = mockProvider();
+  const input = createInput({
+    messages: [
+      {
+        id: 'structured-user',
+        role: 'user',
+        content: [{ type: 'text', text: 'Structured user content.' }],
+      },
+    ],
+  });
+
+  const events = await collectEvents(createOptions({ input }));
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
+    {
+      type: EventType.RUN_ERROR,
+      message: 'Anthropic provider currently requires text user content',
+    },
+  ]);
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
+test('returns only RUN_STARTED for a pre-aborted signal', async () => {
+  const provider = mockProvider();
+  const controller = new AbortController();
+  const input = createInput({
+    messages: [
+      {
+        id: 'structured-user',
+        role: 'user',
+        content: [{ type: 'text', text: 'Must not be mapped.' }],
+      },
+    ],
+  });
+  controller.abort();
+
+  const events = await collectEvents(
+    createOptions({ input, signal: controller.signal }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
+  ]);
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
+test('awaits a transform of the final mapped request before provider creation', async () => {
+  const provider = mockProvider();
+  const input = createInput();
+  let receivedOptions: RequestOptions | undefined;
+  const transformRequestOptions = jest.fn(
+    async (options: RequestOptions): Promise<RequestOptions> => {
+      receivedOptions = options;
+      await Promise.resolve();
+
+      return { ...options, max_tokens: 123, temperature: 0 };
+    },
+  );
+
+  await collectEvents(createOptions({ input, transformRequestOptions }));
+
+  expect(receivedOptions).toEqual({
+    stream: true,
+    model: 'claude-server-model',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: 'Hello, Claude.' }],
+  });
+  expect(MockedAnthropic).toHaveBeenCalledWith({
+    apiKey: 'test-api-key',
+    baseURL: 'https://anthropic.test',
+  });
+  expect(provider.create).toHaveBeenCalledWith(
+    {
+      ...receivedOptions,
+      max_tokens: 123,
+      temperature: 0,
+    },
+    { signal: undefined },
+  );
+});
+
+test('cancellation while an async transform is pending prevents provider creation', async () => {
+  const provider = mockProvider();
+  const controller = new AbortController();
+  const deferred = createDeferred<RequestOptions>();
+  const transformRequestOptions = jest.fn((options: RequestOptions) =>
+    deferred.promise.then(() => options),
+  );
+  const iterator = text(
+    createOptions({ signal: controller.signal, transformRequestOptions }),
+  )[Symbol.asyncIterator]();
+
+  const started = await iterator.next();
+  const pending = iterator.next();
+  await Promise.resolve();
+  controller.abort();
+  deferred.resolve({
+    stream: true,
+    model: 'unused',
+    max_tokens: 1,
+    messages: [],
+  });
+  const done = await pending;
+
+  expect(started).toMatchObject({
+    done: false,
+    value: { type: EventType.RUN_STARTED },
+  });
+  expect(transformRequestOptions).toHaveBeenCalledTimes(1);
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
+test('cancellation immediately after transform prevents provider and terminal events', async () => {
+  const provider = mockProvider();
+  const controller = new AbortController();
+
+  const events = await collectEvents(
+    createOptions({
+      signal: controller.signal,
+      transformRequestOptions: (options) => {
+        controller.abort();
+        return options;
+      },
+    }),
+  );
+
+  expect(events.map((event) => event.type)).toEqual([EventType.RUN_STARTED]);
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
+test('maps provider create rejection to exactly one RUN_ERROR', async () => {
+  MockedAnthropic.mockReset();
+  const create = jest.fn().mockRejectedValue(new Error('Provider unavailable'));
+  MockedAnthropic.mockImplementation(() => ({ messages: { create } }));
+
+  const events = await collectEvents(createOptions());
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.RUN_ERROR,
+  ]);
+  expect(events[1]).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Provider unavailable',
+  });
+});
+
+test('emits canonical mapper events followed by one RUN_FINISHED', async () => {
+  const provider = mockProvider();
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-anthropic',
+      runId: 'run-anthropic',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-anthropic:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-anthropic:assistant',
+      delta: 'Hello from Anthropic.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-anthropic:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-anthropic',
+      runId: 'run-anthropic',
+    },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('cancellation after mapper content suppresses later lifecycle events', async () => {
+  const provider = mockProvider();
+  const controller = new AbortController();
+  const iterator = text(createOptions({ signal: controller.signal }))[
+    Symbol.asyncIterator
+  ]();
+  const events: AGUIEvent[] = [];
+
+  events.push(EventSchemas.parse((await iterator.next()).value));
+  events.push(EventSchemas.parse((await iterator.next()).value));
+  events.push(EventSchemas.parse((await iterator.next()).value));
+  controller.abort();
+  const done = await iterator.next();
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+  ]);
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.TEXT_MESSAGE_END }),
+      expect.objectContaining({ type: EventType.TOOL_CALL_END }),
+      expect.objectContaining({ type: EventType.RUN_ERROR }),
+      expect.objectContaining({ type: EventType.RUN_FINISHED }),
+    ]),
+  );
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('aborts the raw provider stream after a protocol error', async () => {
+  const provider = mockProvider([
+    rawEvent({
+      type: 'message_start',
+      message: {
+        id: 'provider-message',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-server-model',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }),
+    rawEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'invalid' },
+    }),
+  ]);
+
+  const events = await collectEvents(createOptions());
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.RUN_ERROR,
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('aborts the raw provider stream when the consumer returns early', async () => {
+  const provider = mockProvider();
+  const iterator = text(createOptions())[Symbol.asyncIterator]();
+
+  await iterator.next();
+  await iterator.next();
+  const returned = await iterator.return?.();
+
+  expect(returned).toEqual({ done: true, value: undefined });
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});

--- a/packages/anthropic/src/stream/text.fn.spec.ts
+++ b/packages/anthropic/src/stream/text.fn.spec.ts
@@ -237,6 +237,65 @@ test('awaits a transform of the final mapped request before provider creation', 
   );
 });
 
+test('maps transform rejection to exactly one RUN_ERROR without a provider request', async () => {
+  const provider = mockProvider();
+  const transformRequestOptions = jest
+    .fn()
+    .mockRejectedValue(new Error('Transform rejected request'));
+
+  const events = await collectEvents(
+    createOptions({ transformRequestOptions }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-anthropic',
+      runId: 'run-anthropic',
+    },
+    {
+      type: EventType.RUN_ERROR,
+      message: 'Transform rejected request',
+    },
+  ]);
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
+test('checks cancellation after yielding RUN_ERROR', async () => {
+  const provider = mockProvider();
+  let abortedReads = 0;
+  const signal = {
+    get aborted() {
+      abortedReads += 1;
+      return false;
+    },
+  } as AbortSignal;
+  const iterator = text(
+    createOptions({
+      signal,
+      transformRequestOptions: async () => {
+        throw new Error('Transform rejected request');
+      },
+    }),
+  )[Symbol.asyncIterator]();
+
+  const started = await iterator.next();
+  const errored = await iterator.next();
+  const readsAfterError = abortedReads;
+  const done = await iterator.next();
+
+  expect(started.value).toMatchObject({ type: EventType.RUN_STARTED });
+  expect(errored.value).toEqual({
+    type: EventType.RUN_ERROR,
+    message: 'Transform rejected request',
+  });
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(abortedReads).toBe(readsAfterError + 1);
+  expect(MockedAnthropic).not.toHaveBeenCalled();
+  expect(provider.create).not.toHaveBeenCalled();
+});
+
 test('cancellation while an async transform is pending prevents provider creation', async () => {
   const provider = mockProvider();
   const controller = new AbortController();

--- a/packages/anthropic/src/stream/text.fn.ts
+++ b/packages/anthropic/src/stream/text.fn.ts
@@ -1,486 +1,83 @@
-import {
-  Chat,
-  encodeFrame,
-  Frame,
-  mergeMessagesForThread,
-  updateAssistantMessage,
-} from '@hashbrownai/core';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import Anthropic from '@anthropic-ai/sdk';
+import { mapAnthropicEvents } from './anthropic-events';
+import { createAnthropicRequestOptions } from './anthropic-request';
+import type { AnthropicTextStreamOptions } from './types';
 
-type BaseAnthropicTextStreamOptions = {
-  apiKey: string;
-  baseURL?: string;
-  request: Chat.Api.CompletionCreateParams;
-  transformRequestOptions?: (
-    options: Anthropic.Messages.MessageCreateParamsStreaming,
-  ) =>
-    | Anthropic.Messages.MessageCreateParamsStreaming
-    | Promise<Anthropic.Messages.MessageCreateParamsStreaming>;
-};
+type AnthropicProviderStream =
+  AsyncIterable<Anthropic.Messages.RawMessageStreamEvent> & {
+    readonly controller: AbortController;
+  };
 
-type ThreadPersistenceOptions = {
-  loadThread: (threadId: string) => Promise<Chat.Api.Message[]>;
-  saveThread: (
-    thread: Chat.Api.Message[],
-    threadId?: string,
-  ) => Promise<string>;
-};
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-type ThreadlessOptions = BaseAnthropicTextStreamOptions & {
-  loadThread?: undefined;
-  saveThread?: undefined;
-};
-
-type ThreadfulOptions = BaseAnthropicTextStreamOptions &
-  ThreadPersistenceOptions;
-
-export type AnthropicTextStreamOptions = ThreadlessOptions | ThreadfulOptions;
-
-const DEFAULT_MAX_TOKENS = 4096;
-
-export function text(options: ThreadfulOptions): AsyncIterable<Uint8Array>;
-export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
-
+/**
+ * Streams canonical AG-UI events from an Anthropic message request.
+ *
+ * @param options - Provider configuration and AG-UI run input.
+ * @returns An asynchronous stream of canonical AG-UI events.
+ *
+ * @public
+ */
 export async function* text(
   options: AnthropicTextStreamOptions,
-): AsyncIterable<Uint8Array> {
-  const {
-    apiKey,
-    baseURL,
-    request,
-    transformRequestOptions,
-    loadThread,
-    saveThread,
-  } = options;
-  const { model, tools, toolChoice, system } = request;
-  const threadId = request.threadId;
-  let loadedThread: Chat.Api.Message[] = [];
-  let effectiveThreadId = threadId;
+): AsyncIterable<AGUIEvent> {
+  const { apiKey, baseURL, model, input, signal, transformRequestOptions } =
+    options;
+  const { threadId, runId } = input;
+  const messageId = `${runId}:assistant`;
+  let providerStream: AnthropicProviderStream | undefined;
 
-  const anthropic = new Anthropic({
-    apiKey,
-    baseURL,
-  });
-
-  const shouldLoadThread = Boolean(request.threadId);
-  const shouldHydrateThreadOnTheClient = Boolean(
-    request.operation === 'load-thread',
-  );
-
-  if (shouldLoadThread) {
-    yield encodeFrame({ type: 'thread-load-start' });
-
-    if (!loadThread) {
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: 'Thread loading is not available for this transport.',
-      });
-      return;
-    }
-
-    try {
-      loadedThread = await loadThread(request.threadId as string);
-      if (shouldHydrateThreadOnTheClient) {
-        yield encodeFrame({
-          type: 'thread-load-success',
-          thread: loadedThread,
-        });
-      } else {
-        yield encodeFrame({ type: 'thread-load-success' });
-      }
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
-  }
-
-  if (request.operation === 'load-thread') {
+  yield { type: EventType.RUN_STARTED, threadId, runId };
+  if (signal?.aborted) {
     return;
   }
 
-  const mergedMessages =
-    request.threadId && shouldLoadThread
-      ? mergeMessagesForThread(loadedThread, request.messages ?? [])
-      : (request.messages ?? []);
-  let assistantMessage: Chat.Api.AssistantMessage | null = null;
-
   try {
-    const baseOptions: Anthropic.Messages.MessageCreateParamsStreaming = {
-      stream: true,
-      model: model as string,
-      max_tokens: DEFAULT_MAX_TOKENS,
-      system,
-      messages: toAnthropicMessages(mergedMessages),
-      tools: tools && tools.length > 0 ? tools.map(toAnthropicTool) : undefined,
-      tool_choice: mapToolChoice(toolChoice),
-    };
+    const baseOptions = createAnthropicRequestOptions(input, model);
+    const requestOptions = transformRequestOptions
+      ? await transformRequestOptions(baseOptions)
+      : baseOptions;
 
-    const resolvedOptions: Anthropic.Messages.MessageCreateParams =
-      transformRequestOptions
-        ? await transformRequestOptions(baseOptions)
-        : baseOptions;
+    if (signal?.aborted) {
+      return;
+    }
 
-    const stream = anthropic.messages.stream(resolvedOptions);
-    const debugStream = process.env['DEBUG_HASHBROWN_ANTHROPIC'] === '1';
+    const anthropic = new Anthropic({ apiKey, baseURL });
+    providerStream = await anthropic.messages.create(requestOptions, {
+      signal,
+    });
 
-    let finishReason: string | null = null;
-    const toolCallBlocks = new Map<
-      number,
-      {
-        id: string;
-        name: string;
-        index: number;
-        buffer?: string;
-        isOutput: boolean;
-      }
-    >();
-    let toolCallCount = 0;
+    if (signal?.aborted) {
+      return;
+    }
 
-    yield encodeFrame({ type: 'generation-start' });
-
-    for await (const event of stream) {
-      let contentDelta: string | undefined;
-      let toolCallDeltas: Chat.Api.ToolCall[] | undefined;
-
-      if (debugStream) {
-        console.log('[anthropic:event]', JSON.stringify(event));
-      }
-
-      switch (event.type) {
-        case 'content_block_delta': {
-          if (event.delta.type === 'text_delta') {
-            contentDelta = event.delta.text;
-          } else if (event.delta.type === 'input_json_delta') {
-            const base = toolCallBlocks.get(event.index);
-            if (base) {
-              if (base.isOutput) {
-                base.buffer = (base.buffer ?? '') + event.delta.partial_json;
-                toolCallBlocks.set(event.index, base);
-              } else {
-                toolCallDeltas = [
-                  {
-                    index: base.index,
-                    id: base.id,
-                    type: 'function',
-                    function: {
-                      name: base.name,
-                      arguments: event.delta.partial_json,
-                    },
-                  },
-                ];
-              }
-            }
-          }
-          break;
-        }
-        case 'content_block_start': {
-          if (event.content_block.type === 'tool_use') {
-            const base = {
-              id: event.content_block.id,
-              name: event.content_block.name,
-              index: toolCallCount++,
-              buffer: undefined,
-              isOutput: event.content_block.name === 'output',
-            };
-
-            toolCallBlocks.set(event.index, base);
-
-            if (!base.isOutput) {
-              toolCallDeltas = [
-                {
-                  index: base.index,
-                  id: base.id,
-                  type: 'function',
-                  function: {
-                    name: base.name,
-                    arguments: '',
-                  },
-                },
-              ];
-            }
-          }
-          break;
-        }
-        case 'content_block_stop': {
-          const base = toolCallBlocks.get(event.index);
-          toolCallBlocks.delete(event.index);
-
-          if (base?.isOutput && base.buffer) {
-            contentDelta = normalizeOutputArguments(base.buffer);
-          }
-          break;
-        }
-        case 'message_delta': {
-          finishReason = event.delta.stop_reason || null;
-          break;
-        }
-      }
-
-      if (contentDelta !== undefined || toolCallDeltas) {
-        const chunkMessage: Chat.Api.CompletionChunk = {
-          choices: [
-            {
-              index: 0,
-              delta: {
-                content: contentDelta ?? null,
-                role: 'assistant',
-                toolCalls: toolCallDeltas,
-              },
-              finishReason,
-            },
-          ],
-        };
-
-        if (debugStream && toolCallDeltas) {
-          console.log('[anthropic:tool-delta]', JSON.stringify(toolCallDeltas));
-        }
-
-        assistantMessage = updateAssistantMessage(
-          assistantMessage,
-          chunkMessage,
-        );
-
-        yield encodeFrame({ type: 'generation-chunk', chunk: chunkMessage });
+    for await (const event of mapAnthropicEvents({
+      events: providerStream,
+      messageId,
+      signal,
+    })) {
+      yield event;
+      if (signal?.aborted) {
+        return;
       }
     }
 
-    yield encodeFrame({ type: 'generation-finish' });
+    if (signal?.aborted) {
+      return;
+    }
+
+    yield { type: EventType.RUN_FINISHED, threadId, runId };
+    if (signal?.aborted) {
+      return;
+    }
   } catch (error: unknown) {
-    const { message, stack } = normalizeError(error);
-    const frame: Frame = {
-      type: 'generation-error',
-      error: message,
-      stacktrace: stack,
-    };
-
-    yield encodeFrame(frame);
-    return;
-  }
-
-  if (saveThread) {
-    const threadToSave = mergeMessagesForThread(mergedMessages, [
-      ...(assistantMessage ? [assistantMessage] : []),
-    ]);
-    yield encodeFrame({ type: 'thread-save-start' });
-    try {
-      const savedThreadId = await saveThread(threadToSave, effectiveThreadId);
-      if (effectiveThreadId && savedThreadId !== effectiveThreadId) {
-        throw new Error(
-          'Save returned a different threadId than the existing thread',
-        );
-      }
-      effectiveThreadId = savedThreadId;
-      yield encodeFrame({
-        type: 'thread-save-success',
-        threadId: savedThreadId,
-      });
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-save-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
+    if (!signal?.aborted) {
+      yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
     }
+  } finally {
+    providerStream?.controller.abort();
   }
-}
-
-function toAnthropicMessages(
-  messages: Chat.Api.Message[],
-): Anthropic.Messages.MessageParam[] {
-  return messages.map((message): Anthropic.Messages.MessageParam => {
-    if (message.role === 'user') {
-      return {
-        role: 'user',
-        content: message.content ?? '',
-      };
-    }
-
-    if (message.role === 'assistant') {
-      const contentBlocks: Array<
-        Anthropic.Messages.TextBlockParam | Anthropic.Messages.ToolUseBlockParam
-      > = [];
-
-      if (message.content) {
-        contentBlocks.push({
-          type: 'text',
-          text:
-            typeof message.content === 'string'
-              ? message.content
-              : JSON.stringify(message.content),
-        });
-      }
-
-      if (message.toolCalls?.length) {
-        contentBlocks.push(
-          ...message.toolCalls.map((toolCall) => ({
-            type: 'tool_use' as const,
-            id: toolCall.id,
-            name: toolCall.function.name,
-            input: parseJson(toolCall.function.arguments),
-          })),
-        );
-      }
-
-      if (contentBlocks.length === 0) {
-        return {
-          role: 'assistant',
-          content: '',
-        };
-      }
-
-      if (contentBlocks.length === 1 && contentBlocks[0].type === 'text') {
-        return {
-          role: 'assistant',
-          content: (contentBlocks[0] as Anthropic.Messages.TextBlockParam).text,
-        };
-      }
-
-      return {
-        role: 'assistant',
-        content: contentBlocks,
-      };
-    }
-
-    if (message.role === 'tool') {
-      const serializedResult = serializeToolResult(message.content);
-
-      return {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: message.toolCallId || '',
-            content: serializedResult,
-            is_error: message.content.status === 'rejected',
-          },
-        ],
-      };
-    }
-
-    throw new Error(`Invalid message role: ${message['role']}`);
-  });
-}
-
-function toAnthropicTool(tool: Chat.Api.Tool): Anthropic.Tool {
-  return {
-    name: tool.name,
-    description: tool.description,
-    input_schema: tool.parameters as Anthropic.Tool.InputSchema,
-  };
-}
-
-function mapToolChoice(
-  choice?: Chat.Api.CompletionToolChoiceOption,
-): Anthropic.Messages.MessageCreateParams['tool_choice'] {
-  switch (choice) {
-    case 'auto': {
-      return { type: 'auto' };
-    }
-    case 'required': {
-      return { type: 'any' };
-    }
-    case 'none':
-    default:
-      return undefined;
-  }
-}
-
-function parseJson(value: unknown): unknown {
-  if (typeof value !== 'string') {
-    return value;
-  }
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-function serializeToolResult(result: PromiseSettledResult<any>): string {
-  if (result.status === 'fulfilled') {
-    const value = result.value;
-    return typeof value === 'string' ? value : JSON.stringify(value ?? '');
-  }
-
-  const reason = result.reason ?? 'Tool call failed';
-  return typeof reason === 'string' ? reason : JSON.stringify(reason);
-}
-
-function normalizeOutputArguments(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw);
-    const normalized = normalizeNestedJson(parsed);
-    return JSON.stringify(normalized);
-  } catch {
-    return raw;
-  }
-}
-
-function normalizeNestedJson(value: unknown, parentKey?: string): unknown {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-
-    if (looksLikeJson(trimmed)) {
-      try {
-        const parsed = JSON.parse(trimmed);
-        const normalized = normalizeNestedJson(parsed, parentKey);
-
-        if (
-          parentKey &&
-          isPlainObject(normalized) &&
-          Object.keys(normalized).length === 1 &&
-          Object.prototype.hasOwnProperty.call(normalized, parentKey)
-        ) {
-          return normalizeNestedJson(normalized[parentKey], parentKey);
-        }
-
-        return normalized;
-      } catch {
-        return value;
-      }
-    }
-
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((item) => normalizeNestedJson(item, parentKey));
-  }
-
-  if (isPlainObject(value)) {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, val]) => [
-        key,
-        normalizeNestedJson(val, key),
-      ]),
-    );
-  }
-
-  return value;
-}
-
-function looksLikeJson(value: string): boolean {
-  return (
-    (value.startsWith('{') && value.endsWith('}')) ||
-    (value.startsWith('[') && value.endsWith(']'))
-  );
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function normalizeError(error: unknown): { message: string; stack?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, stack: error.stack };
-  }
-  return { message: String(error) };
 }

--- a/packages/anthropic/src/stream/text.fn.ts
+++ b/packages/anthropic/src/stream/text.fn.ts
@@ -76,6 +76,9 @@ export async function* text(
   } catch (error: unknown) {
     if (!signal?.aborted) {
       yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
+      if (signal?.aborted) {
+        return;
+      }
     }
   } finally {
     providerStream?.controller.abort();

--- a/packages/anthropic/src/stream/types.ts
+++ b/packages/anthropic/src/stream/types.ts
@@ -1,0 +1,13 @@
+import type { RunAgentInput } from '@ag-ui/core';
+
+/**
+ * Hashbrown extensions accepted alongside a standard AG-UI run input.
+ *
+ * @public
+ */
+export interface AnthropicHashbrownRunAgentInput extends RunAgentInput {
+  hashbrown?: {
+    responseSchema?: object;
+    ui?: boolean;
+  };
+}

--- a/packages/anthropic/src/stream/types.ts
+++ b/packages/anthropic/src/stream/types.ts
@@ -1,4 +1,5 @@
 import type { RunAgentInput } from '@ag-ui/core';
+import type Anthropic from '@anthropic-ai/sdk';
 
 /**
  * Hashbrown extensions accepted alongside a standard AG-UI run input.
@@ -10,4 +11,28 @@ export interface AnthropicHashbrownRunAgentInput extends RunAgentInput {
     responseSchema?: object;
     ui?: boolean;
   };
+}
+
+/**
+ * Options for streaming an AG-UI run from Anthropic.
+ *
+ * @public
+ */
+export interface AnthropicTextStreamOptions {
+  /** Anthropic API key. */
+  apiKey: string;
+  /** Optional Anthropic-compatible API base URL. */
+  baseURL?: string;
+  /** Model selected by the server for this endpoint. */
+  model: string;
+  /** Standard AG-UI run input plus optional Hashbrown semantics. */
+  input: AnthropicHashbrownRunAgentInput;
+  /** Cancels the provider request when the HTTP request is abandoned. */
+  signal?: AbortSignal;
+  /** Customize the Anthropic request after AG-UI input has been mapped. */
+  transformRequestOptions?: (
+    options: Anthropic.Messages.MessageCreateParamsStreaming,
+  ) =>
+    | Anthropic.Messages.MessageCreateParamsStreaming
+    | Promise<Anthropic.Messages.MessageCreateParamsStreaming>;
 }

--- a/packages/anthropic/tsconfig.lib.json
+++ b/packages/anthropic/tsconfig.lib.json
@@ -6,7 +6,12 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-utils.ts"
+  ],
   "angularCompilerOptions": {
     "extendedDiagnostics": {
       "checks": {

--- a/packages/anthropic/tsconfig.spec.json
+++ b/packages/anthropic/tsconfig.spec.json
@@ -9,6 +9,7 @@
   "include": [
     "jest.config.ts",
     "src/**/*.test.ts",
+    "src/**/*.test-utils.ts",
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
   ]

--- a/packages/core/e2e/package-shape.e2e.spec.ts
+++ b/packages/core/e2e/package-shape.e2e.spec.ts
@@ -184,7 +184,7 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
           const agUiCoreVersion = packageJson.dependencies?.['@ag-ui/core'];
           const agUiClientVersion = packageJson.dependencies?.['@ag-ui/client'];
           if (
-            agUiCoreVersion !== '0.0.58' ||
+            agUiCoreVersion !== '0.0.59' ||
             agUiClientVersion !== agUiCoreVersion
           ) {
             throw new Error(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,8 +17,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.58",
-    "@ag-ui/core": "0.0.58",
+    "@ag-ui/client": "0.0.59",
+    "@ag-ui/core": "0.0.59",
     "@cacheplane/partial-json": "0.2.2"
   },
   "engines": {

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1,5 +1,6 @@
 import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { apiActions, devActions, internalActions } from '../actions';
+import { fryHashbrown } from '../hashbrown';
 import { Chat } from '../models';
 import {
   selectApiMessages,
@@ -1087,6 +1088,203 @@ test('validated start then tool continuation reuses the same thread ID', async (
   expect(send.mock.calls[1]?.[0].input?.threadId).toBe(acceptedThreadId);
 
   teardown?.();
+});
+
+test('continues client tools with isolated reasoning details in transcript order', async () => {
+  jest.clearAllMocks();
+  const secondInputCaptured = createDeferred<TransportRequest>();
+  const toolHandler = jest.fn(async ({ city }: { city: string }) => ({
+    city,
+    condition: 'sunny',
+  }));
+  let requestCount = 0;
+  makeSelection(async (request) => {
+    requestCount++;
+    if (requestCount === 1) {
+      return {
+        events: successfulEvents(request, [
+          {
+            type: EventType.REASONING_MESSAGE_START,
+            messageId: 'reasoning-weather',
+            role: 'reasoning',
+            metadata: { provider: { trace: ['original'] } },
+          },
+          {
+            type: EventType.REASONING_MESSAGE_CONTENT,
+            messageId: 'reasoning-weather',
+            delta: 'I need the weather tool.',
+          },
+          {
+            type: EventType.REASONING_ENCRYPTED_VALUE,
+            subtype: 'message',
+            entityId: 'reasoning-weather',
+            encryptedValue: 'opaque-reasoning',
+          },
+          {
+            type: EventType.REASONING_MESSAGE_END,
+            messageId: 'reasoning-weather',
+          },
+          {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: 'call-weather',
+            toolCallName: 'getWeather',
+            parentMessageId: 'assistant-weather',
+          },
+          {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: 'call-weather',
+            delta: '{"city":"Paris"}',
+          },
+          {
+            type: EventType.TOOL_CALL_END,
+            toolCallId: 'call-weather',
+          },
+        ]),
+      };
+    }
+
+    secondInputCaptured.resolve(request);
+    return {
+      events: successfulEvents(request, [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'assistant-final',
+          role: 'assistant',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: 'assistant-final',
+          delta: 'It is sunny in Paris.',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: 'assistant-final',
+        },
+      ]),
+    };
+  });
+  const chat = fryHashbrown({
+    model: 'stub-model',
+    system: 'You are a test bot',
+    tools: [
+      {
+        name: 'getWeather',
+        description: 'Get weather for a city.',
+        schema: s.object('Weather lookup', {
+          city: s.string('City name'),
+        }),
+        handler: toolHandler,
+      },
+    ],
+  });
+  const teardown = chat.sizzle();
+
+  chat.sendMessage({ role: 'user', content: 'What is the weather in Paris?' });
+  const secondRequest = await secondInputCaptured.promise;
+
+  expect(toolHandler).toHaveBeenCalledWith(
+    { city: 'Paris' },
+    expect.any(AbortSignal),
+  );
+  expect(secondRequest.input?.messages.map(({ role }) => role)).toEqual([
+    'system',
+    'user',
+    'reasoning',
+    'assistant',
+    'tool',
+  ]);
+  const priorUserMessage = secondRequest.input?.messages[1];
+  expect(priorUserMessage?.role).toBe('user');
+  expect(typeof priorUserMessage?.id === 'string').toBe(true);
+  expect(
+    priorUserMessage?.role === 'user' &&
+      priorUserMessage.content === 'What is the weather in Paris?',
+  ).toBe(true);
+  const safeContinuation = secondRequest.input?.messages
+    .slice(2)
+    .map((message) => {
+      if (message.role !== 'reasoning') {
+        return message;
+      }
+
+      const { encryptedValue, ...safeMessage } = message;
+      return {
+        ...safeMessage,
+        hasEncryptedValue:
+          typeof encryptedValue === 'string' && encryptedValue.length > 0,
+      };
+    });
+  expect(safeContinuation).toEqual([
+    {
+      id: 'reasoning-weather',
+      role: 'reasoning',
+      content: 'I need the weather tool.',
+      hasEncryptedValue: true,
+      metadata: { provider: { trace: ['original'] } },
+    },
+    {
+      id: expect.any(String),
+      role: 'assistant',
+      content: '',
+      toolCalls: [
+        {
+          id: 'call-weather',
+          type: 'function',
+          function: {
+            name: 'getWeather',
+            arguments: '{"city":"Paris"}',
+          },
+        },
+      ],
+    },
+    {
+      id: 'call-weather',
+      role: 'tool',
+      toolCallId: 'call-weather',
+      content: '{"city":"Paris","condition":"sunny"}',
+    },
+  ]);
+  const committedAssistant = chat
+    .messages()
+    .find(
+      (message) =>
+        message.role === 'assistant' && message.reasoningDetails !== undefined,
+    );
+  if (committedAssistant?.role !== 'assistant') {
+    throw new Error('Expected a committed assistant reasoning message.');
+  }
+  const capturedReasoning = secondRequest.input?.messages.find(
+    (message) => message.role === 'reasoning',
+  );
+  if (!capturedReasoning || capturedReasoning.role !== 'reasoning') {
+    throw new Error('Expected captured continuation reasoning.');
+  }
+  const capturedMetadata = capturedReasoning.metadata as {
+    provider: { trace: string[] };
+  };
+  const committedReasoning = committedAssistant.reasoningDetails?.[0];
+  const committedMetadata = committedReasoning?.metadata as {
+    provider: { trace: string[] };
+  };
+  const originalEncryptedValue = capturedReasoning.encryptedValue;
+
+  expect(capturedReasoning === committedReasoning).toBe(false);
+  expect(capturedMetadata).not.toBe(committedMetadata);
+  expect(capturedMetadata.provider).not.toBe(committedMetadata.provider);
+  expect(
+    typeof originalEncryptedValue === 'string' &&
+      originalEncryptedValue.length > 0 &&
+      committedReasoning?.encryptedValue === originalEncryptedValue,
+  ).toBe(true);
+  capturedReasoning.encryptedValue = 'mutated-captured-value';
+  capturedMetadata.provider.trace[0] = 'mutated-captured-metadata';
+
+  expect(committedReasoning?.encryptedValue === originalEncryptedValue).toBe(
+    true,
+  );
+  expect(committedMetadata).toEqual({ provider: { trace: ['original'] } });
+
+  teardown();
 });
 
 test('sends one RunAgentInput and requests only tools, structured, and ui', async () => {

--- a/packages/core/src/models/api.models.ts
+++ b/packages/core/src/models/api.models.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ReasoningMessage } from '@ag-ui/core';
 import { DeepPartial } from '../utils';
 import { ModelInput } from '../transport';
 
@@ -32,6 +33,19 @@ export interface AssistantMessage {
   role: 'assistant';
   content?: string;
   toolCalls?: ToolCall[];
+
+  /**
+   * Human-readable reasoning. When `reasoningDetails` is present, this value
+   * is derived from the ordered records' nonempty content.
+   */
+  reasoning?: string;
+
+  /**
+   * Ordered AG-UI reasoning records, including opaque continuation data such
+   * as encrypted values, subagent run IDs, and metadata. When present, these
+   * records take precedence over `reasoning`.
+   */
+  readonly reasoningDetails?: readonly Readonly<ReasoningMessage>[];
 }
 
 /**

--- a/packages/core/src/models/internal.models.ts
+++ b/packages/core/src/models/internal.models.ts
@@ -11,7 +11,7 @@ import { JsonValue } from '../utils';
 export type ɵInternalReasoning =
   | {
       readonly kind: 'details';
-      readonly details: readonly ReasoningMessage[];
+      readonly details: readonly Readonly<ReasoningMessage>[];
     }
   | {
       readonly kind: 'display';

--- a/packages/core/src/models/internal.models.ts
+++ b/packages/core/src/models/internal.models.ts
@@ -1,6 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue } from '../utils';
+
+/**
+ * Internal provider-neutral representation of assistant reasoning.
+ *
+ * @internal
+ */
+export type ɵInternalReasoning =
+  | {
+      readonly kind: 'details';
+      readonly details: readonly ReasoningMessage[];
+    }
+  | {
+      readonly kind: 'display';
+      readonly text: string;
+    };
 
 /**
  * @public
@@ -34,6 +50,7 @@ export interface AssistantMessage {
   content?: string;
   contentResolved?: JsonValue;
   toolCallIds: string[];
+  reasoning?: ɵInternalReasoning;
 }
 
 /**

--- a/packages/core/src/models/internal_helpers.spec.ts
+++ b/packages/core/src/models/internal_helpers.spec.ts
@@ -1,0 +1,233 @@
+import { type ReasoningMessage } from '@ag-ui/core';
+import {
+  type AnyTool,
+  type AssistantMessage as ViewAssistantMessage,
+} from './view.models';
+import {
+  toApiMessagesFromInternal,
+  toInternalMessagesFromApi,
+  toInternalMessagesFromView,
+  toViewMessagesFromInternal,
+} from './internal_helpers';
+
+function viewAssistant(
+  reasoning?: string,
+  reasoningDetails?: readonly Readonly<ReasoningMessage>[],
+): ViewAssistantMessage<string, AnyTool> {
+  return {
+    role: 'assistant',
+    content: 'answer',
+    toolCalls: [],
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(reasoningDetails !== undefined ? { reasoningDetails } : {}),
+  };
+}
+
+test('hydrates visible reasoning from details and isolates nested metadata', () => {
+  // Arrange
+  const metadata = { nested: { value: 'original' } };
+  const message = viewAssistant('stale display reasoning', [
+    {
+      id: 'r-1',
+      role: 'reasoning',
+      content: 'step one',
+      metadata,
+    },
+    {
+      id: 'r-2',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'opaque',
+    },
+    {
+      id: 'r-3',
+      role: 'reasoning',
+      content: 'step two',
+    },
+  ]);
+
+  // Act
+  const [internal] = toInternalMessagesFromView(message);
+  metadata.nested.value = 'mutated';
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Assert
+  expect(view).toEqual(
+    viewAssistant('step one\n\nstep two', [
+      {
+        id: 'r-1',
+        role: 'reasoning',
+        content: 'step one',
+        metadata: { nested: { value: 'original' } },
+      },
+      {
+        id: 'r-2',
+        role: 'reasoning',
+        content: '',
+        encryptedValue: 'opaque',
+      },
+      {
+        id: 'r-3',
+        role: 'reasoning',
+        content: 'step two',
+      },
+    ]),
+  );
+});
+
+test('preserves display-only empty reasoning as an own property', () => {
+  // Arrange
+  const message = viewAssistant('');
+
+  // Act
+  const [internal] = toInternalMessagesFromView(message);
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Assert
+  expect(view).toEqual(viewAssistant(''));
+  expect(Object.hasOwn(view, 'reasoning')).toBe(true);
+  expect((view as ViewAssistantMessage<string, AnyTool>).reasoning).toBe('');
+  expect(view).not.toHaveProperty('reasoningDetails');
+});
+
+test('round-trips complete ordered reasoning details through API messages', () => {
+  // Arrange
+  const details: readonly Readonly<ReasoningMessage>[] = [
+    {
+      id: 'r-1',
+      role: 'reasoning',
+      content: 'step one',
+      encryptedValue: 'opaque',
+      subagentRunId: 'subagent-1',
+      metadata: {
+        continuation: {
+          cursor: 'cursor-1',
+          checkpoints: [
+            { token: 'checkpoint-1' },
+            { token: 'checkpoint-2', state: { complete: false } },
+          ],
+        },
+      },
+    },
+  ];
+  const message = viewAssistant('stale display reasoning', details);
+  const [internal] = toInternalMessagesFromView(message);
+
+  // Act
+  const [api] = toApiMessagesFromInternal(internal, []);
+  const [roundTrippedInternal] = toInternalMessagesFromApi(api);
+  const [view] = toViewMessagesFromInternal(roundTrippedInternal, {}, []);
+
+  // Assert
+  expect(view).toEqual(viewAssistant('step one', details));
+});
+
+test('preserves all-opaque reasoning details without visible reasoning', () => {
+  // Arrange
+  const details: readonly Readonly<ReasoningMessage>[] = [
+    {
+      id: 'r-1',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'opaque-1',
+    },
+    {
+      id: 'r-2',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'opaque-2',
+      subagentRunId: 'subagent-2',
+    },
+  ];
+  const message = viewAssistant('stale display reasoning', details);
+
+  // Act
+  const [internal] = toInternalMessagesFromView(message);
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Assert
+  expect(view).toEqual(viewAssistant(undefined, details));
+  expect(view).not.toHaveProperty('reasoning');
+});
+
+test('prefers empty reasoning details over stale display reasoning', () => {
+  // Arrange
+  const message = viewAssistant('stale display reasoning', []);
+
+  // Act
+  const [internal] = toInternalMessagesFromView(message);
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Assert
+  expect(view).toEqual(viewAssistant(undefined, []));
+  expect(view).not.toHaveProperty('reasoning');
+});
+
+test('isolates reasoning details at view, API, and internal boundaries', () => {
+  // Arrange
+  const message = viewAssistant(undefined, [
+    {
+      id: 'r-1',
+      role: 'reasoning',
+      content: 'step one',
+      metadata: { nested: { value: 'original' } },
+    },
+  ]);
+  const [internal] = toInternalMessagesFromView(message);
+  const [api] = toApiMessagesFromInternal(internal, []);
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Act
+  const viewDetail = message.reasoningDetails?.[0];
+  const apiDetail =
+    api.role === 'assistant' ? api.reasoningDetails?.[0] : undefined;
+  const viewMetadata = viewDetail?.metadata?.['nested'] as { value: string };
+  const apiMetadata = apiDetail?.metadata?.['nested'] as { value: string };
+  viewMetadata.value = 'view mutation';
+  apiMetadata.value = 'API mutation';
+  const [rehydratedInternal] = toInternalMessagesFromApi(api);
+  apiMetadata.value = 'second API mutation';
+  const [rehydratedView] = toViewMessagesFromInternal(
+    rehydratedInternal,
+    {},
+    [],
+  );
+
+  // Assert
+  expect(view).toEqual(
+    viewAssistant('step one', [
+      {
+        id: 'r-1',
+        role: 'reasoning',
+        content: 'step one',
+        metadata: { nested: { value: 'original' } },
+      },
+    ]),
+  );
+  expect(rehydratedView).toEqual(
+    viewAssistant('step one', [
+      {
+        id: 'r-1',
+        role: 'reasoning',
+        content: 'step one',
+        metadata: { nested: { value: 'API mutation' } },
+      },
+    ]),
+  );
+});
+
+test('omits reasoning fields when they are absent', () => {
+  // Arrange
+  const message = viewAssistant();
+
+  // Act
+  const [internal] = toInternalMessagesFromView(message);
+  const [api] = toApiMessagesFromInternal(internal, []);
+  const [view] = toViewMessagesFromInternal(internal, {}, []);
+
+  // Assert
+  expect(api).not.toHaveProperty('reasoning');
+  expect(api).not.toHaveProperty('reasoningDetails');
+  expect(view).not.toHaveProperty('reasoning');
+  expect(view).not.toHaveProperty('reasoningDetails');
+});

--- a/packages/core/src/models/internal_helpers.ts
+++ b/packages/core/src/models/internal_helpers.ts
@@ -1,6 +1,71 @@
 import * as Chat from './public_api';
+import type { ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue, resolveWithSchema } from '../utils';
+
+type ReasoningInput = {
+  readonly reasoning?: string;
+  readonly reasoningDetails?: readonly Readonly<ReasoningMessage>[];
+};
+
+function cloneReasoningMessage(
+  reasoning: Readonly<ReasoningMessage>,
+): ReasoningMessage {
+  return {
+    ...reasoning,
+    ...(reasoning.metadata
+      ? { metadata: structuredClone(reasoning.metadata) }
+      : {}),
+  };
+}
+
+function cloneReasoningDetails(
+  details: readonly Readonly<ReasoningMessage>[],
+): readonly ReasoningMessage[] {
+  return details.map(cloneReasoningMessage);
+}
+
+function toInternalReasoning(
+  message: ReasoningInput,
+): Chat.Internal.ɵInternalReasoning | undefined {
+  if (message.reasoningDetails !== undefined) {
+    return {
+      kind: 'details',
+      details: cloneReasoningDetails(message.reasoningDetails),
+    };
+  }
+
+  if (message.reasoning !== undefined) {
+    return {
+      kind: 'display',
+      text: message.reasoning,
+    };
+  }
+
+  return undefined;
+}
+
+function toReasoningOutput(
+  reasoning: Chat.Internal.ɵInternalReasoning | undefined,
+): ReasoningInput {
+  if (reasoning?.kind === 'details') {
+    const text = reasoning.details
+      .map((detail) => detail.content)
+      .filter((content) => content.length > 0)
+      .join('\n\n');
+
+    return {
+      ...(text ? { reasoning: text } : {}),
+      reasoningDetails: cloneReasoningDetails(reasoning.details),
+    };
+  }
+
+  if (reasoning?.kind === 'display') {
+    return { reasoning: reasoning.text };
+  }
+
+  return {};
+}
 
 function normalizeAssistantContent(
   resolved: JsonValue | undefined,
@@ -54,12 +119,14 @@ export function toInternalMessagesFromView(
         typeof message.content === 'string'
           ? (message.content as string | undefined)
           : JSON.stringify(message.content);
+      const reasoning = toInternalReasoning(message);
       return [
         {
           role: 'assistant',
           content,
           contentResolved,
           toolCallIds: message.toolCalls.map((toolCall) => toolCall.toolCallId),
+          ...(reasoning ? { reasoning } : {}),
         },
       ];
     }
@@ -114,6 +181,7 @@ export function toViewMessagesFromInternal(
         {
           role: 'assistant',
           content,
+          ...toReasoningOutput(message.reasoning),
           toolCalls: message.toolCallIds.flatMap(
             (toolCallId): Chat.AnyToolCall[] => {
               const toolCall = toolCalls[toolCallId];
@@ -238,6 +306,7 @@ export function toApiMessagesFromInternal(
         {
           role: 'assistant',
           content,
+          ...toReasoningOutput(message.reasoning),
           toolCalls: toolCallsForMessage.map((toolCall, index) => ({
             id: toolCall.id,
             index,
@@ -472,6 +541,7 @@ export function toInternalMessagesFromApi(
   const rawContent = output ? output.function.arguments : message.content;
   const content =
     typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent);
+  const reasoning = toInternalReasoning(message);
 
   return [
     {
@@ -482,6 +552,7 @@ export function toInternalMessagesFromApi(
         message.toolCalls
           ?.filter((toolCall) => toolCall.function.name !== 'output')
           .map((toolCall) => toolCall.id) || [],
+      ...(reasoning ? { reasoning } : {}),
     },
   ];
 }

--- a/packages/core/src/models/view.models.ts
+++ b/packages/core/src/models/view.models.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue, Prettify } from '../utils';
 
@@ -69,6 +70,19 @@ export interface AssistantMessage<Output, ToolUnion extends AnyTool> {
   role: 'assistant';
   content?: Output;
   toolCalls: ToolCall<ToolUnion>[];
+
+  /**
+   * Human-readable reasoning. When `reasoningDetails` is present, this value
+   * is derived from the ordered records' nonempty content.
+   */
+  reasoning?: string;
+
+  /**
+   * Ordered AG-UI reasoning records, including opaque continuation data such
+   * as encrypted values, subagent run IDs, and metadata. When present, these
+   * records take precedence over `reasoning`.
+   */
+  readonly reasoningDetails?: readonly Readonly<ReasoningMessage>[];
 }
 
 /**

--- a/packages/core/src/reducers/status.reducer.spec.ts
+++ b/packages/core/src/reducers/status.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@ag-ui/core';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { apiActions, devActions, internalActions } from '../actions';
 import { Chat } from '../models';
 import { createStore } from '../utils/micro-ngrx';
@@ -99,6 +99,56 @@ test('marks generation active from AG-UI chunk events', () => {
     isReceiving: true,
     isGenerating: true,
   });
+});
+
+test('marks generation active from every AG-UI reasoning lifecycle event', () => {
+  const state = {
+    ...initialStatusState,
+    isReceiving: false,
+    isGenerating: false,
+  };
+  const events: AGUIEvent[] = [
+    {
+      type: EventType.REASONING_START,
+      messageId: 'reasoning-group-1',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: 'reasoning-1',
+      role: 'reasoning' as const,
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: 'reasoning-1',
+      delta: 'Analysis',
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message' as const,
+      entityId: 'reasoning-1',
+      encryptedValue: 'opaque',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: 'reasoning-1',
+    },
+    {
+      type: EventType.REASONING_END,
+      messageId: 'reasoning-group-1',
+    },
+  ];
+
+  const nextStates = events.map((event) =>
+    reducer(state, apiActions.generateMessageEvent(event)),
+  );
+
+  for (const next of nextStates) {
+    expect(next).toEqual({
+      ...state,
+      isReceiving: true,
+      isGenerating: true,
+    });
+  }
 });
 
 test('ignores AG-UI events unrelated to generation status', () => {

--- a/packages/core/src/reducers/status.reducer.ts
+++ b/packages/core/src/reducers/status.reducer.ts
@@ -64,6 +64,12 @@ export const reducer = createReducer(
       case EventType.TEXT_MESSAGE_START:
       case EventType.TEXT_MESSAGE_CONTENT:
       case EventType.TEXT_MESSAGE_CHUNK:
+      case EventType.REASONING_START:
+      case EventType.REASONING_MESSAGE_START:
+      case EventType.REASONING_MESSAGE_CONTENT:
+      case EventType.REASONING_ENCRYPTED_VALUE:
+      case EventType.REASONING_MESSAGE_END:
+      case EventType.REASONING_END:
       case EventType.TOOL_CALL_START:
       case EventType.TOOL_CALL_ARGS:
       case EventType.TOOL_CALL_CHUNK:

--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -1,4 +1,4 @@
-import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { type AGUIEvent, EventType, type ReasoningMessage } from '@ag-ui/core';
 import { apiActions, internalActions } from '../actions';
 import { Chat } from '../models';
 import { s } from '../schema';
@@ -91,6 +91,74 @@ function runFinished(): AGUIEvent {
     threadId: 'thread-1',
     runId: 'run-1',
   };
+}
+
+function reasoningStart(
+  messageId: string,
+  options: {
+    metadata?: Record<string, unknown>;
+    subagentRunId?: string;
+  } = {},
+): AGUIEvent {
+  return {
+    type: EventType.REASONING_MESSAGE_START,
+    messageId,
+    role: 'reasoning',
+    ...options,
+  };
+}
+
+function reasoningContent(
+  messageId: string,
+  delta: string,
+  options: {
+    metadata?: Record<string, unknown>;
+    subagentRunId?: string;
+  } = {},
+): AGUIEvent {
+  return {
+    type: EventType.REASONING_MESSAGE_CONTENT,
+    messageId,
+    delta,
+    ...options,
+  };
+}
+
+function reasoningEnd(
+  messageId: string,
+  options: {
+    metadata?: Record<string, unknown>;
+    subagentRunId?: string;
+  } = {},
+): AGUIEvent {
+  return {
+    type: EventType.REASONING_MESSAGE_END,
+    messageId,
+    ...options,
+  };
+}
+
+function reasoningEncryptedValue(
+  entityId: string,
+  encryptedValue: string,
+  subtype: 'message' | 'tool-call' = 'message',
+  metadata?: Record<string, unknown>,
+): AGUIEvent {
+  return {
+    type: EventType.REASONING_ENCRYPTED_VALUE,
+    subtype,
+    entityId,
+    encryptedValue,
+    metadata,
+  };
+}
+
+function reasoningDetails(
+  state: StreamingMessageState,
+): readonly Readonly<ReasoningMessage>[] {
+  return state.message?.reasoning?.kind === 'details'
+    ? state.message.reasoning.details
+    : [];
 }
 
 const generationSilentlyRetiredAction =
@@ -539,6 +607,439 @@ test('stores AG-UI run errors without discarding the partial message', () => {
 
   expect(state.message?.content).toBe('partial');
   expect(state.error).toEqual(new Error('provider failed'));
+});
+
+test('creates a pending assistant placeholder from the first reasoning message start', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [reasoningStart('reasoning-1')]);
+
+  expect(next.message).toEqual({
+    role: 'assistant',
+    content: '',
+    toolCallIds: [],
+    reasoning: {
+      kind: 'details',
+      details: [
+        {
+          id: 'reasoning-1',
+          role: 'reasoning',
+          content: '',
+        },
+      ],
+    },
+  });
+});
+
+test('finalizes a reasoning-only assistant message', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'I considered the options.'),
+    reasoningEnd('reasoning-1'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(state.message).toEqual({
+    role: 'assistant',
+    content: '',
+    toolCallIds: [],
+    reasoning: {
+      kind: 'details',
+      details: [
+        {
+          id: 'reasoning-1',
+          role: 'reasoning',
+          content: 'I considered the options.',
+        },
+      ],
+    },
+  });
+});
+
+test('completes reasoning with a prototype-named message id', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [
+    reasoningStart('constructor'),
+    reasoningContent('constructor', 'Analysis'),
+    reasoningEnd('constructor'),
+    runFinished(),
+  ]);
+
+  expect(next.error).toBeUndefined();
+  expect(reasoningDetails(next)).toEqual([
+    { id: 'constructor', role: 'reasoning', content: 'Analysis' },
+  ]);
+});
+
+test('finalizes reasoning followed by assistant text', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'Analysis'),
+    reasoningEnd('reasoning-1'),
+    ...textEvents('Answer'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(state.message?.content).toBe('Answer');
+  expect(reasoningDetails(state)).toEqual([
+    { id: 'reasoning-1', role: 'reasoning', content: 'Analysis' },
+  ]);
+});
+
+test('finalizes reasoning followed by a tool call', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'I need a lookup.'),
+    reasoningEnd('reasoning-1'),
+    ...toolEvents('call-1', 'lookup', '{}'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(state.message?.toolCallIds).toEqual(['call-1']);
+  expect(reasoningDetails(state)).toEqual([
+    {
+      id: 'reasoning-1',
+      role: 'reasoning',
+      content: 'I need a lookup.',
+    },
+  ]);
+});
+
+test('preserves multiple reasoning details in lifecycle order', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'First'),
+    reasoningEnd('reasoning-1'),
+    reasoningStart('reasoning-2'),
+    reasoningContent('reasoning-2', 'Second'),
+    reasoningEnd('reasoning-2'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(reasoningDetails(state)).toEqual([
+    { id: 'reasoning-1', role: 'reasoning', content: 'First' },
+    { id: 'reasoning-2', role: 'reasoning', content: 'Second' },
+  ]);
+});
+
+test('finalizes a redacted reasoning detail with empty display content', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningEncryptedValue('reasoning-1', 'opaque'),
+    reasoningEnd('reasoning-1'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(reasoningDetails(state)).toEqual([
+    {
+      id: 'reasoning-1',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'opaque',
+    },
+  ]);
+  expect(state.message?.content).toBe('');
+});
+
+test('keeps readable reasoning content separate from its encrypted value', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'Readable summary'),
+    reasoningEncryptedValue('reasoning-1', 'opaque'),
+    reasoningEnd('reasoning-1'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(reasoningDetails(state)).toEqual([
+    {
+      id: 'reasoning-1',
+      role: 'reasoning',
+      content: 'Readable summary',
+      encryptedValue: 'opaque',
+    },
+  ]);
+  expect(state.message?.content).toBe('');
+});
+
+test('preserves the latest mechanically supplied reasoning subagent run id', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1', { subagentRunId: 'subagent-start' }),
+    reasoningContent('reasoning-1', 'Analysis', {
+      subagentRunId: 'subagent-content',
+    }),
+    reasoningEnd('reasoning-1', { subagentRunId: 'subagent-end' }),
+  ]);
+
+  expect(reasoningDetails(state)).toEqual([
+    {
+      id: 'reasoning-1',
+      role: 'reasoning',
+      content: 'Analysis',
+      subagentRunId: 'subagent-end',
+    },
+  ]);
+});
+
+test('merges cloned reasoning metadata shallowly across start content and end', () => {
+  const startMetadata = {
+    stable: 'start',
+    replaced: { start: true },
+    list: ['start'],
+  };
+  const contentMetadata = {
+    replaced: { content: true },
+    list: ['content'],
+    contentOnly: true,
+  };
+  const endMetadata = {
+    stable: 'end',
+    endOnly: true,
+  };
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1', { metadata: startMetadata }),
+    reasoningContent('reasoning-1', 'Analysis', {
+      metadata: contentMetadata,
+    }),
+    reasoningEnd('reasoning-1', { metadata: endMetadata }),
+  ]);
+  startMetadata.replaced.start = false;
+  startMetadata.list.push('mutated');
+  contentMetadata.replaced.content = false;
+  contentMetadata.list.push('mutated');
+  endMetadata.stable = 'mutated';
+
+  expect(reasoningDetails(state)[0]?.metadata).toEqual({
+    stable: 'end',
+    replaced: { content: true },
+    list: ['content'],
+    contentOnly: true,
+    endOnly: true,
+  });
+});
+
+test('keeps encrypted-value event metadata local to that event', () => {
+  const encryptedMetadata = { provider: { signature: 'event-only' } };
+  let state = startState();
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1', {
+      metadata: { accumulated: 'detail' },
+    }),
+    reasoningEncryptedValue(
+      'reasoning-1',
+      'opaque',
+      'message',
+      encryptedMetadata,
+    ),
+  ]);
+
+  encryptedMetadata.provider.signature = 'mutated';
+
+  expect(reasoningDetails(state)[0]).toEqual({
+    id: 'reasoning-1',
+    role: 'reasoning',
+    content: '',
+    encryptedValue: 'opaque',
+    metadata: { accumulated: 'detail' },
+  });
+});
+
+test('sets encrypted values on active and completed reasoning details', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-active'),
+    reasoningEncryptedValue('reasoning-active', 'active-opaque'),
+    reasoningStart('reasoning-complete'),
+    reasoningEnd('reasoning-complete'),
+    reasoningEncryptedValue('reasoning-complete', 'complete-opaque'),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(reasoningDetails(state)).toEqual([
+    {
+      id: 'reasoning-active',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'active-opaque',
+    },
+    {
+      id: 'reasoning-complete',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'complete-opaque',
+    },
+  ]);
+});
+
+test('reports a stream error for a duplicate reasoning start', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningStart('reasoning-1'),
+  ]);
+
+  expect(state.error?.message).toBe(
+    'Reasoning message reasoning-1 has already started',
+  );
+});
+
+test('reports a stream error for reasoning content without a start', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [
+    reasoningContent('reasoning-unknown', 'Analysis'),
+  ]);
+
+  expect(next.error?.message).toBe(
+    'Reasoning message reasoning-unknown is not active',
+  );
+});
+
+test('reports a stream error for reasoning content after end', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningEnd('reasoning-1'),
+    reasoningContent('reasoning-1', 'Too late'),
+  ]);
+
+  expect(state.error?.message).toBe(
+    'Reasoning message reasoning-1 is not active',
+  );
+});
+
+test('reports a stream error for ending an unknown reasoning message', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [reasoningEnd('reasoning-unknown')]);
+
+  expect(next.error?.message).toBe(
+    'Reasoning message reasoning-unknown is not active',
+  );
+});
+
+test('reports a stream error for a duplicate reasoning end', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningEnd('reasoning-1'),
+    reasoningEnd('reasoning-1'),
+  ]);
+
+  expect(state.error?.message).toBe(
+    'Reasoning message reasoning-1 is not active',
+  );
+});
+
+test('reports a stream error for an unknown message encrypted-value id', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [
+    reasoningEncryptedValue('reasoning-unknown', 'opaque'),
+  ]);
+
+  expect(next.error?.message).toBe(
+    'Reasoning message reasoning-unknown does not exist',
+  );
+});
+
+test('reports a stream error when a run finishes with active reasoning', () => {
+  let state = startState();
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', 'Unfinished'),
+    runFinished(),
+  ]);
+
+  expect(state.error?.message).toBe(
+    'Reasoning message reasoning-1 is still active',
+  );
+});
+
+test('accepts top-level reasoning grouping events as exact no-ops', () => {
+  const state = startState();
+
+  const afterStart = reduceEvents(state, [
+    {
+      type: EventType.REASONING_START,
+      messageId: 'reasoning-group-1',
+    },
+  ]);
+  const afterEnd = reduceEvents(afterStart, [
+    {
+      type: EventType.REASONING_END,
+      messageId: 'reasoning-group-1',
+    },
+  ]);
+
+  expect(afterStart).toBe(state);
+  expect(afterEnd).toBe(state);
+});
+
+test('accepts tool-call encrypted values as exact no-ops', () => {
+  const state = startState();
+
+  const next = reduceEvents(state, [
+    reasoningEncryptedValue('unknown-tool-call', 'opaque', 'tool-call', {
+      eventOnly: true,
+    }),
+  ]);
+
+  expect(next).toBe(state);
+  expect(next.error).toBeUndefined();
+});
+
+test('isolates reasoning content and encrypted values from structured output parsing', () => {
+  const responseSchema = s.object('output', {
+    message: s.string('message'),
+  });
+  let state = startState(responseSchema, false);
+
+  state = reduceEvents(state, [
+    reasoningStart('reasoning-1'),
+    reasoningContent('reasoning-1', '{"message":"reasoning"}'),
+    reasoningEncryptedValue('reasoning-1', '{"message":"encrypted"}'),
+    reasoningEnd('reasoning-1'),
+  ]);
+
+  expect(state.outputParserState).toBeUndefined();
+  expect(state.message?.content).toBe('');
+  expect(state.message?.contentResolved).toBeUndefined();
+
+  state = reduceEvents(state, [
+    ...textEvents('{"message":"text"}'),
+    runFinished(),
+  ]);
+
+  expect(state.error).toBeUndefined();
+  expect(state.message?.contentResolved).toEqual({ message: 'text' });
 });
 
 test('silent retirement resets all partial generation state', () => {

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -1,4 +1,14 @@
-import { type AGUIEvent, EventType } from '@ag-ui/core';
+import {
+  type AGUIEvent,
+  EventType,
+  mergeMetadata,
+  type Metadata,
+  type ReasoningEncryptedValueEvent,
+  type ReasoningMessage,
+  type ReasoningMessageContentEvent,
+  type ReasoningMessageEndEvent,
+  type ReasoningMessageStartEvent,
+} from '@ag-ui/core';
 import {
   create,
   finish,
@@ -25,6 +35,7 @@ export interface StreamingMessageState {
   toolParserStateById: ParserMap;
   toolCacheById: CacheMap;
   finalizedToolCallIds: Record<string, true>;
+  reasoningMessageStatusById: Record<string, 'active' | 'complete'>;
   configSnapshot?: {
     responseSchema?: s.HashbrownType;
     emulateStructuredOutput: boolean;
@@ -43,6 +54,7 @@ export const initialState: StreamingMessageState = {
   toolParserStateById: {},
   toolCacheById: {},
   finalizedToolCallIds: {},
+  reasoningMessageStatusById: {},
   configSnapshot: undefined,
   error: undefined,
 };
@@ -147,6 +159,200 @@ function getToolCallMetadata(rawEvent: unknown) {
   }
 
   return metadata as Record<string, unknown>;
+}
+
+function cloneMetadata(metadata: Metadata | undefined) {
+  return metadata === undefined ? undefined : structuredClone(metadata);
+}
+
+function withStreamError(
+  state: StreamingMessageState,
+  message: string,
+): StreamingMessageState {
+  return {
+    ...state,
+    error: state.error ?? new Error(message),
+  };
+}
+
+function getReasoningDetails(
+  message: Chat.Internal.AssistantMessage | null,
+): readonly Readonly<ReasoningMessage>[] {
+  return message?.reasoning?.kind === 'details'
+    ? message.reasoning.details
+    : [];
+}
+
+function updateReasoningDetail(
+  state: StreamingMessageState,
+  messageId: string,
+  update: (detail: Readonly<ReasoningMessage>) => ReasoningMessage,
+): StreamingMessageState | undefined {
+  const message = state.message;
+  const details = getReasoningDetails(message);
+  const detailIndex = details.findIndex((detail) => detail.id === messageId);
+  if (!message || detailIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    ...state,
+    message: {
+      ...message,
+      reasoning: {
+        kind: 'details',
+        details: details.map((detail, index) =>
+          index === detailIndex ? update(detail) : detail,
+        ),
+      },
+    },
+  };
+}
+
+function mergeReasoningEventFields(
+  detail: Readonly<ReasoningMessage>,
+  event: {
+    metadata?: Metadata;
+    subagentRunId?: string;
+  },
+): ReasoningMessage {
+  const metadata = mergeMetadata(
+    detail.metadata,
+    cloneMetadata(event.metadata),
+  );
+
+  return {
+    ...detail,
+    ...(event.subagentRunId !== undefined
+      ? { subagentRunId: event.subagentRunId }
+      : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+function startReasoningMessage(
+  state: StreamingMessageState,
+  event: ReasoningMessageStartEvent,
+): StreamingMessageState {
+  if (Object.hasOwn(state.reasoningMessageStatusById, event.messageId)) {
+    return withStreamError(
+      state,
+      `Reasoning message ${event.messageId} has already started`,
+    );
+  }
+
+  const details = getReasoningDetails(state.message);
+  const metadata = mergeMetadata(undefined, cloneMetadata(event.metadata));
+  const detail: ReasoningMessage = {
+    id: event.messageId,
+    role: 'reasoning',
+    content: '',
+    ...(event.subagentRunId !== undefined
+      ? { subagentRunId: event.subagentRunId }
+      : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+  const message = state.message ?? {
+    role: 'assistant' as const,
+    content: '',
+    toolCallIds: state.toolCalls.map((toolCall) => toolCall.id),
+  };
+
+  return {
+    ...state,
+    message: {
+      ...message,
+      reasoning: {
+        kind: 'details',
+        details: [...details, detail],
+      },
+    },
+    reasoningMessageStatusById: {
+      ...state.reasoningMessageStatusById,
+      [event.messageId]: 'active',
+    },
+  };
+}
+
+function appendReasoningContent(
+  state: StreamingMessageState,
+  event: ReasoningMessageContentEvent,
+): StreamingMessageState {
+  if (
+    !Object.hasOwn(state.reasoningMessageStatusById, event.messageId) ||
+    state.reasoningMessageStatusById[event.messageId] !== 'active'
+  ) {
+    return withStreamError(
+      state,
+      `Reasoning message ${event.messageId} is not active`,
+    );
+  }
+
+  const next = updateReasoningDetail(state, event.messageId, (detail) => ({
+    ...mergeReasoningEventFields(detail, event),
+    content: detail.content + event.delta,
+  }));
+  return (
+    next ??
+    withStreamError(
+      state,
+      `Reasoning message ${event.messageId} does not exist`,
+    )
+  );
+}
+
+function endReasoningMessage(
+  state: StreamingMessageState,
+  event: ReasoningMessageEndEvent,
+): StreamingMessageState {
+  if (
+    !Object.hasOwn(state.reasoningMessageStatusById, event.messageId) ||
+    state.reasoningMessageStatusById[event.messageId] !== 'active'
+  ) {
+    return withStreamError(
+      state,
+      `Reasoning message ${event.messageId} is not active`,
+    );
+  }
+
+  const next = updateReasoningDetail(state, event.messageId, (detail) =>
+    mergeReasoningEventFields(detail, event),
+  );
+  if (!next) {
+    return withStreamError(
+      state,
+      `Reasoning message ${event.messageId} does not exist`,
+    );
+  }
+
+  return {
+    ...next,
+    reasoningMessageStatusById: {
+      ...next.reasoningMessageStatusById,
+      [event.messageId]: 'complete',
+    },
+  };
+}
+
+function applyReasoningEncryptedValue(
+  state: StreamingMessageState,
+  event: ReasoningEncryptedValueEvent,
+): StreamingMessageState {
+  if (event.subtype === 'tool-call') {
+    return state;
+  }
+
+  const next = updateReasoningDetail(state, event.entityId, (detail) => ({
+    ...detail,
+    encryptedValue: event.encryptedValue,
+    ...(event.subagentRunId !== undefined
+      ? { subagentRunId: event.subagentRunId }
+      : {}),
+  }));
+  return (
+    next ??
+    withStreamError(state, `Reasoning message ${event.entityId} does not exist`)
+  );
 }
 
 function startTextMessage(
@@ -549,7 +755,17 @@ function finalizeToolCalls(
 }
 
 function finishRun(state: StreamingMessageState): StreamingMessageState {
-  return finalizeToolCalls(finalizeOutput(state));
+  const activeReasoningMessageId = Object.entries(
+    state.reasoningMessageStatusById,
+  ).find(([, status]) => status === 'active')?.[0];
+  const next = activeReasoningMessageId
+    ? withStreamError(
+        state,
+        `Reasoning message ${activeReasoningMessageId} is still active`,
+      )
+    : state;
+
+  return finalizeToolCalls(finalizeOutput(next));
 }
 
 function reduceEvent(
@@ -557,6 +773,17 @@ function reduceEvent(
   event: AGUIEvent,
 ): StreamingMessageState {
   switch (event.type) {
+    case EventType.REASONING_START:
+    case EventType.REASONING_END:
+      return state;
+    case EventType.REASONING_MESSAGE_START:
+      return startReasoningMessage(state, event);
+    case EventType.REASONING_MESSAGE_CONTENT:
+      return appendReasoningContent(state, event);
+    case EventType.REASONING_ENCRYPTED_VALUE:
+      return applyReasoningEncryptedValue(state, event);
+    case EventType.REASONING_MESSAGE_END:
+      return endReasoningMessage(state, event);
     case EventType.TEXT_MESSAGE_START:
       return startTextMessage(state, event);
     case EventType.TEXT_MESSAGE_CONTENT:

--- a/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
@@ -89,6 +89,246 @@ test('maps assistant content and function tool calls', () => {
   ] satisfies Message[]);
 });
 
+test('emits ordered reasoning details before the assistant and its tool results', () => {
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'assistant',
+      content: 'Checking.',
+      reasoning: 'Stale display reasoning.',
+      reasoningDetails: [
+        {
+          id: 'reasoning-readable',
+          role: 'reasoning',
+          content: 'I need the weather.',
+          encryptedValue: 'encrypted-readable',
+          subagentRunId: 'subagent-1',
+          metadata: { provider: { cache: ['hit'] } },
+        },
+        {
+          id: 'reasoning-opaque',
+          role: 'reasoning',
+          content: '',
+          encryptedValue: 'encrypted-opaque',
+          subagentRunId: 'subagent-2',
+          metadata: { provider: { cache: ['opaque'] } },
+        },
+      ],
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-weather',
+          type: 'function',
+          function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-weather',
+      toolName: 'getWeather',
+      content: { status: 'fulfilled', value: 'Sunny' },
+    },
+  ];
+
+  const input = createInput({ messages });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'reasoning-readable',
+      role: 'reasoning',
+      content: 'I need the weather.',
+      encryptedValue: 'encrypted-readable',
+      subagentRunId: 'subagent-1',
+      metadata: { provider: { cache: ['hit'] } },
+    },
+    {
+      id: 'reasoning-opaque',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'encrypted-opaque',
+      subagentRunId: 'subagent-2',
+      metadata: { provider: { cache: ['opaque'] } },
+    },
+    {
+      id: 'thread-1:message:0',
+      role: 'assistant',
+      content: 'Checking.',
+      toolCalls: [
+        {
+          id: 'call-weather',
+          type: 'function',
+          function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
+        },
+      ],
+    },
+    {
+      id: 'call-weather',
+      role: 'tool',
+      toolCallId: 'call-weather',
+      content: 'Sunny',
+    },
+  ] satisfies Message[]);
+});
+
+test('emits metadata-free display reasoning with a deterministic ID', () => {
+  const input = createInput({
+    messages: [
+      {
+        role: 'assistant',
+        content: 'Answer.',
+        reasoning: 'Visible reasoning.',
+      },
+    ],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'thread-1:message:0:reasoning',
+      role: 'reasoning',
+      content: 'Visible reasoning.',
+    },
+    {
+      id: 'thread-1:message:0',
+      role: 'assistant',
+      content: 'Answer.',
+    },
+  ] satisfies Message[]);
+});
+
+test('emits display-only empty reasoning', () => {
+  const input = createInput({
+    messages: [{ role: 'assistant', content: 'Answer.', reasoning: '' }],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'thread-1:message:0:reasoning',
+      role: 'reasoning',
+      content: '',
+    },
+    {
+      id: 'thread-1:message:0',
+      role: 'assistant',
+      content: 'Answer.',
+    },
+  ] satisfies Message[]);
+});
+
+test('prefers empty reasoning details over stale display reasoning', () => {
+  const input = createInput({
+    messages: [
+      {
+        role: 'assistant',
+        content: 'Answer.',
+        reasoning: 'Stale display reasoning.',
+        reasoningDetails: [],
+      },
+    ],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'thread-1:message:0',
+      role: 'assistant',
+      content: 'Answer.',
+    },
+  ] satisfies Message[]);
+});
+
+test('emits no reasoning record for an assistant without reasoning fields', () => {
+  const input = createInput({
+    messages: [{ role: 'assistant', content: 'Answer.' }],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'thread-1:message:0',
+      role: 'assistant',
+      content: 'Answer.',
+    },
+  ] satisfies Message[]);
+});
+
+test('isolates reasoning detail metadata from source and sibling output records', () => {
+  const metadata = { provider: { cache: ['original'] } };
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'assistant',
+      content: 'Answer.',
+      reasoningDetails: [
+        { id: 'reasoning-1', role: 'reasoning', content: 'First.', metadata },
+        { id: 'reasoning-2', role: 'reasoning', content: 'Second.', metadata },
+      ],
+    },
+  ];
+
+  const input = createInput({ messages });
+  metadata.provider.cache[0] = 'source-mutated';
+  const output = input.messages.filter(
+    (message): message is Extract<Message, { role: 'reasoning' }> =>
+      message.role === 'reasoning',
+  );
+  const firstMetadata = output[0]?.metadata as {
+    provider: { cache: string[] };
+  };
+  firstMetadata.provider.cache[0] = 'output-mutated';
+
+  expect(output).toEqual([
+    {
+      id: 'reasoning-1',
+      role: 'reasoning',
+      content: 'First.',
+      metadata: { provider: { cache: ['output-mutated'] } },
+    },
+    {
+      id: 'reasoning-2',
+      role: 'reasoning',
+      content: 'Second.',
+      metadata: { provider: { cache: ['original'] } },
+    },
+  ]);
+});
+
+test('keeps unrelated system, user, and tool messages unchanged without reasoning', () => {
+  const input = createInput({
+    system: 'System prompt.',
+    messages: [
+      { role: 'user', content: 'Hello.' },
+      { role: 'assistant', content: 'Calling a tool.' },
+      {
+        role: 'tool',
+        toolCallId: 'call-1',
+        toolName: 'echo',
+        content: { status: 'fulfilled', value: { greeting: 'Hello.' } },
+      },
+    ],
+  });
+
+  expect(input.messages).toEqual([
+    {
+      id: 'thread-1:system',
+      role: 'system',
+      content: 'System prompt.',
+    },
+    {
+      id: 'thread-1:message:0',
+      role: 'user',
+      content: 'Hello.',
+    },
+    {
+      id: 'thread-1:message:1',
+      role: 'assistant',
+      content: 'Calling a tool.',
+    },
+    {
+      id: 'call-1',
+      role: 'tool',
+      toolCallId: 'call-1',
+      content: '{"greeting":"Hello."}',
+    },
+  ] satisfies Message[]);
+});
+
 test('maps fulfilled tool results without losing strings', () => {
   const messages: Chat.Api.Message[] = [
     {

--- a/packages/core/src/transport/hashbrown-run-agent-input.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.ts
@@ -1,4 +1,9 @@
-import type { Message, RunAgentInput, Tool } from '@ag-ui/core';
+import type {
+  Message,
+  ReasoningMessage,
+  RunAgentInput,
+  Tool,
+} from '@ag-ui/core';
 import { Chat } from '../models';
 
 /**
@@ -64,18 +69,29 @@ function normalizeRejection(reason: unknown): string {
   return normalizeValue(reason);
 }
 
+function cloneReasoningMessage(
+  reasoning: Readonly<ReasoningMessage>,
+): ReasoningMessage {
+  return {
+    ...reasoning,
+    ...(reasoning.metadata
+      ? { metadata: structuredClone(reasoning.metadata) }
+      : {}),
+  };
+}
+
 function mapMessage(
   message: Chat.Api.Message,
   threadId: string,
   index: number,
-): Message | undefined {
+): Message[] {
   const id = `${threadId}:message:${index}`;
 
   switch (message.role) {
     case 'user':
-      return { id, role: 'user', content: message.content };
-    case 'assistant':
-      return {
+      return [{ id, role: 'user', content: message.content }];
+    case 'assistant': {
+      const assistant: Message = {
         id,
         role: 'assistant',
         ...(message.content !== undefined ? { content: message.content } : {}),
@@ -92,27 +108,52 @@ function mapMessage(
             }
           : {}),
       };
+
+      if (message.reasoningDetails !== undefined) {
+        return [
+          ...message.reasoningDetails.map(cloneReasoningMessage),
+          assistant,
+        ];
+      }
+
+      if (message.reasoning !== undefined) {
+        return [
+          {
+            id: `${id}:reasoning`,
+            role: 'reasoning',
+            content: message.reasoning,
+          },
+          assistant,
+        ];
+      }
+
+      return [assistant];
+    }
     case 'tool': {
       if (message.content.status === 'fulfilled') {
-        return {
-          id: message.toolCallId,
-          role: 'tool',
-          toolCallId: message.toolCallId,
-          content: normalizeValue(message.content.value),
-        };
+        return [
+          {
+            id: message.toolCallId,
+            role: 'tool',
+            toolCallId: message.toolCallId,
+            content: normalizeValue(message.content.value),
+          },
+        ];
       }
 
       const error = normalizeRejection(message.content.reason);
-      return {
-        id: message.toolCallId,
-        role: 'tool',
-        toolCallId: message.toolCallId,
-        content: error,
-        error,
-      };
+      return [
+        {
+          id: message.toolCallId,
+          role: 'tool',
+          toolCallId: message.toolCallId,
+          content: error,
+          error,
+        },
+      ];
     }
     case 'error':
-      return undefined;
+      return [];
   }
 }
 
@@ -138,10 +179,9 @@ export function createHashbrownRunAgentInput({
   responseSchema,
   ui,
 }: CreateHashbrownRunAgentInputOptions): HashbrownRunAgentInput {
-  const history = messages.flatMap((message, index) => {
-    const mapped = mapMessage(message, threadId, index);
-    return mapped ? [mapped] : [];
-  });
+  const history = messages.flatMap((message, index) =>
+    mapMessage(message, threadId, index),
+  );
   const hashbrown =
     responseSchema !== undefined || ui === true
       ? {

--- a/packages/openai/jest.config.ts
+++ b/packages/openai/jest.config.ts
@@ -7,5 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/openai',
-  testPathIgnorePatterns: ['(?!.*integration).*\\.ts$'],
+  testPathIgnorePatterns: ['/integration\\.spec\\.ts$'],
 };

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -12,7 +12,7 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@ag-ui/core": "0.0.58",
+    "@ag-ui/core": "0.0.59",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/openai/project.json
+++ b/packages/openai/project.json
@@ -40,7 +40,7 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "packages/openai/jest.config.ts",
-        "passWithNoTests": true
+        "passWithNoTests": false
       }
     },
     "e2e": {

--- a/packages/openai/src/integration.spec.ts
+++ b/packages/openai/src/integration.spec.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
 import {
   runProviderAGUIWithAimock,
   startAimock,
@@ -255,6 +255,7 @@ test('OpenAI maps complete AG-UI history without provider-specific wire keys', a
         throw new Error('stop after capture');
       },
     }),
+    (event) => EventSchemas.parse(event),
   );
 
   expect(capturedMessages).toEqual([

--- a/packages/openai/src/integration.spec.ts
+++ b/packages/openai/src/integration.spec.ts
@@ -1,6 +1,9 @@
 import { resolve } from 'node:path';
-import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
-import { startAimock } from '@hashbrownai/testing/aimock';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import {
+  runProviderAGUIWithAimock,
+  startAimock,
+} from '@hashbrownai/testing/aimock';
 import OpenAI from 'openai';
 import { HashbrownOpenAI } from './index';
 import type { OpenAIHashbrownRunAgentInput } from './stream/text.fn';
@@ -34,36 +37,21 @@ function baseInput(userMessage: string): OpenAIHashbrownRunAgentInput {
   };
 }
 
-async function collectEvents(
-  events: AsyncIterable<AGUIEvent>,
-): Promise<AGUIEvent[]> {
-  const collected: AGUIEvent[] = [];
-
-  for await (const event of events) {
-    collected.push(EventSchemas.parse(event));
-  }
-
-  return collected;
-}
-
 async function runFixture(
   fixtureName: string,
   input: OpenAIHashbrownRunAgentInput,
 ): Promise<AGUIEvent[]> {
-  const aimock = await startAimock({ fixturePath: fixturePath(fixtureName) });
-
-  try {
-    return await collectEvents(
+  return runProviderAGUIWithAimock({
+    fixturePath: fixturePath(fixtureName),
+    createStream: (aimock, signal) =>
       HashbrownOpenAI.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.openAiBaseUrl,
         model: OPENAI_MODEL,
         input,
+        signal,
       }),
-    );
-  } finally {
-    await aimock.stop();
-  }
+  });
 }
 
 function contentEvents(events: AGUIEvent[]) {
@@ -189,27 +177,21 @@ test('OpenAI maps the Hashbrown response schema to native structured output', as
     },
   };
   let capturedResponseFormat: unknown;
-  const aimock = await startAimock({
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('structured-output.json'),
-  });
-
-  let events: AGUIEvent[];
-  try {
-    events = await collectEvents(
+    createStream: (aimock, signal) =>
       HashbrownOpenAI.stream.text({
         apiKey: 'test-not-used',
         baseURL: aimock.openAiBaseUrl,
         model: OPENAI_MODEL,
         input,
+        signal,
         transformRequestOptions: (options) => {
           capturedResponseFormat = options.response_format;
           return options;
         },
       }),
-    );
-  } finally {
-    await aimock.stop();
-  }
+  });
 
   expect(capturedResponseFormat).toEqual({
     type: 'json_schema',
@@ -263,7 +245,7 @@ test('OpenAI maps complete AG-UI history without provider-specific wire keys', a
   ];
   let capturedMessages: OpenAI.ChatCompletionMessageParam[] | undefined;
 
-  await collectEvents(
+  await Array.fromAsync(
     HashbrownOpenAI.stream.text({
       apiKey: 'test-not-used',
       model: OPENAI_MODEL,

--- a/packages/openai/src/stream/text.fn.spec.ts
+++ b/packages/openai/src/stream/text.fn.spec.ts
@@ -1,0 +1,372 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import OpenAI from 'openai';
+import {
+  type OpenAIHashbrownRunAgentInput,
+  type OpenAITextStreamOptions,
+  text,
+} from './text.fn';
+
+jest.mock('openai', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+type Chunk = OpenAI.Chat.Completions.ChatCompletionChunk;
+
+const MockedOpenAI = OpenAI as unknown as jest.Mock;
+
+function createInput(
+  overrides: Partial<OpenAIHashbrownRunAgentInput> = {},
+): OpenAIHashbrownRunAgentInput {
+  return {
+    threadId: 'thread-openai',
+    runId: 'run-openai',
+    messages: [{ id: 'user-openai', role: 'user', content: 'Hello.' }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+function createOptions(
+  overrides: Partial<OpenAITextStreamOptions> = {},
+): OpenAITextStreamOptions {
+  return {
+    apiKey: 'test-api-key',
+    baseURL: 'https://openai.test/v1',
+    model: 'gpt-test',
+    input: createInput(),
+    ...overrides,
+  };
+}
+
+function chunk(
+  delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta,
+): Chunk {
+  return {
+    id: 'completion-chunk',
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+    created: 0,
+    model: 'gpt-test',
+    object: 'chat.completion.chunk',
+  };
+}
+
+function createProviderStream(chunks: readonly Chunk[], sourceError?: Error) {
+  const abort = jest.fn();
+  const iteratorReturn = jest.fn(async () => ({
+    done: true as const,
+    value: undefined,
+  }));
+  let index = 0;
+  const stream = {
+    abort,
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<Chunk>> {
+          if (sourceError) {
+            throw sourceError;
+          }
+
+          const value = chunks[index];
+          index += 1;
+
+          return value === undefined
+            ? { done: true, value: undefined }
+            : { done: false, value };
+        },
+        return: iteratorReturn,
+      };
+    },
+  };
+
+  return { abort, iteratorReturn, stream };
+}
+
+function mockProvider(chunks: readonly Chunk[] = [], sourceError?: Error) {
+  MockedOpenAI.mockReset();
+  const providerStream = createProviderStream(chunks, sourceError);
+  const stream = jest.fn().mockReturnValue(providerStream.stream);
+  MockedOpenAI.mockImplementation(() => ({
+    chat: { completions: { stream } },
+  }));
+
+  return { ...providerStream, create: stream };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    deepFreeze(nestedValue);
+  }
+
+  return Object.freeze(value);
+}
+
+async function collectEvents(
+  options: OpenAITextStreamOptions,
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of text(options)) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  return events;
+}
+
+test('isolates frozen schemas from a mutating transform and omits reasoning', async () => {
+  const provider = mockProvider();
+  const input = deepFreeze(
+    createInput({
+      messages: [
+        { id: 'user-openai', role: 'user', content: 'Use the schema.' },
+        {
+          id: 'reasoning-openai',
+          role: 'reasoning',
+          content: 'private reasoning',
+          encryptedValue: 'private signature',
+          metadata: { provider: { trace: ['private trace'] } },
+        },
+        { id: 'assistant-openai', role: 'assistant', content: 'Prior answer.' },
+      ],
+      tools: [
+        {
+          name: 'lookup',
+          description: 'Lookup a value.',
+          parameters: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'Original tool field.' },
+            },
+            required: ['query'],
+          },
+        },
+      ],
+      hashbrown: {
+        responseSchema: {
+          type: 'object',
+          properties: {
+            answer: {
+              type: 'string',
+              description: 'Original response field.',
+            },
+          },
+          required: ['answer'],
+        },
+      },
+    }),
+  );
+  const inputSnapshot = structuredClone(input);
+  let capturedOptions:
+    OpenAI.Chat.ChatCompletionCreateParamsStreaming | undefined;
+
+  const events = await collectEvents(
+    createOptions({
+      input,
+      transformRequestOptions: (options) => {
+        capturedOptions = options;
+        const tool = options.tools?.[0];
+        if (tool?.type !== 'function') {
+          throw new Error('Expected a function tool.');
+        }
+        const toolParameters = tool.function.parameters as {
+          properties: { query: { description: string } };
+        };
+        const responseFormat = options.response_format;
+        if (responseFormat?.type !== 'json_schema') {
+          throw new Error('Expected native JSON schema response format.');
+        }
+        const responseSchema = responseFormat.json_schema.schema as {
+          properties: { answer: { description: string } };
+        };
+
+        toolParameters.properties.query.description = 'Mutated tool field.';
+        responseSchema.properties.answer.description =
+          'Mutated response field.';
+        return options;
+      },
+    }),
+  );
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.RUN_FINISHED,
+  ]);
+  expect(input).toEqual(inputSnapshot);
+  expect(capturedOptions?.messages).toEqual([
+    { role: 'user', content: 'Use the schema.' },
+    { role: 'assistant', content: 'Prior answer.' },
+  ]);
+  expect(JSON.stringify(capturedOptions)).not.toContain('private reasoning');
+  expect(JSON.stringify(capturedOptions)).not.toContain('private signature');
+  expect(JSON.stringify(capturedOptions)).not.toContain('private trace');
+  const capturedTool = capturedOptions?.tools?.[0];
+  expect(capturedTool?.type).toBe('function');
+  if (capturedTool?.type !== 'function') {
+    throw new Error('Expected a captured function tool.');
+  }
+  expect(
+    (
+      capturedTool.function.parameters as {
+        properties: { query: { description: string } };
+      }
+    ).properties.query.description,
+  ).toBe('Mutated tool field.');
+  expect(input.tools[0]?.parameters).toEqual(
+    inputSnapshot.tools[0]?.parameters,
+  );
+  expect(input.hashbrown?.responseSchema).toEqual(
+    inputSnapshot.hashbrown?.responseSchema,
+  );
+  expect(provider.create).toHaveBeenCalledTimes(1);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('streams refusal fragments through one assistant text lifecycle', async () => {
+  const provider = mockProvider([
+    chunk({ refusal: 'I cannot' }),
+    chunk({ refusal: ' help with that.' }),
+  ]);
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-openai:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-openai:assistant',
+      delta: 'I cannot',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-openai:assistant',
+      delta: ' help with that.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-openai:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('maps a provider source rejection to one RUN_ERROR and cleans up', async () => {
+  const sourceError = new Error('OpenAI source failed');
+  const provider = mockProvider([], sourceError);
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+    { type: EventType.RUN_ERROR, message: 'OpenAI source failed' },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('cancellation after content emits no synthetic lifecycle ends', async () => {
+  const provider = mockProvider([
+    chunk({ content: 'First fragment.' }),
+    chunk({ content: 'Second fragment.' }),
+  ]);
+  const controller = new AbortController();
+  const iterator = text(createOptions({ signal: controller.signal }))[
+    Symbol.asyncIterator
+  ]();
+  const events = [
+    EventSchemas.parse((await iterator.next()).value),
+    EventSchemas.parse((await iterator.next()).value),
+    EventSchemas.parse((await iterator.next()).value),
+  ];
+
+  controller.abort();
+  const done = await iterator.next();
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+  ]);
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.TEXT_MESSAGE_END }),
+      expect.objectContaining({ type: EventType.TOOL_CALL_END }),
+      expect.objectContaining({ type: EventType.RUN_ERROR }),
+      expect.objectContaining({ type: EventType.RUN_FINISHED }),
+    ]),
+  );
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+  expect(provider.iteratorReturn).toHaveBeenCalledTimes(1);
+});
+
+test('consumer return aborts an active provider stream', async () => {
+  const provider = mockProvider([chunk({ content: 'First fragment.' })]);
+  const iterator = text(createOptions())[Symbol.asyncIterator]();
+
+  await iterator.next();
+  await iterator.next();
+  const returned = await iterator.return?.();
+
+  expect(returned).toEqual({ done: true, value: undefined });
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+  expect(provider.iteratorReturn).toHaveBeenCalledTimes(1);
+});
+
+test('incomplete tool metadata produces one RUN_ERROR without synthetic ends', async () => {
+  const provider = mockProvider([
+    chunk({
+      tool_calls: [
+        {
+          index: 0,
+          function: { arguments: '{"query":"hashbrown"}' },
+        },
+      ],
+    }),
+  ]);
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-openai',
+      runId: 'run-openai',
+    },
+    {
+      type: EventType.RUN_ERROR,
+      message: 'OpenAI returned incomplete metadata for tool call at index 0',
+    },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});

--- a/packages/openai/src/stream/text.fn.ts
+++ b/packages/openai/src/stream/text.fn.ts
@@ -3,6 +3,8 @@ import {
   EventType,
   type Message,
   type RunAgentInput,
+  type TextMessageContentEvent,
+  type TextMessageStartEvent,
 } from '@ag-ui/core';
 import OpenAI from 'openai';
 import type { FunctionParameters } from 'openai/resources/shared';
@@ -115,9 +117,38 @@ function createResponseFormat(
       strict: true,
       name: 'schema',
       description: '',
-      schema: responseSchema as Record<string, unknown>,
+      schema: structuredClone(responseSchema) as Record<string, unknown>,
     },
   };
+}
+
+/**
+ * Maps one non-empty provider text fragment to canonical AG-UI events.
+ */
+function createTextDeltaEvents(
+  messageId: string,
+  delta: string | null | undefined,
+  started: boolean,
+): Array<TextMessageStartEvent | TextMessageContentEvent> {
+  if (!delta) {
+    return [];
+  }
+
+  const contentEvent: TextMessageContentEvent = {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId,
+    delta,
+  };
+  if (started) {
+    return [contentEvent];
+  }
+
+  const startEvent: TextMessageStartEvent = {
+    type: EventType.TEXT_MESSAGE_START,
+    messageId,
+    role: 'assistant',
+  };
+  return [startEvent, contentEvent];
 }
 
 function mergeToolCall(
@@ -193,7 +224,10 @@ export async function* text(
               function: {
                 name: tool.name,
                 description: tool.description,
-                parameters: tool.parameters as FunctionParameters,
+                parameters:
+                  tool.parameters === undefined
+                    ? undefined
+                    : (structuredClone(tool.parameters) as FunctionParameters),
                 strict: true,
               },
             }))
@@ -221,27 +255,20 @@ export async function* text(
           continue;
         }
 
-        const content = choice.delta.content;
-        if (content) {
-          if (!textStarted) {
+        for (const textDelta of [choice.delta.content, choice.delta.refusal]) {
+          const textEvents = createTextDeltaEvents(
+            messageId,
+            textDelta,
+            textStarted,
+          );
+          if (textEvents.length > 0) {
             textStarted = true;
-            yield {
-              type: EventType.TEXT_MESSAGE_START,
-              messageId,
-              role: 'assistant',
-            };
+          }
+          for (const event of textEvents) {
+            yield event;
             if (signal?.aborted) {
               return;
             }
-          }
-
-          yield {
-            type: EventType.TEXT_MESSAGE_CONTENT,
-            messageId,
-            delta: content,
-          };
-          if (signal?.aborted) {
-            return;
           }
         }
 

--- a/tools/runtime-smoke/angular/src/app/plain-smoke.ts
+++ b/tools/runtime-smoke/angular/src/app/plain-smoke.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
 import { chatResource, createTool } from '@hashbrownai/angular';
 import { s } from '@hashbrownai/core';
 
@@ -51,6 +56,15 @@ function errorText(error: unknown): string {
         [textContent]="toErrorText(chat.generatingError())"
       ></div>
       <div data-testid="tool-count">{{ toolCount() }}</div>
+      <div data-testid="reasoning" [textContent]="reasoningText()"></div>
+      <div
+        data-testid="reasoning-detail-count"
+        [textContent]="reasoningDetails().length"
+      ></div>
+      <div
+        data-testid="reasoning-has-opaque-value"
+        [textContent]="reasoningHasOpaqueValue() ? 'true' : 'false'"
+      ></div>
     </section>
   `,
 })
@@ -78,6 +92,33 @@ export class PlainSmoke {
     system: 'Runtime smoke system prompt.',
     tools: isToolScenario() ? [this.getWeather] : [],
   });
+  protected readonly reasoningDetails = computed(() => {
+    const snapshot = this.chat.snapshot();
+    if (snapshot.status === 'error') {
+      return [];
+    }
+
+    const message = [...snapshot.value]
+      .reverse()
+      .find(
+        (candidate) =>
+          candidate.role === 'assistant' &&
+          candidate.reasoningDetails !== undefined,
+      );
+
+    return message?.role === 'assistant'
+      ? (message.reasoningDetails ?? [])
+      : [];
+  });
+  protected readonly reasoningText = computed(() =>
+    this.reasoningDetails()
+      .map((detail) => detail.content)
+      .filter((content) => content.length > 0)
+      .join('\n\n'),
+  );
+  protected readonly reasoningHasOpaqueValue = computed(() =>
+    this.reasoningDetails().some((detail) => Boolean(detail.encryptedValue)),
+  );
 
   protected onPromptInput(event: Event): void {
     this.prompt.set((event.currentTarget as HTMLInputElement).value);

--- a/tools/runtime-smoke/e2e/harness/agui.ts
+++ b/tools/runtime-smoke/e2e/harness/agui.ts
@@ -100,6 +100,79 @@ export function createTextRunEvents(
 }
 
 /**
+ * Creates a deterministic successful text run preceded by one reasoning detail.
+ */
+export function createReasoningTextRunEvents(
+  input: HashbrownRunInput,
+  reasoning: {
+    readonly messageId: string;
+    readonly content: string;
+    readonly encryptedValue: string;
+    readonly metadata?: Record<string, unknown>;
+  },
+  assistantMessageId: string,
+  chunks: readonly string[],
+  timestamp = DEFAULT_TIMESTAMP,
+): AGUIEvent[] {
+  return [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+      timestamp,
+    },
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: reasoning.messageId,
+      role: 'reasoning',
+      ...(reasoning.metadata ? { metadata: reasoning.metadata } : {}),
+      timestamp: timestamp + 1,
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: reasoning.messageId,
+      delta: reasoning.content,
+      timestamp: timestamp + 2,
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: reasoning.messageId,
+      encryptedValue: reasoning.encryptedValue,
+      timestamp: timestamp + 3,
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: reasoning.messageId,
+      timestamp: timestamp + 4,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: assistantMessageId,
+      role: 'assistant',
+      timestamp: timestamp + 5,
+    },
+    ...chunks.map((delta, index): AGUIEvent => ({
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: assistantMessageId,
+      delta,
+      timestamp: timestamp + index + 6,
+    })),
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: assistantMessageId,
+      timestamp: timestamp + chunks.length + 6,
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: input.threadId,
+      runId: input.runId,
+      timestamp: timestamp + chunks.length + 7,
+    },
+  ];
+}
+
+/**
  * Creates a deterministic failed run for the supplied request.
  */
 export function createRunErrorEvents(

--- a/tools/runtime-smoke/e2e/harness/app-driver.ts
+++ b/tools/runtime-smoke/e2e/harness/app-driver.ts
@@ -56,6 +56,21 @@ export class AppDriver {
     return this.page.getByTestId('tool-count');
   }
 
+  /** Returns the rendered reasoning text locator. */
+  reasoning(): Locator {
+    return this.page.getByTestId('reasoning');
+  }
+
+  /** Returns the rendered reasoning detail count locator. */
+  reasoningDetailCount(): Locator {
+    return this.page.getByTestId('reasoning-detail-count');
+  }
+
+  /** Returns whether the reasoning includes an opaque continuation value. */
+  reasoningHasOpaqueValue(): Locator {
+    return this.page.getByTestId('reasoning-has-opaque-value');
+  }
+
   /** Returns the structured answer locator. */
   structuredAnswer(): Locator {
     return this.page.getByTestId('structured-answer');

--- a/tools/runtime-smoke/e2e/specs/reasoning.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/reasoning.spec.ts
@@ -1,0 +1,55 @@
+import { createAppDriver } from '../harness/app-driver';
+import {
+  createReasoningTextRunEvents,
+  type HashbrownRunInput,
+  registerRunFixture,
+} from '../harness/agui';
+import { openScenario } from '../harness/browser';
+import { expect, test } from '../harness/test-fixture';
+
+test.use({ trace: 'off' });
+
+test('shows streamed reasoning and persists safe reasoning probes', async ({
+  page,
+  aimock,
+}) => {
+  const captured: HashbrownRunInput[] = [];
+  const hygiene = await openScenario(page, aimock, {
+    scenario: 'plain',
+    register: () =>
+      registerRunFixture(
+        aimock.aguiMock,
+        captured,
+        () => true,
+        (input) =>
+          createReasoningTextRunEvents(
+            input,
+            {
+              messageId: 'reasoning-plain',
+              content: 'I considered the greeting.',
+              encryptedValue: 'fixture-opaque-value',
+              metadata: { provider: { trace: ['plain'] } },
+            },
+            'assistant-plain',
+            ['Hello from reasoning.'],
+            1_700_000_004_000,
+          ),
+        150,
+      ),
+  });
+  const driver = createAppDriver(page);
+
+  await driver.send('Say hello with reasoning');
+
+  await driver.expectLoading();
+  await expect(driver.reasoning()).toHaveText('I considered the greeting.');
+  await expect(driver.reasoningDetailCount()).toHaveText('1');
+  await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
+  await driver.expectIdle();
+  await expect(driver.assistant()).toHaveText('Hello from reasoning.');
+  await expect(driver.reasoning()).toHaveText('I considered the greeting.');
+  await expect(driver.reasoningDetailCount()).toHaveText('1');
+  await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
+  expect(captured.length).toBe(1);
+  await hygiene.assertClean();
+});

--- a/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
@@ -9,6 +9,8 @@ import {
 import { openScenario } from '../harness/browser';
 import { expect, test } from '../harness/test-fixture';
 
+test.use({ trace: 'off' });
+
 const weatherResult = {
   city: 'Paris',
   temperatureC: 21,
@@ -56,6 +58,13 @@ function createContinuationMessages(
   return [
     ...createInitialMessages(threadId),
     {
+      id: 'reasoning-weather',
+      role: 'reasoning',
+      content: 'I need the weather tool.',
+      encryptedValue: 'fixture-opaque-value',
+      metadata: { provider: { trace: ['weather'] } },
+    },
+    {
       id: `${threadId}:message:1`,
       role: 'assistant',
       content: '',
@@ -86,6 +95,22 @@ function hasExactWeatherContinuation(input: HashbrownRunInput): boolean {
   );
 }
 
+/** Returns transcript records with opaque values reduced to presence booleans. */
+function safeTranscript(messages: HashbrownRunInput['messages']) {
+  return messages.map((message) => {
+    if (message.role !== 'reasoning') {
+      return message;
+    }
+
+    const { encryptedValue, ...safeMessage } = message;
+    return {
+      ...safeMessage,
+      hasOpaqueValue:
+        typeof encryptedValue === 'string' && encryptedValue.length > 0,
+    };
+  });
+}
+
 function createToolContinuationEvents(
   input: HashbrownRunInput,
   requestIndex: number,
@@ -99,28 +124,53 @@ function createToolContinuationEvents(
         timestamp: 1_700_000_002_000,
       },
       {
+        type: EventType.REASONING_MESSAGE_START,
+        messageId: 'reasoning-weather',
+        role: 'reasoning',
+        metadata: { provider: { trace: ['weather'] } },
+        timestamp: 1_700_000_002_001,
+      },
+      {
+        type: EventType.REASONING_MESSAGE_CONTENT,
+        messageId: 'reasoning-weather',
+        delta: 'I need the weather tool.',
+        timestamp: 1_700_000_002_002,
+      },
+      {
+        type: EventType.REASONING_ENCRYPTED_VALUE,
+        subtype: 'message',
+        entityId: 'reasoning-weather',
+        encryptedValue: 'fixture-opaque-value',
+        timestamp: 1_700_000_002_003,
+      },
+      {
+        type: EventType.REASONING_MESSAGE_END,
+        messageId: 'reasoning-weather',
+        timestamp: 1_700_000_002_004,
+      },
+      {
         type: EventType.TOOL_CALL_START,
         toolCallId: 'call-weather',
         toolCallName: 'getWeather',
         parentMessageId: `${input.threadId}:message:1`,
-        timestamp: 1_700_000_002_001,
+        timestamp: 1_700_000_002_005,
       },
       {
         type: EventType.TOOL_CALL_ARGS,
         toolCallId: 'call-weather',
         delta: '{"city":"Paris"}',
-        timestamp: 1_700_000_002_002,
+        timestamp: 1_700_000_002_006,
       },
       {
         type: EventType.TOOL_CALL_END,
         toolCallId: 'call-weather',
-        timestamp: 1_700_000_002_003,
+        timestamp: 1_700_000_002_007,
       },
       {
         type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
-        timestamp: 1_700_000_002_004,
+        timestamp: 1_700_000_002_008,
       },
     ];
   }
@@ -167,6 +217,9 @@ test('executes a tool once and automatically continues the run', async ({
     'What is the weather in Paris?',
   );
   await driver.expectLoading();
+  await expect(driver.reasoning()).toHaveText('I need the weather tool.');
+  await expect(driver.reasoningDetailCount()).toHaveText('1');
+  await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
   await expect(driver.toolCount()).toHaveText('1');
   await expect.poll(() => attempted.length).toBe(2);
   await expect.poll(() => captured.length).toBe(2);
@@ -175,18 +228,28 @@ test('executes a tool once and automatically continues the run', async ({
     'It is 21 C and sunny in Paris.',
   );
   await driver.expectIdle();
+  await expect(driver.reasoning()).toHaveText('I need the weather tool.');
+  await expect(driver.reasoningDetailCount()).toHaveText('1');
+  await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
   await expect(driver.toolCount()).toHaveText('1');
   await expect(driver.error()).toHaveJSProperty('textContent', '');
   await expect(driver.sendingError()).toHaveJSProperty('textContent', '');
   await expect(driver.generatingError()).toHaveJSProperty('textContent', '');
-  expect(captured).toHaveLength(2);
+  expect(captured.length).toBe(2);
   const [firstInput, secondInput] = captured;
   if (!firstInput || !secondInput) {
     throw new Error('Expected two captured tool continuation run inputs.');
   }
-  expect(attempted).toHaveLength(2);
+  expect(attempted.length).toBe(2);
   expect(secondInput.threadId).toBe(firstInput.threadId);
   expect(secondInput.runId).not.toBe(firstInput.runId);
+  expect(secondInput.messages.map(({ role }) => role)).toEqual([
+    'system',
+    'user',
+    'reasoning',
+    'assistant',
+    'tool',
+  ]);
   expect(firstInput).toEqual({
     threadId: firstInput.threadId,
     runId: firstInput.runId,
@@ -196,10 +259,13 @@ test('executes a tool once and automatically continues the run', async ({
     state: {},
     forwardedProps: {},
   });
-  expect(secondInput).toEqual({
+  expect({
+    ...secondInput,
+    messages: safeTranscript(secondInput.messages),
+  }).toEqual({
     threadId: firstInput.threadId,
     runId: secondInput.runId,
-    messages: createContinuationMessages(firstInput.threadId),
+    messages: safeTranscript(createContinuationMessages(firstInput.threadId)),
     tools: [expectedWeatherTool],
     context: [],
     state: {},

--- a/tools/runtime-smoke/react/src/plain-smoke.tsx
+++ b/tools/runtime-smoke/react/src/plain-smoke.tsx
@@ -37,6 +37,7 @@ export function PlainSmoke({ scenario }: PlainSmokeProps) {
     generatingError,
     isLoading,
     lastAssistantMessage,
+    messages,
     sendMessage,
     sendingError,
     stop,
@@ -45,6 +46,24 @@ export function PlainSmoke({ scenario }: PlainSmokeProps) {
     system: 'Runtime smoke system prompt.',
     tools: scenario === 'tool' ? [getWeather] : [],
   });
+  const reasoningMessage = [...messages]
+    .reverse()
+    .find(
+      (message) =>
+        message.role === 'assistant' &&
+        message.reasoningDetails !== undefined,
+    );
+  const reasoningDetails =
+    reasoningMessage?.role === 'assistant'
+      ? (reasoningMessage.reasoningDetails ?? [])
+      : [];
+  const reasoningText = reasoningDetails
+    .map((detail) => detail.content)
+    .filter((content) => content.length > 0)
+    .join('\n\n');
+  const reasoningHasOpaqueValue = reasoningDetails.some((detail) =>
+    Boolean(detail.encryptedValue),
+  );
 
   function send() {
     setSubmitted(prompt);
@@ -71,6 +90,11 @@ export function PlainSmoke({ scenario }: PlainSmokeProps) {
       <div data-testid="sending-error">{errorText(sendingError)}</div>
       <div data-testid="generating-error">{errorText(generatingError)}</div>
       <div data-testid="tool-count">{toolCount}</div>
+      <div data-testid="reasoning">{reasoningText}</div>
+      <div data-testid="reasoning-detail-count">{reasoningDetails.length}</div>
+      <div data-testid="reasoning-has-opaque-value">
+        {reasoningHasOpaqueValue ? 'true' : 'false'}
+      </div>
     </section>
   );
 }

--- a/tools/testing/aimock/fixtures/anthropic-error.json
+++ b/tools/testing/aimock/fixtures/anthropic-error.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "return provider error" },
+      "response": {
+        "status": 400,
+        "error": {
+          "message": "Deterministic provider error from aimock.",
+          "type": "invalid_request_error"
+        }
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/anthropic/reasoning-tool-call.json
+++ b/tools/testing/aimock/fixtures/anthropic/reasoning-tool-call.json
@@ -1,0 +1,31 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "reason before calling lookup",
+        "hasToolResult": false
+      },
+      "response": {
+        "reasoning": "I need the lookup result.",
+        "reasoningSignature": "signature_tool_fixture",
+        "toolCalls": [
+          {
+            "id": "call_reasoning_lookup_fixture",
+            "name": "lookup",
+            "arguments": "{\"query\":\"hashbrown\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "reason before calling lookup",
+        "hasToolResult": true,
+        "toolResultContains": "fixture continuation result"
+      },
+      "response": {
+        "content": "Continued answer from aimock."
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/fixtures/anthropic/reasoning.json
+++ b/tools/testing/aimock/fixtures/anthropic/reasoning.json
@@ -1,0 +1,14 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "reason before answering"
+      },
+      "response": {
+        "reasoning": "I will answer deterministically.",
+        "reasoningSignature": "signature_reasoning_fixture",
+        "content": "Reasoned answer from aimock."
+      }
+    }
+  ]
+}

--- a/tools/testing/aimock/provider-e2e.spec.ts
+++ b/tools/testing/aimock/provider-e2e.spec.ts
@@ -288,3 +288,115 @@ test('runProviderAGUIWithAimock lets an event hook abort after a parsed event', 
     startAimock.mockRestore();
   }
 });
+
+test('runProviderAGUIWithAimock stops reading when an event hook aborts', async () => {
+  const events = [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-provider',
+      runId: 'run-provider',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-provider',
+      runId: 'run-provider',
+    },
+  ] satisfies AGUIEvent[];
+  let eventIndex = 0;
+  const iterator: AsyncIterator<AGUIEvent> = {
+    next: jest.fn(async (): Promise<IteratorResult<AGUIEvent>> => {
+      const event = events[eventIndex];
+      eventIndex += 1;
+      return event
+        ? { done: false, value: event }
+        : { done: true, value: undefined };
+    }),
+    return: jest.fn(async () => ({ done: true as const, value: undefined })),
+  };
+  const aimock = {
+    stop: jest.fn(async () => undefined),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockResolvedValue(aimock);
+
+  try {
+    const result = await runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      createStream: () => ({
+        [Symbol.asyncIterator]: () => iterator,
+      }),
+      onEvent: (event, controls) => {
+        if (event.type === EventType.RUN_STARTED) {
+          controls.abort();
+        }
+      },
+    });
+
+    expect(result).toEqual([events[0]]);
+    expect(iterator.next).toHaveBeenCalledTimes(1);
+    expect(iterator.return).toHaveBeenCalledTimes(1);
+    expect(aimock.stop).toHaveBeenCalledTimes(1);
+  } finally {
+    startAimock.mockRestore();
+  }
+});
+
+test('runProviderAGUIWithAimock stops aimock when createStream throws', async () => {
+  const createStreamError = new Error('create stream failed');
+  const aimock = {
+    stop: jest.fn(async () => undefined),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockResolvedValue(aimock);
+
+  try {
+    const result = runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      createStream: () => {
+        throw createStreamError;
+      },
+    });
+
+    await expect(result).rejects.toBe(createStreamError);
+    expect(aimock.stop).toHaveBeenCalledTimes(1);
+  } finally {
+    startAimock.mockRestore();
+  }
+});
+
+test('runProviderAGUIWithAimock stops aimock when iterator cleanup rejects', async () => {
+  const cleanupCalls: string[] = [];
+  const iteratorReturnError = new Error('iterator return failed');
+  const iterator: AsyncIterator<AGUIEvent> = {
+    next: jest.fn(async () => ({ done: true as const, value: undefined })),
+    return: jest.fn(async () => {
+      cleanupCalls.push('return');
+      throw iteratorReturnError;
+    }),
+  };
+  const aimock = {
+    stop: jest.fn(async () => {
+      cleanupCalls.push('stop');
+    }),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockResolvedValue(aimock);
+
+  try {
+    const result = runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      createStream: () => ({
+        [Symbol.asyncIterator]: () => iterator,
+      }),
+    });
+
+    await expect(result).rejects.toBe(iteratorReturnError);
+    expect(cleanupCalls).toEqual(['return', 'stop']);
+    expect(aimock.stop).toHaveBeenCalledTimes(1);
+  } finally {
+    startAimock.mockRestore();
+  }
+});

--- a/tools/testing/aimock/provider-e2e.spec.ts
+++ b/tools/testing/aimock/provider-e2e.spec.ts
@@ -1,9 +1,14 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
 import { encodeFrame, type Frame } from '@hashbrownai/core';
+import * as aimockRunner from './aimock-runner';
 import type { AimockHandle } from './aimock-runner';
-import { runProviderTextWithAimock } from './provider-e2e';
+import {
+  runProviderAGUIWithAimock,
+  runProviderTextWithAimock,
+} from './provider-e2e';
 
 async function* openAiCompatibleTextStream(
   aimock: AimockHandle,
@@ -119,5 +124,167 @@ test('runProviderTextWithAimock collects Hashbrown frames from an aimock-backed 
     ).toBe('Hello from aimock.');
   } finally {
     rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('runProviderAGUIWithAimock parses and collects canonical events with an owned signal', async () => {
+  const calls: string[] = [];
+  const events = [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-provider',
+      runId: 'run-provider',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-provider',
+      runId: 'run-provider',
+    },
+  ] satisfies AGUIEvent[];
+  const aimock = {
+    stop: jest.fn(async () => {
+      calls.push('stop');
+    }),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockImplementation(async () => {
+      calls.push('start');
+      return aimock;
+    });
+  const parseEvent = jest.spyOn(EventSchemas, 'parse');
+  let receivedAimock: AimockHandle | undefined;
+  let receivedSignal: AbortSignal | undefined;
+  let signalInitiallyAborted: boolean | undefined;
+
+  try {
+    const result = await runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      chunkSize: 17,
+      createStream: (_aimock: AimockHandle, signal: AbortSignal) => {
+        calls.push('createStream');
+        receivedAimock = _aimock;
+        receivedSignal = signal;
+        signalInitiallyAborted = signal.aborted;
+        return (async function* () {
+          yield* events;
+        })();
+      },
+    });
+
+    expect(result).toEqual(events);
+    expect(startAimock).toHaveBeenCalledWith({
+      fixturePath: '/fixtures/provider.json',
+      chunkSize: 17,
+    });
+    expect(calls).toEqual(['start', 'createStream', 'stop']);
+    expect(parseEvent.mock.calls.map(([event]) => event)).toEqual(events);
+    expect(receivedAimock).toBe(aimock);
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(signalInitiallyAborted).toBe(false);
+    expect(receivedSignal?.aborted).toBe(true);
+  } finally {
+    parseEvent.mockRestore();
+    startAimock.mockRestore();
+  }
+});
+
+test('runProviderAGUIWithAimock rejects malformed events and performs ordered cleanup', async () => {
+  const cleanup: string[] = [];
+  const malformedEvent = {
+    type: EventType.RUN_STARTED,
+  } as unknown as AGUIEvent;
+  let receivedSignal: AbortSignal | undefined;
+  const iterator: AsyncIterator<AGUIEvent> = {
+    next: jest.fn(async () => ({ done: false, value: malformedEvent })),
+    return: jest.fn(async () => {
+      cleanup.push(receivedSignal?.aborted ? 'return' : 'return-before-abort');
+      return { done: true as const, value: undefined };
+    }),
+  };
+  const aimock = {
+    stop: jest.fn(async () => {
+      cleanup.push('stop');
+    }),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockResolvedValue(aimock);
+
+  try {
+    const result = runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      createStream: (_aimock: AimockHandle, signal: AbortSignal) => {
+        receivedSignal = signal;
+        return {
+          [Symbol.asyncIterator]: () => iterator,
+        };
+      },
+    });
+
+    await expect(result).rejects.toThrow();
+    expect(iterator.return).toHaveBeenCalledTimes(1);
+    expect(cleanup).toEqual(['return', 'stop']);
+    expect(receivedSignal?.aborted).toBe(true);
+  } finally {
+    startAimock.mockRestore();
+  }
+});
+
+test('runProviderAGUIWithAimock lets an event hook abort after a parsed event', async () => {
+  const textMessageStart = {
+    type: EventType.TEXT_MESSAGE_START,
+    messageId: 'message-provider',
+  } as unknown as AGUIEvent;
+  const runFinished = {
+    type: EventType.RUN_FINISHED,
+    threadId: 'thread-provider',
+    runId: 'run-provider',
+  } satisfies AGUIEvent;
+  const aimock = {
+    stop: jest.fn(async () => undefined),
+  } as unknown as AimockHandle;
+  const startAimock = jest
+    .spyOn(aimockRunner, 'startAimock')
+    .mockResolvedValue(aimock);
+  let receivedSignal: AbortSignal | undefined;
+  let abortEventCount = 0;
+
+  try {
+    const result = await runProviderAGUIWithAimock({
+      fixturePath: '/fixtures/provider.json',
+      createStream: (_aimock: AimockHandle, signal: AbortSignal) => {
+        receivedSignal = signal;
+        signal.addEventListener('abort', () => {
+          abortEventCount += 1;
+        });
+        return (async function* () {
+          yield textMessageStart;
+          if (signal.aborted) {
+            return;
+          }
+          yield runFinished;
+        })();
+      },
+      onEvent: async (
+        event: AGUIEvent,
+        controls: { readonly abort: () => void },
+      ) => {
+        await Promise.resolve();
+        if (
+          event.type === EventType.TEXT_MESSAGE_START &&
+          event.role === 'assistant'
+        ) {
+          controls.abort();
+          controls.abort();
+        }
+      },
+    });
+
+    expect(result).toEqual([{ ...textMessageStart, role: 'assistant' }]);
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(abortEventCount).toBe(1);
+  } finally {
+    startAimock.mockRestore();
   }
 });

--- a/tools/testing/aimock/provider-e2e.ts
+++ b/tools/testing/aimock/provider-e2e.ts
@@ -1,3 +1,4 @@
+import { type AGUIEvent, EventSchemas } from '@ag-ui/core';
 import { decodeFrames, type Frame } from '@hashbrownai/core';
 import { type AimockHandle, startAimock } from './aimock-runner';
 
@@ -9,6 +10,29 @@ export interface ProviderTextAimockRunOptions {
   readonly fixturePath: string;
   /** Create the provider stream after aimock is started. */
   readonly createStream: (aimock: AimockHandle) => AsyncIterable<Uint8Array>;
+}
+
+/**
+ * Options for collecting a provider AG-UI stream against an aimock fixture.
+ */
+export interface ProviderAGUIAimockRunOptions {
+  /** Path to one fixture file or a directory of `.json` fixture files. */
+  readonly fixturePath: string;
+  /** Optional chunk size passed through to aimock. */
+  readonly chunkSize?: number;
+  /** Create the provider stream after aimock is started. */
+  readonly createStream: (
+    aimock: AimockHandle,
+    signal: AbortSignal,
+  ) => AsyncIterable<AGUIEvent>;
+  /** Observe each parsed event and optionally abort the provider stream. */
+  readonly onEvent?: (
+    event: AGUIEvent,
+    controls: {
+      /** Abort the helper-owned signal. Safe to call more than once. */
+      readonly abort: () => void;
+    },
+  ) => void | Promise<void>;
 }
 
 function toReadableStream(
@@ -55,5 +79,51 @@ export async function runProviderTextWithAimock(
   } finally {
     abortController.abort();
     await aimock.stop();
+  }
+}
+
+/**
+ * Run a provider AG-UI stream against aimock and collect validated events.
+ */
+export async function runProviderAGUIWithAimock(
+  options: ProviderAGUIAimockRunOptions,
+): Promise<AGUIEvent[]> {
+  const aimock = await startAimock({
+    fixturePath: options.fixturePath,
+    chunkSize: options.chunkSize,
+  });
+  const abortController = new AbortController();
+  const controls = {
+    abort: () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    },
+  };
+  let iterator: AsyncIterator<AGUIEvent> | undefined;
+
+  try {
+    iterator = options
+      .createStream(aimock, abortController.signal)
+      [Symbol.asyncIterator]();
+    const events: AGUIEvent[] = [];
+
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) {
+        return events;
+      }
+
+      const event = EventSchemas.parse(next.value);
+      events.push(event);
+      await options.onEvent?.(event, controls);
+    }
+  } finally {
+    abortController.abort();
+    try {
+      await iterator?.return?.();
+    } finally {
+      await aimock.stop();
+    }
   }
 }

--- a/tools/testing/aimock/provider-e2e.ts
+++ b/tools/testing/aimock/provider-e2e.ts
@@ -117,6 +117,9 @@ export async function runProviderAGUIWithAimock(
       const event = EventSchemas.parse(next.value);
       events.push(event);
       await options.onEvent?.(event, controls);
+      if (abortController.signal.aborted) {
+        return events;
+      }
     }
   } finally {
     abortController.abort();

--- a/www/analog/package.json
+++ b/www/analog/package.json
@@ -2,8 +2,8 @@
   "name": "@hashbrownai/www",
   "type": "module",
   "dependencies": {
-    "@ag-ui/core": "0.0.58",
-    "@ag-ui/encoder": "0.0.58",
+    "@ag-ui/core": "0.0.59",
+    "@ag-ui/encoder": "0.0.59",
     "@hashbrownai/core": "file:../../packages/core",
     "@hashbrownai/openai": "file:../../packages/openai",
     "@angular/common": "22.1.1",


### PR DESCRIPTION
## Summary

- Add first-class AG-UI reasoning support to the core runtime, including ordered reasoning details, metadata, encrypted values, reducer handling, history serialization, and tool-loop continuation.
- Replace the Anthropic frame-based stream with canonical AG-UI input and events using the current Anthropic SDK.
- Add native Anthropic structured output, signed thinking and redacted-thinking continuation, exhaustive native stream handling, and RAW events for provider-specific server activity.
- Harden OpenAI Chat Completions with schema isolation, refusal streaming, lifecycle cleanup, and fail-closed unit-test discovery.
- Add deterministic aimock fixtures and browser runtime coverage for reasoning and tool continuation.

## Breaking Changes

- `HashbrownAnthropic.stream.text()` now accepts an AG-UI run input and returns `AsyncIterable<AGUIEvent>` instead of encoded Hashbrown frames.
- Anthropic request and thread-persistence options have been removed from the provider stream API. Thread and tool-loop ownership remains in the Hashbrown client runtime.
- Anthropic now requires `@anthropic-ai/sdk` `0.122.0` and Node.js 20 or newer.
- AG-UI packages are aligned on `0.0.59`.

## Anthropic

- Maps AG-UI system, developer, user, assistant, tool, and reasoning history into native Messages requests.
- Uses `output_config.format` for native JSON schema output.
- Preserves signed `thinking` and opaque `redacted_thinking` blocks across tool continuations.
- Emits canonical text, tool-call, and reasoning lifecycles.
- Emits provider-specific citations and server-tool activity as AG-UI RAW events.
- Handles cancellation and failures without synthesizing incomplete lifecycle endings.

## OpenAI

OpenAI remains on Chat Completions in this change. Reasoning history is intentionally omitted because Chat Completions does not provide a portable continuation representation equivalent to Anthropic thinking blocks. This does not add Responses API support or synthesize reasoning events.

The mapper now clones schema-bearing request fields before transforms and maps streamed refusal fragments through the canonical assistant text lifecycle.

## Verification

- Core: 516 unit tests and package E2E passed.
- Angular: 156 unit tests and package compatibility E2E passed.
- React: 82 unit tests and package E2E passed.
- Anthropic: 137 unit tests and 12 fixture E2E tests passed; fixture E2E passed three consecutive uncached runs.
- OpenAI: 6 unit tests and 10 fixture E2E tests passed; fixture E2E passed two consecutive uncached runs.
- Shared testing infrastructure: 21 tests, typecheck, and lint passed.
- Runtime harness: 24 tests, typecheck, and lint passed.
- Browser smoke: 24/24 Playwright scenarios passed across Angular and React.
- Builds, package lint targets, and API extraction passed for all affected packages.

## Release

No release is included in this PR.
