### PR TITLE
feat(core): preserve AG-UI continuation data across runs

### DIFF
--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1131,6 +1131,18 @@ test('continues client tools with isolated reasoning details in transcript order
             parentMessageId: 'assistant-weather',
           },
           {
+            type: EventType.REASONING_ENCRYPTED_VALUE,
+            subtype: 'message',
+            entityId: 'assistant-weather',
+            encryptedValue: 'opaque-assistant',
+          },
+          {
+            type: EventType.REASONING_ENCRYPTED_VALUE,
+            subtype: 'tool-call',
+            entityId: 'call-weather',
+            encryptedValue: 'opaque-tool-call',
+          },
+          {
             type: EventType.TOOL_CALL_ARGS,
             toolCallId: 'call-weather',
             delta: '{"city":"Paris"}',
@@ -1203,16 +1215,41 @@ test('continues client tools with isolated reasoning details in transcript order
   const safeContinuation = secondRequest.input?.messages
     .slice(2)
     .map((message) => {
-      if (message.role !== 'reasoning') {
-        return message;
+      if (message.role === 'assistant') {
+        const { encryptedValue, toolCalls, ...safeMessage } = message;
+        return {
+          ...safeMessage,
+          hasEncryptedValue:
+            typeof encryptedValue === 'string' && encryptedValue.length > 0,
+          ...(toolCalls
+            ? {
+                toolCalls: toolCalls.map((toolCall) => {
+                  const {
+                    encryptedValue: toolEncryptedValue,
+                    ...safeToolCall
+                  } = toolCall;
+                  return {
+                    ...safeToolCall,
+                    hasEncryptedValue:
+                      typeof toolEncryptedValue === 'string' &&
+                      toolEncryptedValue.length > 0,
+                  };
+                }),
+              }
+            : {}),
+        };
       }
 
-      const { encryptedValue, ...safeMessage } = message;
-      return {
-        ...safeMessage,
-        hasEncryptedValue:
-          typeof encryptedValue === 'string' && encryptedValue.length > 0,
-      };
+      if (message.role === 'reasoning') {
+        const { encryptedValue, ...safeMessage } = message;
+        return {
+          ...safeMessage,
+          hasEncryptedValue:
+            typeof encryptedValue === 'string' && encryptedValue.length > 0,
+        };
+      }
+
+      return message;
     });
   expect(safeContinuation).toEqual([
     {
@@ -1226,10 +1263,12 @@ test('continues client tools with isolated reasoning details in transcript order
       id: expect.any(String),
       role: 'assistant',
       content: '',
+      hasEncryptedValue: true,
       toolCalls: [
         {
           id: 'call-weather',
           type: 'function',
+          hasEncryptedValue: true,
           function: {
             name: 'getWeather',
             arguments: '{"city":"Paris"}',
@@ -1253,6 +1292,17 @@ test('continues client tools with isolated reasoning details in transcript order
   if (committedAssistant?.role !== 'assistant') {
     throw new Error('Expected a committed assistant reasoning message.');
   }
+  const capturedAssistant = secondRequest.input?.messages.find(
+    (message) => message.role === 'assistant',
+  );
+  if (!capturedAssistant || capturedAssistant.role !== 'assistant') {
+    throw new Error('Expected captured continuation assistant.');
+  }
+  const capturedToolCall = capturedAssistant.toolCalls?.[0];
+  const committedToolCall = committedAssistant.toolCalls[0];
+  if (!capturedToolCall || !committedToolCall) {
+    throw new Error('Expected captured and committed continuation tool calls.');
+  }
   const capturedReasoning = secondRequest.input?.messages.find(
     (message) => message.role === 'reasoning',
   );
@@ -1267,7 +1317,11 @@ test('continues client tools with isolated reasoning details in transcript order
     provider: { trace: string[] };
   };
   const originalEncryptedValue = capturedReasoning.encryptedValue;
+  const originalAssistantEncryptedValue = capturedAssistant.encryptedValue;
+  const originalToolEncryptedValue = capturedToolCall.encryptedValue;
 
+  expect(capturedAssistant).not.toBe(committedAssistant);
+  expect(capturedToolCall).not.toBe(committedToolCall);
   expect(capturedReasoning === committedReasoning).toBe(false);
   expect(capturedMetadata).not.toBe(committedMetadata);
   expect(capturedMetadata.provider).not.toBe(committedMetadata.provider);
@@ -1276,9 +1330,21 @@ test('continues client tools with isolated reasoning details in transcript order
       originalEncryptedValue.length > 0 &&
       committedReasoning?.encryptedValue === originalEncryptedValue,
   ).toBe(true);
+  expect(originalAssistantEncryptedValue).toBe('opaque-assistant');
+  expect(originalToolEncryptedValue).toBe('opaque-tool-call');
+  expect(committedAssistant.encryptedValue).toBe(
+    originalAssistantEncryptedValue,
+  );
+  expect(committedToolCall.encryptedValue).toBe(originalToolEncryptedValue);
+  capturedAssistant.encryptedValue = 'mutated-captured-assistant';
+  capturedToolCall.encryptedValue = 'mutated-captured-tool-call';
   capturedReasoning.encryptedValue = 'mutated-captured-value';
   capturedMetadata.provider.trace[0] = 'mutated-captured-metadata';
 
+  expect(committedAssistant.encryptedValue).toBe(
+    originalAssistantEncryptedValue,
+  );
+  expect(committedToolCall.encryptedValue).toBe(originalToolEncryptedValue);
   expect(committedReasoning?.encryptedValue === originalEncryptedValue).toBe(
     true,
   );

--- a/packages/core/src/models/api.models.ts
+++ b/packages/core/src/models/api.models.ts
@@ -23,6 +23,13 @@ export interface ToolCall {
     name: string;
     arguments: string;
   };
+
+  /**
+   * Opaque provider continuation data preserved across AG-UI runs.
+   * Hashbrown does not inspect or display this value.
+   */
+  encryptedValue?: string;
+
   metadata?: Record<string, unknown>;
 }
 
@@ -33,6 +40,12 @@ export interface AssistantMessage {
   role: 'assistant';
   content?: string;
   toolCalls?: ToolCall[];
+
+  /**
+   * Opaque provider continuation data preserved across AG-UI runs.
+   * Hashbrown does not inspect or display this value.
+   */
+  encryptedValue?: string;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value

--- a/packages/core/src/models/internal.models.ts
+++ b/packages/core/src/models/internal.models.ts
@@ -39,6 +39,13 @@ export interface ToolCall {
   result?: PromiseSettledResult<any>;
   progress?: number;
   status: 'pending' | 'done';
+
+  /**
+   * Opaque provider continuation data preserved across AG-UI runs.
+   * Hashbrown does not inspect or display this value.
+   */
+  encryptedValue?: string;
+
   metadata?: Record<string, unknown>;
 }
 
@@ -50,6 +57,13 @@ export interface AssistantMessage {
   content?: string;
   contentResolved?: JsonValue;
   toolCallIds: string[];
+
+  /**
+   * Opaque provider continuation data preserved across AG-UI runs.
+   * Hashbrown does not inspect or display this value.
+   */
+  encryptedValue?: string;
+
   reasoning?: ɵInternalReasoning;
 }
 

--- a/packages/core/src/models/internal_helpers.spec.ts
+++ b/packages/core/src/models/internal_helpers.spec.ts
@@ -1,4 +1,5 @@
 import { type ReasoningMessage } from '@ag-ui/core';
+import { Chat } from './index';
 import {
   type AnyTool,
   type AssistantMessage as ViewAssistantMessage,
@@ -7,6 +8,8 @@ import {
   toApiMessagesFromInternal,
   toInternalMessagesFromApi,
   toInternalMessagesFromView,
+  toInternalToolCallsFromApiMessages,
+  toInternalToolCallsFromView,
   toViewMessagesFromInternal,
 } from './internal_helpers';
 
@@ -230,4 +233,142 @@ test('omits reasoning fields when they are absent', () => {
   expect(api).not.toHaveProperty('reasoningDetails');
   expect(view).not.toHaveProperty('reasoning');
   expect(view).not.toHaveProperty('reasoningDetails');
+});
+
+test('round-trips assistant and tool-call encrypted values through API messages', () => {
+  // Arrange
+  const message: Chat.Internal.AssistantMessage = {
+    role: 'assistant',
+    content: '',
+    encryptedValue: 'assistant-opaque',
+    toolCallIds: ['call-1'],
+  };
+  const toolCall: Chat.Internal.ToolCall = {
+    id: 'call-1',
+    name: 'search',
+    arguments: '{"query":"hashbrown"}',
+    argumentsResolved: { query: 'hashbrown' },
+    encryptedValue: 'tool-opaque',
+    status: 'done',
+    result: { status: 'fulfilled', value: { matches: 1 } },
+  };
+
+  // Act
+  const apiMessages = toApiMessagesFromInternal(message, [toolCall]);
+  const apiAssistant = apiMessages[0];
+  if (apiAssistant?.role !== 'assistant') {
+    throw new Error('Expected an API assistant message.');
+  }
+  const [roundTrippedMessage] = toInternalMessagesFromApi(apiAssistant);
+  const [roundTrippedToolCall] =
+    toInternalToolCallsFromApiMessages(apiMessages);
+
+  // Assert
+  expect(apiAssistant.encryptedValue).toBe('assistant-opaque');
+  expect(apiAssistant.toolCalls?.[0]?.encryptedValue).toBe('tool-opaque');
+  expect(roundTrippedMessage).toMatchObject({
+    role: 'assistant',
+    encryptedValue: 'assistant-opaque',
+  });
+  expect(roundTrippedToolCall).toMatchObject({
+    id: 'call-1',
+    encryptedValue: 'tool-opaque',
+    status: 'done',
+  });
+});
+
+test('round-trips assistant and tool-call encrypted values through view messages', () => {
+  // Arrange
+  const message: Chat.Internal.AssistantMessage = {
+    role: 'assistant',
+    content: '',
+    encryptedValue: 'assistant-opaque',
+    toolCallIds: ['call-pending', 'call-done'],
+  };
+  const pendingToolCall: Chat.Internal.ToolCall = {
+    id: 'call-pending',
+    name: 'search',
+    arguments: '{"query":"hashbrown"}',
+    argumentsResolved: { query: 'hashbrown' },
+    encryptedValue: 'pending-tool-opaque',
+    status: 'pending',
+  };
+  const doneToolCall: Chat.Internal.ToolCall = {
+    id: 'call-done',
+    name: 'search',
+    arguments: '{"query":"ag-ui"}',
+    argumentsResolved: { query: 'ag-ui' },
+    encryptedValue: 'done-tool-opaque',
+    status: 'done',
+    result: { status: 'fulfilled', value: { matches: 1 } },
+  };
+  const tool: Chat.AnyTool = {
+    name: 'search',
+    description: 'Search records.',
+    schema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+    handler: async () => undefined,
+  };
+
+  // Act
+  const [view] = toViewMessagesFromInternal(
+    message,
+    {
+      'call-pending': pendingToolCall,
+      'call-done': doneToolCall,
+    },
+    [tool],
+  );
+  if (view?.role !== 'assistant') {
+    throw new Error('Expected a view assistant message.');
+  }
+  const [roundTrippedMessage] = toInternalMessagesFromView(view);
+  const [roundTrippedPendingToolCall, roundTrippedDoneToolCall] =
+    toInternalToolCallsFromView([view]);
+
+  // Assert
+  expect(view.encryptedValue).toBe('assistant-opaque');
+  expect(view.toolCalls[0]?.encryptedValue).toBe('pending-tool-opaque');
+  expect(view.toolCalls[1]?.encryptedValue).toBe('done-tool-opaque');
+  expect(roundTrippedMessage).toMatchObject({
+    role: 'assistant',
+    encryptedValue: 'assistant-opaque',
+  });
+  expect(roundTrippedPendingToolCall).toMatchObject({
+    id: 'call-pending',
+    encryptedValue: 'pending-tool-opaque',
+    status: 'pending',
+  });
+  expect(roundTrippedDoneToolCall).toMatchObject({
+    id: 'call-done',
+    encryptedValue: 'done-tool-opaque',
+    status: 'done',
+  });
+});
+
+test('omits assistant and tool-call encrypted values when absent', () => {
+  // Arrange
+  const message: Chat.Internal.AssistantMessage = {
+    role: 'assistant',
+    content: '',
+    toolCallIds: ['call-1'],
+  };
+  const toolCall: Chat.Internal.ToolCall = {
+    id: 'call-1',
+    name: 'search',
+    arguments: '{}',
+    status: 'pending',
+  };
+
+  // Act
+  const [api] = toApiMessagesFromInternal(message, [toolCall]);
+
+  // Assert
+  expect(api).not.toHaveProperty('encryptedValue');
+  expect(api?.role === 'assistant' && api.toolCalls?.[0]).not.toHaveProperty(
+    'encryptedValue',
+  );
 });

--- a/packages/core/src/models/internal_helpers.ts
+++ b/packages/core/src/models/internal_helpers.ts
@@ -126,6 +126,9 @@ export function toInternalMessagesFromView(
           content,
           contentResolved,
           toolCallIds: message.toolCalls.map((toolCall) => toolCall.toolCallId),
+          ...(message.encryptedValue !== undefined
+            ? { encryptedValue: message.encryptedValue }
+            : {}),
           ...(reasoning ? { reasoning } : {}),
         },
       ];
@@ -181,6 +184,9 @@ export function toViewMessagesFromInternal(
         {
           role: 'assistant',
           content,
+          ...(message.encryptedValue !== undefined
+            ? { encryptedValue: message.encryptedValue }
+            : {}),
           ...toReasoningOutput(message.reasoning),
           toolCalls: message.toolCallIds.flatMap(
             (toolCallId): Chat.AnyToolCall[] => {
@@ -210,6 +216,9 @@ export function toViewMessagesFromInternal(
                       status: 'done',
                       name: toolCall.name,
                       toolCallId,
+                      ...(toolCall.encryptedValue !== undefined
+                        ? { encryptedValue: toolCall.encryptedValue }
+                        : {}),
                       args: s.isHashbrownType(tool.schema)
                         ? (resolvedArgs ?? null)
                         : (resolvedArgs ?? JSON.parse(toolArgsString)),
@@ -230,6 +239,9 @@ export function toViewMessagesFromInternal(
                       name: toolCall.name,
                       toolCallId,
                       progress: toolCall.progress,
+                      ...(toolCall.encryptedValue !== undefined
+                        ? { encryptedValue: toolCall.encryptedValue }
+                        : {}),
                       args: s.isHashbrownType(tool.schema)
                         ? (resolvedArgs ?? null)
                         : (resolvedArgs ?? null),
@@ -306,6 +318,9 @@ export function toApiMessagesFromInternal(
         {
           role: 'assistant',
           content,
+          ...(message.encryptedValue !== undefined
+            ? { encryptedValue: message.encryptedValue }
+            : {}),
           ...toReasoningOutput(message.reasoning),
           toolCalls: toolCallsForMessage.map((toolCall, index) => ({
             id: toolCall.id,
@@ -318,6 +333,9 @@ export function toApiMessagesFromInternal(
                   ? toolCall.arguments
                   : JSON.stringify(toolCall.arguments),
             },
+            ...(toolCall.encryptedValue !== undefined
+              ? { encryptedValue: toolCall.encryptedValue }
+              : {}),
             metadata: toolCall.metadata,
           })),
         },
@@ -392,6 +410,9 @@ export function toInternalToolCallsFromApi(
           ? toolCall.function.arguments
           : undefined,
       status: 'pending',
+      ...(toolCall.encryptedValue !== undefined
+        ? { encryptedValue: toolCall.encryptedValue }
+        : {}),
       metadata: toolCall.metadata,
     },
   ];
@@ -437,6 +458,9 @@ export function toInternalToolCallsFromApiMessages(
               ? toolCall.function.arguments
               : undefined),
           status: 'pending',
+          ...(toolCall.encryptedValue !== undefined
+            ? { encryptedValue: toolCall.encryptedValue }
+            : {}),
           metadata: toolCall.metadata,
         };
       });
@@ -453,6 +477,9 @@ export function toInternalToolCallsFromApiMessages(
         arguments: existing?.arguments ?? '',
         status: 'done',
         result: message.content,
+        ...(existing?.encryptedValue !== undefined
+          ? { encryptedValue: existing.encryptedValue }
+          : {}),
         metadata: existing?.metadata,
       };
     }
@@ -486,6 +513,9 @@ export function toInternalToolCallsFromView(
             argumentsResolved: toolCall.args,
             status: 'done',
             result: toolCall.result,
+            ...(toolCall.encryptedValue !== undefined
+              ? { encryptedValue: toolCall.encryptedValue }
+              : {}),
           };
         }
         case 'pending': {
@@ -495,6 +525,9 @@ export function toInternalToolCallsFromView(
             status: 'pending',
             arguments: JSON.stringify(toolCall.args),
             argumentsResolved: toolCall.args,
+            ...(toolCall.encryptedValue !== undefined
+              ? { encryptedValue: toolCall.encryptedValue }
+              : {}),
           };
         }
       }
@@ -548,6 +581,9 @@ export function toInternalMessagesFromApi(
       role: 'assistant',
       content,
       contentResolved: typeof rawContent === 'object' ? rawContent : undefined,
+      ...(message.encryptedValue !== undefined
+        ? { encryptedValue: message.encryptedValue }
+        : {}),
       toolCallIds:
         message.toolCalls
           ?.filter((toolCall) => toolCall.function.name !== 'output')

--- a/packages/core/src/models/view.models.ts
+++ b/packages/core/src/models/view.models.ts
@@ -38,23 +38,34 @@ export type UserMessage = {
  */
 export type ToolCall<ToolUnion extends AnyTool> = Prettify<
   ToolUnion extends Tool<infer Name, infer Args, infer Result>
-    ?
-        | {
-            role: 'tool';
-            status: 'done';
-            name: Name;
-            args: Args;
-            result: PromiseSettledResult<Result>;
-            toolCallId: string;
-          }
-        | {
-            role: 'tool';
-            status: 'pending';
-            name: Name;
-            args: Args;
-            toolCallId: string;
-            progress?: number;
-          }
+    ? | {
+          role: 'tool';
+          status: 'done';
+          name: Name;
+          args: Args;
+          result: PromiseSettledResult<Result>;
+          toolCallId: string;
+
+          /**
+           * Opaque provider continuation data preserved across AG-UI runs.
+           * Hashbrown does not inspect or display this value.
+           */
+          encryptedValue?: string;
+        }
+      | {
+          role: 'tool';
+          status: 'pending';
+          name: Name;
+          args: Args;
+          toolCallId: string;
+          progress?: number;
+
+          /**
+           * Opaque provider continuation data preserved across AG-UI runs.
+           * Hashbrown does not inspect or display this value.
+           */
+          encryptedValue?: string;
+        }
     : never
 >;
 
@@ -70,6 +81,12 @@ export interface AssistantMessage<Output, ToolUnion extends AnyTool> {
   role: 'assistant';
   content?: Output;
   toolCalls: ToolCall<ToolUnion>[];
+
+  /**
+   * Opaque provider continuation data preserved across AG-UI runs.
+   * Hashbrown does not inspect or display this value.
+   */
+  encryptedValue?: string;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value
@@ -97,9 +114,7 @@ export type ErrorMessage = {
  * @public
  */
 export type Message<Output, Tools extends AnyTool> =
-  | UserMessage
-  | AssistantMessage<Output, Tools>
-  | ErrorMessage;
+  UserMessage | AssistantMessage<Output, Tools> | ErrorMessage;
 
 /**
  * @public

--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -957,16 +957,15 @@ test('reports a stream error for a duplicate reasoning end', () => {
   );
 });
 
-test('reports a stream error for an unknown message encrypted-value id', () => {
+test('ignores an unknown message encrypted-value id', () => {
   const state = startState();
 
   const next = reduceEvents(state, [
     reasoningEncryptedValue('reasoning-unknown', 'opaque'),
   ]);
 
-  expect(next.error?.message).toBe(
-    'Reasoning message reasoning-unknown does not exist',
-  );
+  expect(next).toBe(state);
+  expect(next.error).toBeUndefined();
 });
 
 test('reports a stream error when a run finishes with active reasoning', () => {
@@ -1003,13 +1002,63 @@ test('accepts top-level reasoning grouping events as exact no-ops', () => {
   expect(afterEnd).toBe(state);
 });
 
-test('accepts tool-call encrypted values as exact no-ops', () => {
+test('sets a tool-call encrypted value without mutating prior state', () => {
+  const state = reduceEvents(
+    startState(),
+    toolEvents('call-1', 'search', '{"query":"hashbrown"}'),
+  );
+  const priorToolCall = state.toolCalls[0];
+
+  const next = reduceEvents(state, [
+    reasoningEncryptedValue('call-1', 'tool-opaque', 'tool-call', {
+      eventOnly: true,
+    }),
+  ]);
+
+  expect(next).not.toBe(state);
+  expect(next.toolCalls).not.toBe(state.toolCalls);
+  expect(next.toolCalls[0]).not.toBe(priorToolCall);
+  expect(priorToolCall).not.toHaveProperty('encryptedValue');
+  expect(next.toolCalls[0]?.encryptedValue).toBe('tool-opaque');
+  expect(next.toolCalls[0]?.arguments).toBe('{"query":"hashbrown"}');
+  expect(next.error).toBeUndefined();
+});
+
+test('sets an assistant encrypted value without changing message content', () => {
+  const state = reduceEvents(startState(), textEvents('Answer', 'assistant-1'));
+  const priorMessage = state.message;
+
+  const next = reduceEvents(state, [
+    reasoningEncryptedValue('assistant-1', 'assistant-opaque'),
+  ]);
+
+  expect(next).not.toBe(state);
+  expect(next.message).not.toBe(priorMessage);
+  expect(priorMessage).not.toHaveProperty('encryptedValue');
+  expect(next.message?.encryptedValue).toBe('assistant-opaque');
+  expect(next.message?.content).toBe('Answer');
+  expect(next.error).toBeUndefined();
+});
+
+test('keeps the latest assistant and tool-call encrypted values', () => {
+  let state = reduceEvents(startState(), toolEvents('call-1', 'search', '{}'));
+
+  state = reduceEvents(state, [
+    reasoningEncryptedValue('message-1', 'assistant-first'),
+    reasoningEncryptedValue('call-1', 'tool-first', 'tool-call'),
+    reasoningEncryptedValue('message-1', 'assistant-latest'),
+    reasoningEncryptedValue('call-1', 'tool-latest', 'tool-call'),
+  ]);
+
+  expect(state.message?.encryptedValue).toBe('assistant-latest');
+  expect(state.toolCalls[0]?.encryptedValue).toBe('tool-latest');
+});
+
+test('ignores an unknown tool-call encrypted-value id', () => {
   const state = startState();
 
   const next = reduceEvents(state, [
-    reasoningEncryptedValue('unknown-tool-call', 'opaque', 'tool-call', {
-      eventOnly: true,
-    }),
+    reasoningEncryptedValue('unknown-tool-call', 'opaque', 'tool-call'),
   ]);
 
   expect(next).toBe(state);

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -339,7 +339,31 @@ function applyReasoningEncryptedValue(
   event: ReasoningEncryptedValueEvent,
 ): StreamingMessageState {
   if (event.subtype === 'tool-call') {
-    return state;
+    const toolCallIndex = state.toolCalls.findIndex(
+      (toolCall) => toolCall.id === event.entityId,
+    );
+    if (toolCallIndex === -1) {
+      return state;
+    }
+
+    return {
+      ...state,
+      toolCalls: state.toolCalls.map((toolCall, index) =>
+        index === toolCallIndex
+          ? { ...toolCall, encryptedValue: event.encryptedValue }
+          : toolCall,
+      ),
+    };
+  }
+
+  if (state.message && state.messageId === event.entityId) {
+    return {
+      ...state,
+      message: {
+        ...state.message,
+        encryptedValue: event.encryptedValue,
+      },
+    };
   }
 
   const next = updateReasoningDetail(state, event.entityId, (detail) => ({
@@ -349,10 +373,7 @@ function applyReasoningEncryptedValue(
       ? { subagentRunId: event.subagentRunId }
       : {}),
   }));
-  return (
-    next ??
-    withStreamError(state, `Reasoning message ${event.entityId} does not exist`)
-  );
+  return next ?? state;
 }
 
 function startTextMessage(

--- a/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
@@ -48,7 +48,7 @@ test('prepends a standard AG-UI system message to the full history', () => {
   ] satisfies Message[]);
 });
 
-test('maps assistant content and function tool calls', () => {
+test('omits absent assistant and tool-call encrypted values', () => {
   const messages: Chat.Api.Message[] = [
     {
       role: 'assistant',
@@ -94,6 +94,7 @@ test('emits ordered reasoning details before the assistant and its tool results'
     {
       role: 'assistant',
       content: 'Checking.',
+      encryptedValue: 'assistant-opaque',
       reasoning: 'Stale display reasoning.',
       reasoningDetails: [
         {
@@ -118,6 +119,7 @@ test('emits ordered reasoning details before the assistant and its tool results'
           index: 0,
           id: 'call-weather',
           type: 'function',
+          encryptedValue: 'tool-opaque',
           function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
         },
       ],
@@ -153,10 +155,12 @@ test('emits ordered reasoning details before the assistant and its tool results'
       id: 'thread-1:message:0',
       role: 'assistant',
       content: 'Checking.',
+      encryptedValue: 'assistant-opaque',
       toolCalls: [
         {
           id: 'call-weather',
           type: 'function',
+          encryptedValue: 'tool-opaque',
           function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
         },
       ],

--- a/packages/core/src/transport/hashbrown-run-agent-input.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.ts
@@ -95,11 +95,17 @@ function mapMessage(
         id,
         role: 'assistant',
         ...(message.content !== undefined ? { content: message.content } : {}),
+        ...(message.encryptedValue !== undefined
+          ? { encryptedValue: message.encryptedValue }
+          : {}),
         ...(message.toolCalls !== undefined
           ? {
               toolCalls: message.toolCalls.map((toolCall) => ({
                 id: toolCall.id,
                 type: 'function' as const,
+                ...(toolCall.encryptedValue !== undefined
+                  ? { encryptedValue: toolCall.encryptedValue }
+                  : {}),
                 function: {
                   name: toolCall.function.name,
                   arguments: toolCall.function.arguments,

--- a/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
@@ -68,10 +68,12 @@ function createContinuationMessages(
       id: `${threadId}:message:1`,
       role: 'assistant',
       content: '',
+      encryptedValue: 'fixture-assistant-opaque-value',
       toolCalls: [
         {
           id: 'call-weather',
           type: 'function',
+          encryptedValue: 'fixture-tool-opaque-value',
           function: {
             name: 'getWeather',
             arguments: '{"city":"Paris"}',
@@ -98,16 +100,39 @@ function hasExactWeatherContinuation(input: HashbrownRunInput): boolean {
 /** Returns transcript records with opaque values reduced to presence booleans. */
 function safeTranscript(messages: HashbrownRunInput['messages']) {
   return messages.map((message) => {
-    if (message.role !== 'reasoning') {
-      return message;
+    if (message.role === 'assistant') {
+      const { encryptedValue, toolCalls, ...safeMessage } = message;
+      return {
+        ...safeMessage,
+        hasOpaqueValue:
+          typeof encryptedValue === 'string' && encryptedValue.length > 0,
+        ...(toolCalls
+          ? {
+              toolCalls: toolCalls.map((toolCall) => {
+                const { encryptedValue: toolEncryptedValue, ...safeToolCall } =
+                  toolCall;
+                return {
+                  ...safeToolCall,
+                  hasOpaqueValue:
+                    typeof toolEncryptedValue === 'string' &&
+                    toolEncryptedValue.length > 0,
+                };
+              }),
+            }
+          : {}),
+      };
     }
 
-    const { encryptedValue, ...safeMessage } = message;
-    return {
-      ...safeMessage,
-      hasOpaqueValue:
-        typeof encryptedValue === 'string' && encryptedValue.length > 0,
-    };
+    if (message.role === 'reasoning') {
+      const { encryptedValue, ...safeMessage } = message;
+      return {
+        ...safeMessage,
+        hasOpaqueValue:
+          typeof encryptedValue === 'string' && encryptedValue.length > 0,
+      };
+    }
+
+    return message;
   });
 }
 
@@ -156,21 +181,35 @@ function createToolContinuationEvents(
         timestamp: 1_700_000_002_005,
       },
       {
+        type: EventType.REASONING_ENCRYPTED_VALUE,
+        subtype: 'message',
+        entityId: `${input.threadId}:message:1`,
+        encryptedValue: 'fixture-assistant-opaque-value',
+        timestamp: 1_700_000_002_006,
+      },
+      {
+        type: EventType.REASONING_ENCRYPTED_VALUE,
+        subtype: 'tool-call',
+        entityId: 'call-weather',
+        encryptedValue: 'fixture-tool-opaque-value',
+        timestamp: 1_700_000_002_007,
+      },
+      {
         type: EventType.TOOL_CALL_ARGS,
         toolCallId: 'call-weather',
         delta: '{"city":"Paris"}',
-        timestamp: 1_700_000_002_006,
+        timestamp: 1_700_000_002_008,
       },
       {
         type: EventType.TOOL_CALL_END,
         toolCallId: 'call-weather',
-        timestamp: 1_700_000_002_007,
+        timestamp: 1_700_000_002_009,
       },
       {
         type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
-        timestamp: 1_700_000_002_008,
+        timestamp: 1_700_000_002_010,
       },
     ];
   }
@@ -250,6 +289,20 @@ test('executes a tool once and automatically continues the run', async ({
     'assistant',
     'tool',
   ]);
+  const continuationAssistant = secondInput.messages.find(
+    (message) => message.role === 'assistant',
+  );
+  if (!continuationAssistant || continuationAssistant.role !== 'assistant') {
+    throw new Error('Expected an assistant in the continuation request.');
+  }
+  const continuationToolCall = continuationAssistant.toolCalls?.[0];
+  if (!continuationToolCall) {
+    throw new Error('Expected a tool call in the continuation request.');
+  }
+  expect(continuationAssistant.encryptedValue).toBe(
+    'fixture-assistant-opaque-value',
+  );
+  expect(continuationToolCall.encryptedValue).toBe('fixture-tool-opaque-value');
   expect(firstInput).toEqual({
     threadId: firstInput.threadId,
     runId: firstInput.runId,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/liveloveapp/hashbrown/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)

## PR Type

```text
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Hashbrown preserves encrypted continuation data on reasoning records, but equivalent data attached to assistant messages and tool calls is lost while reducing events, converting message representations, and constructing subsequent AG-UI run requests.

Tool-call encrypted-value events are ignored, while unresolved message encrypted-value events can fail the active stream. This prevents providers from receiving the complete continuation transcript after a client-side tool executes.

## What is the new behavior?

- Adds optional `encryptedValue` fields to Hashbrown assistant-message and tool-call models.
- Preserves these values across API, internal, and public view representations.
- Applies assistant and tool-call encrypted-value events immutably.
- Treats encrypted-value events for unknown entity IDs as no-ops.
- Serializes continuation values onto their canonical AG-UI assistant and tool-call fields.
- Replays the complete continuation transcript in the next run after client-side tool execution.
- Keeps opaque values out of rendered content and broad test diagnostics.
- Adds unit, integration, and Angular/React browser coverage for the complete continuation loop.

No provider-specific behavior or dependencies are changed.

## Does this PR introduce a breaking change?

```text
[ ] Yes
[x] No
```

Unknown encrypted-value events for unresolved entity IDs now remain no-ops instead of failing the stream. This is an intentional robustness change and requires no application migration.

## Other information

Verification completed locally:

- Core build, lint, API extraction, and 522 tests
- Angular build, lint, API extraction, and 156 tests
- React build, API extraction, and 82 tests
- Runtime harness typecheck, lint, and 24 tests
- Angular and React runtime application builds and lint
- 24 Playwright scenarios across Angular and React
- Diff scope, formatting, and reference audits
