### PR TITLE
feat(core): preserve AG-UI metadata across continuations

### DIFF
--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1352,6 +1352,12 @@ test('continues client tools with isolated reasoning details in transcript order
   const committedToolMetadata = committedToolCall.metadata as {
     provider: { toolSteps: { index: number }[] };
   };
+  const [capturedAssistantStep] =
+    capturedAssistantMetadata.provider.assistantSteps;
+  const [capturedToolStep] = capturedToolMetadata.provider.toolSteps;
+  if (!capturedAssistantStep || !capturedToolStep) {
+    throw new Error('Expected captured provider metadata steps.');
+  }
 
   expect(capturedAssistant).not.toBe(committedAssistant);
   expect(capturedToolCall).not.toBe(committedToolCall);
@@ -1381,8 +1387,8 @@ test('continues client tools with isolated reasoning details in transcript order
   capturedToolCall.encryptedValue = 'mutated-captured-tool-call';
   capturedReasoning.encryptedValue = 'mutated-captured-value';
   capturedMetadata.provider.trace[0] = 'mutated-captured-metadata';
-  capturedAssistantMetadata.provider.assistantSteps[0]!.index = 99;
-  capturedToolMetadata.provider.toolSteps[0]!.index = 100;
+  capturedAssistantStep.index = 99;
+  capturedToolStep.index = 100;
 
   expect(committedAssistant.encryptedValue).toBe(
     originalAssistantEncryptedValue,

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1125,6 +1125,18 @@ test('continues client tools with isolated reasoning details in transcript order
             messageId: 'reasoning-weather',
           },
           {
+            type: EventType.TEXT_MESSAGE_START,
+            messageId: 'assistant-weather',
+            role: 'assistant',
+          },
+          {
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: 'assistant-weather',
+            metadata: {
+              provider: { assistantSteps: [{ index: 0 }] },
+            },
+          },
+          {
             type: EventType.TOOL_CALL_START,
             toolCallId: 'call-weather',
             toolCallName: 'getWeather',
@@ -1150,6 +1162,9 @@ test('continues client tools with isolated reasoning details in transcript order
           {
             type: EventType.TOOL_CALL_END,
             toolCallId: 'call-weather',
+            metadata: {
+              provider: { toolSteps: [{ index: 1 }] },
+            },
           },
         ]),
       };
@@ -1264,11 +1279,17 @@ test('continues client tools with isolated reasoning details in transcript order
       role: 'assistant',
       content: '',
       hasEncryptedValue: true,
+      metadata: {
+        provider: { assistantSteps: [{ index: 0 }] },
+      },
       toolCalls: [
         {
           id: 'call-weather',
           type: 'function',
           hasEncryptedValue: true,
+          metadata: {
+            provider: { toolSteps: [{ index: 1 }] },
+          },
           function: {
             name: 'getWeather',
             arguments: '{"city":"Paris"}',
@@ -1319,12 +1340,32 @@ test('continues client tools with isolated reasoning details in transcript order
   const originalEncryptedValue = capturedReasoning.encryptedValue;
   const originalAssistantEncryptedValue = capturedAssistant.encryptedValue;
   const originalToolEncryptedValue = capturedToolCall.encryptedValue;
+  const capturedAssistantMetadata = capturedAssistant.metadata as {
+    provider: { assistantSteps: { index: number }[] };
+  };
+  const committedAssistantMetadata = committedAssistant.metadata as {
+    provider: { assistantSteps: { index: number }[] };
+  };
+  const capturedToolMetadata = capturedToolCall.metadata as {
+    provider: { toolSteps: { index: number }[] };
+  };
+  const committedToolMetadata = committedToolCall.metadata as {
+    provider: { toolSteps: { index: number }[] };
+  };
 
   expect(capturedAssistant).not.toBe(committedAssistant);
   expect(capturedToolCall).not.toBe(committedToolCall);
   expect(capturedReasoning === committedReasoning).toBe(false);
   expect(capturedMetadata).not.toBe(committedMetadata);
   expect(capturedMetadata.provider).not.toBe(committedMetadata.provider);
+  expect(capturedAssistantMetadata).not.toBe(committedAssistantMetadata);
+  expect(capturedAssistantMetadata.provider).not.toBe(
+    committedAssistantMetadata.provider,
+  );
+  expect(capturedToolMetadata).not.toBe(committedToolMetadata);
+  expect(capturedToolMetadata.provider).not.toBe(
+    committedToolMetadata.provider,
+  );
   expect(
     typeof originalEncryptedValue === 'string' &&
       originalEncryptedValue.length > 0 &&
@@ -1340,6 +1381,8 @@ test('continues client tools with isolated reasoning details in transcript order
   capturedToolCall.encryptedValue = 'mutated-captured-tool-call';
   capturedReasoning.encryptedValue = 'mutated-captured-value';
   capturedMetadata.provider.trace[0] = 'mutated-captured-metadata';
+  capturedAssistantMetadata.provider.assistantSteps[0]!.index = 99;
+  capturedToolMetadata.provider.toolSteps[0]!.index = 100;
 
   expect(committedAssistant.encryptedValue).toBe(
     originalAssistantEncryptedValue,
@@ -1349,6 +1392,12 @@ test('continues client tools with isolated reasoning details in transcript order
     true,
   );
   expect(committedMetadata).toEqual({ provider: { trace: ['original'] } });
+  expect(committedAssistantMetadata).toEqual({
+    provider: { assistantSteps: [{ index: 0 }] },
+  });
+  expect(committedToolMetadata).toEqual({
+    provider: { toolSteps: [{ index: 1 }] },
+  });
 
   teardown();
 });

--- a/packages/core/src/models/api.models.ts
+++ b/packages/core/src/models/api.models.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ReasoningMessage } from '@ag-ui/core';
+import type { Metadata, ReasoningMessage } from '@ag-ui/core';
 import { DeepPartial } from '../utils';
 import { ModelInput } from '../transport';
 
@@ -31,7 +31,7 @@ export interface ToolCall {
   encryptedValue?: string;
 
   /** Provider metadata preserved across AG-UI runs. */
-  metadata?: Record<string, unknown>;
+  metadata?: Metadata;
 }
 
 /**
@@ -49,7 +49,7 @@ export interface AssistantMessage {
   encryptedValue?: string;
 
   /** Provider metadata preserved across AG-UI runs. */
-  metadata?: Record<string, unknown>;
+  metadata?: Metadata;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value

--- a/packages/core/src/models/api.models.ts
+++ b/packages/core/src/models/api.models.ts
@@ -30,6 +30,7 @@ export interface ToolCall {
    */
   encryptedValue?: string;
 
+  /** Provider metadata preserved across AG-UI runs. */
   metadata?: Record<string, unknown>;
 }
 
@@ -46,6 +47,9 @@ export interface AssistantMessage {
    * Hashbrown does not inspect or display this value.
    */
   encryptedValue?: string;
+
+  /** Provider metadata preserved across AG-UI runs. */
+  metadata?: Record<string, unknown>;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value

--- a/packages/core/src/models/internal.models.ts
+++ b/packages/core/src/models/internal.models.ts
@@ -46,6 +46,7 @@ export interface ToolCall {
    */
   encryptedValue?: string;
 
+  /** Provider metadata preserved across AG-UI runs. */
   metadata?: Record<string, unknown>;
 }
 
@@ -63,6 +64,9 @@ export interface AssistantMessage {
    * Hashbrown does not inspect or display this value.
    */
   encryptedValue?: string;
+
+  /** Provider metadata preserved across AG-UI runs. */
+  metadata?: Record<string, unknown>;
 
   reasoning?: ɵInternalReasoning;
 }

--- a/packages/core/src/models/internal.models.ts
+++ b/packages/core/src/models/internal.models.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ReasoningMessage } from '@ag-ui/core';
+import type { Metadata, ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue } from '../utils';
 
@@ -47,7 +47,7 @@ export interface ToolCall {
   encryptedValue?: string;
 
   /** Provider metadata preserved across AG-UI runs. */
-  metadata?: Record<string, unknown>;
+  metadata?: Metadata;
 }
 
 /**
@@ -66,7 +66,7 @@ export interface AssistantMessage {
   encryptedValue?: string;
 
   /** Provider metadata preserved across AG-UI runs. */
-  metadata?: Record<string, unknown>;
+  metadata?: Metadata;
 
   reasoning?: ɵInternalReasoning;
 }

--- a/packages/core/src/models/internal_helpers.spec.ts
+++ b/packages/core/src/models/internal_helpers.spec.ts
@@ -401,8 +401,12 @@ test('preserves and isolates assistant and tool-call metadata through API messag
   const apiAssistant = api as Chat.Api.AssistantMessage & {
     metadata?: Record<string, unknown>;
   };
+  const [sourceToolStep] = toolMetadata.google.steps;
+  if (!sourceToolStep) {
+    throw new Error('Expected source tool metadata step.');
+  }
   assistantMetadata.google.runId = 'source mutation';
-  toolMetadata.google.steps[0]!.index = 99;
+  sourceToolStep.index = 99;
   const [roundTrippedMessage] = toInternalMessagesFromApi(apiAssistant);
   const [roundTrippedToolCall] = toInternalToolCallsFromApiMessages([api]);
   const apiGoogle = apiAssistant.metadata?.['google'] as {
@@ -415,7 +419,11 @@ test('preserves and isolates assistant and tool-call metadata through API messag
     apiGoogle.runId = 'API mutation';
   }
   if (apiToolGoogle) {
-    apiToolGoogle.steps[0]!.index = 100;
+    const [apiToolStep] = apiToolGoogle.steps;
+    if (!apiToolStep) {
+      throw new Error('Expected API tool metadata step.');
+    }
+    apiToolStep.index = 100;
   }
 
   // Assert
@@ -486,9 +494,14 @@ test('preserves and isolates assistant and tool-call metadata through view messa
       metadata?: Record<string, unknown>;
     }
   >;
+  const [sourcePendingStep] = pendingMetadata.google.steps;
+  const [sourceDoneStep] = doneMetadata.google.steps;
+  if (!sourcePendingStep || !sourceDoneStep) {
+    throw new Error('Expected source view metadata steps.');
+  }
   assistantMetadata.google.runId = 'source mutation';
-  pendingMetadata.google.steps[0]!.index = 99;
-  doneMetadata.google.steps[0]!.index = 100;
+  sourcePendingStep.index = 99;
+  sourceDoneStep.index = 100;
   const [roundTrippedMessage] =
     toInternalMessagesFromView(viewAssistantMessage);
   const [roundTrippedPending, roundTrippedDone] = toInternalToolCallsFromView([
@@ -507,10 +520,18 @@ test('preserves and isolates assistant and tool-call metadata through view messa
     viewGoogle.runId = 'view mutation';
   }
   if (viewPendingGoogle) {
-    viewPendingGoogle.steps[0]!.index = 101;
+    const [viewPendingStep] = viewPendingGoogle.steps;
+    if (!viewPendingStep) {
+      throw new Error('Expected pending view metadata step.');
+    }
+    viewPendingStep.index = 101;
   }
   if (viewDoneGoogle) {
-    viewDoneGoogle.steps[0]!.index = 102;
+    const [viewDoneStep] = viewDoneGoogle.steps;
+    if (!viewDoneStep) {
+      throw new Error('Expected done view metadata step.');
+    }
+    viewDoneStep.index = 102;
   }
 
   // Assert

--- a/packages/core/src/models/internal_helpers.spec.ts
+++ b/packages/core/src/models/internal_helpers.spec.ts
@@ -372,3 +372,183 @@ test('omits assistant and tool-call encrypted values when absent', () => {
     'encryptedValue',
   );
 });
+
+test('preserves and isolates assistant and tool-call metadata through API messages', () => {
+  // Arrange
+  const assistantMetadata = { google: { runId: 'run-1' } };
+  const toolMetadata = { google: { steps: [{ index: 1 }] } };
+  const message = {
+    role: 'assistant',
+    content: '',
+    toolCallIds: ['call-1'],
+    metadata: assistantMetadata,
+  } as Chat.Internal.AssistantMessage & {
+    metadata: Record<string, unknown>;
+  };
+  const toolCall: Chat.Internal.ToolCall = {
+    id: 'call-1',
+    name: 'search',
+    arguments: '{}',
+    status: 'pending',
+    metadata: toolMetadata,
+  };
+
+  // Act
+  const [api] = toApiMessagesFromInternal(message, [toolCall]);
+  if (api?.role !== 'assistant') {
+    throw new Error('Expected an API assistant message.');
+  }
+  const apiAssistant = api as Chat.Api.AssistantMessage & {
+    metadata?: Record<string, unknown>;
+  };
+  assistantMetadata.google.runId = 'source mutation';
+  toolMetadata.google.steps[0]!.index = 99;
+  const [roundTrippedMessage] = toInternalMessagesFromApi(apiAssistant);
+  const [roundTrippedToolCall] = toInternalToolCallsFromApiMessages([api]);
+  const apiGoogle = apiAssistant.metadata?.['google'] as {
+    runId: string;
+  };
+  const apiToolGoogle = apiAssistant.toolCalls?.[0]?.metadata?.['google'] as {
+    steps: { index: number }[];
+  };
+  if (apiGoogle) {
+    apiGoogle.runId = 'API mutation';
+  }
+  if (apiToolGoogle) {
+    apiToolGoogle.steps[0]!.index = 100;
+  }
+
+  // Assert
+  expect(roundTrippedMessage).toMatchObject({
+    role: 'assistant',
+    metadata: { google: { runId: 'run-1' } },
+  });
+  expect(roundTrippedToolCall).toMatchObject({
+    id: 'call-1',
+    metadata: { google: { steps: [{ index: 1 }] } },
+  });
+});
+
+test('preserves and isolates assistant and tool-call metadata through view messages', () => {
+  // Arrange
+  const assistantMetadata = { google: { runId: 'run-1' } };
+  const pendingMetadata = { google: { steps: [{ index: 1 }] } };
+  const doneMetadata = { google: { steps: [{ index: 2 }] } };
+  const message = {
+    role: 'assistant',
+    content: '',
+    toolCallIds: ['call-pending', 'call-done'],
+    metadata: assistantMetadata,
+  } as Chat.Internal.AssistantMessage & {
+    metadata: Record<string, unknown>;
+  };
+  const pendingToolCall: Chat.Internal.ToolCall = {
+    id: 'call-pending',
+    name: 'search',
+    arguments: '{}',
+    argumentsResolved: {},
+    status: 'pending',
+    metadata: pendingMetadata,
+  };
+  const doneToolCall: Chat.Internal.ToolCall = {
+    id: 'call-done',
+    name: 'search',
+    arguments: '{}',
+    argumentsResolved: {},
+    status: 'done',
+    result: { status: 'fulfilled', value: 'done' },
+    metadata: doneMetadata,
+  };
+  const tool: Chat.AnyTool = {
+    name: 'search',
+    description: 'Search records.',
+    schema: { type: 'object', properties: {} },
+    handler: async () => undefined,
+  };
+
+  // Act
+  const [view] = toViewMessagesFromInternal(
+    message,
+    {
+      'call-pending': pendingToolCall,
+      'call-done': doneToolCall,
+    },
+    [tool],
+  );
+  if (view?.role !== 'assistant') {
+    throw new Error('Expected a view assistant message.');
+  }
+  const viewAssistantMessage = view as typeof view & {
+    metadata?: Record<string, unknown>;
+  };
+  const viewToolCalls = viewAssistantMessage.toolCalls as Array<
+    (typeof viewAssistantMessage.toolCalls)[number] & {
+      metadata?: Record<string, unknown>;
+    }
+  >;
+  assistantMetadata.google.runId = 'source mutation';
+  pendingMetadata.google.steps[0]!.index = 99;
+  doneMetadata.google.steps[0]!.index = 100;
+  const [roundTrippedMessage] =
+    toInternalMessagesFromView(viewAssistantMessage);
+  const [roundTrippedPending, roundTrippedDone] = toInternalToolCallsFromView([
+    viewAssistantMessage,
+  ]);
+  const viewGoogle = viewAssistantMessage.metadata?.['google'] as {
+    runId: string;
+  };
+  const viewPendingGoogle = viewToolCalls[0]?.metadata?.['google'] as {
+    steps: { index: number }[];
+  };
+  const viewDoneGoogle = viewToolCalls[1]?.metadata?.['google'] as {
+    steps: { index: number }[];
+  };
+  if (viewGoogle) {
+    viewGoogle.runId = 'view mutation';
+  }
+  if (viewPendingGoogle) {
+    viewPendingGoogle.steps[0]!.index = 101;
+  }
+  if (viewDoneGoogle) {
+    viewDoneGoogle.steps[0]!.index = 102;
+  }
+
+  // Assert
+  expect(roundTrippedMessage).toMatchObject({
+    role: 'assistant',
+    metadata: { google: { runId: 'run-1' } },
+  });
+  expect(roundTrippedPending).toMatchObject({
+    id: 'call-pending',
+    metadata: { google: { steps: [{ index: 1 }] } },
+  });
+  expect(roundTrippedDone).toMatchObject({
+    id: 'call-done',
+    metadata: { google: { steps: [{ index: 2 }] } },
+  });
+});
+
+test('omits assistant and tool-call metadata when absent', () => {
+  // Arrange
+  const message: Chat.Internal.AssistantMessage = {
+    role: 'assistant',
+    content: '',
+    toolCallIds: ['call-1'],
+  };
+  const toolCall: Chat.Internal.ToolCall = {
+    id: 'call-1',
+    name: 'search',
+    arguments: '{}',
+    status: 'pending',
+  };
+
+  // Act
+  const [api] = toApiMessagesFromInternal(message, [toolCall]);
+  if (api?.role !== 'assistant') {
+    throw new Error('Expected an API assistant message.');
+  }
+
+  // Assert
+  expect(api).not.toHaveProperty('metadata');
+  expect(api.toolCalls?.[0]).not.toHaveProperty('metadata');
+});

--- a/packages/core/src/models/internal_helpers.ts
+++ b/packages/core/src/models/internal_helpers.ts
@@ -1,5 +1,5 @@
 import * as Chat from './public_api';
-import type { ReasoningMessage } from '@ag-ui/core';
+import type { Metadata, ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue, resolveWithSchema } from '../utils';
 
@@ -8,9 +8,7 @@ type ReasoningInput = {
   readonly reasoningDetails?: readonly Readonly<ReasoningMessage>[];
 };
 
-function cloneMetadata(
-  metadata: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
+function cloneMetadata(metadata: Metadata | undefined): Metadata | undefined {
   return metadata === undefined ? undefined : structuredClone(metadata);
 }
 

--- a/packages/core/src/models/internal_helpers.ts
+++ b/packages/core/src/models/internal_helpers.ts
@@ -8,6 +8,12 @@ type ReasoningInput = {
   readonly reasoningDetails?: readonly Readonly<ReasoningMessage>[];
 };
 
+function cloneMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return metadata === undefined ? undefined : structuredClone(metadata);
+}
+
 function cloneReasoningMessage(
   reasoning: Readonly<ReasoningMessage>,
 ): ReasoningMessage {
@@ -129,6 +135,9 @@ export function toInternalMessagesFromView(
           ...(message.encryptedValue !== undefined
             ? { encryptedValue: message.encryptedValue }
             : {}),
+          ...(message.metadata !== undefined
+            ? { metadata: cloneMetadata(message.metadata) }
+            : {}),
           ...(reasoning ? { reasoning } : {}),
         },
       ];
@@ -187,6 +196,9 @@ export function toViewMessagesFromInternal(
           ...(message.encryptedValue !== undefined
             ? { encryptedValue: message.encryptedValue }
             : {}),
+          ...(message.metadata !== undefined
+            ? { metadata: cloneMetadata(message.metadata) }
+            : {}),
           ...toReasoningOutput(message.reasoning),
           toolCalls: message.toolCallIds.flatMap(
             (toolCallId): Chat.AnyToolCall[] => {
@@ -219,6 +231,9 @@ export function toViewMessagesFromInternal(
                       ...(toolCall.encryptedValue !== undefined
                         ? { encryptedValue: toolCall.encryptedValue }
                         : {}),
+                      ...(toolCall.metadata !== undefined
+                        ? { metadata: cloneMetadata(toolCall.metadata) }
+                        : {}),
                       args: s.isHashbrownType(tool.schema)
                         ? (resolvedArgs ?? null)
                         : (resolvedArgs ?? JSON.parse(toolArgsString)),
@@ -241,6 +256,9 @@ export function toViewMessagesFromInternal(
                       progress: toolCall.progress,
                       ...(toolCall.encryptedValue !== undefined
                         ? { encryptedValue: toolCall.encryptedValue }
+                        : {}),
+                      ...(toolCall.metadata !== undefined
+                        ? { metadata: cloneMetadata(toolCall.metadata) }
                         : {}),
                       args: s.isHashbrownType(tool.schema)
                         ? (resolvedArgs ?? null)
@@ -321,6 +339,9 @@ export function toApiMessagesFromInternal(
           ...(message.encryptedValue !== undefined
             ? { encryptedValue: message.encryptedValue }
             : {}),
+          ...(message.metadata !== undefined
+            ? { metadata: cloneMetadata(message.metadata) }
+            : {}),
           ...toReasoningOutput(message.reasoning),
           toolCalls: toolCallsForMessage.map((toolCall, index) => ({
             id: toolCall.id,
@@ -336,7 +357,9 @@ export function toApiMessagesFromInternal(
             ...(toolCall.encryptedValue !== undefined
               ? { encryptedValue: toolCall.encryptedValue }
               : {}),
-            metadata: toolCall.metadata,
+            ...(toolCall.metadata !== undefined
+              ? { metadata: cloneMetadata(toolCall.metadata) }
+              : {}),
           })),
         },
         ...toolMessages,
@@ -413,7 +436,9 @@ export function toInternalToolCallsFromApi(
       ...(toolCall.encryptedValue !== undefined
         ? { encryptedValue: toolCall.encryptedValue }
         : {}),
-      metadata: toolCall.metadata,
+      ...(toolCall.metadata !== undefined
+        ? { metadata: cloneMetadata(toolCall.metadata) }
+        : {}),
     },
   ];
 }
@@ -461,7 +486,9 @@ export function toInternalToolCallsFromApiMessages(
           ...(toolCall.encryptedValue !== undefined
             ? { encryptedValue: toolCall.encryptedValue }
             : {}),
-          metadata: toolCall.metadata,
+          ...(toolCall.metadata !== undefined
+            ? { metadata: cloneMetadata(toolCall.metadata) }
+            : {}),
         };
       });
     }
@@ -480,7 +507,9 @@ export function toInternalToolCallsFromApiMessages(
         ...(existing?.encryptedValue !== undefined
           ? { encryptedValue: existing.encryptedValue }
           : {}),
-        metadata: existing?.metadata,
+        ...(existing?.metadata !== undefined
+          ? { metadata: cloneMetadata(existing.metadata) }
+          : {}),
       };
     }
   });
@@ -516,6 +545,9 @@ export function toInternalToolCallsFromView(
             ...(toolCall.encryptedValue !== undefined
               ? { encryptedValue: toolCall.encryptedValue }
               : {}),
+            ...(toolCall.metadata !== undefined
+              ? { metadata: cloneMetadata(toolCall.metadata) }
+              : {}),
           };
         }
         case 'pending': {
@@ -527,6 +559,9 @@ export function toInternalToolCallsFromView(
             argumentsResolved: toolCall.args,
             ...(toolCall.encryptedValue !== undefined
               ? { encryptedValue: toolCall.encryptedValue }
+              : {}),
+            ...(toolCall.metadata !== undefined
+              ? { metadata: cloneMetadata(toolCall.metadata) }
               : {}),
           };
         }
@@ -583,6 +618,9 @@ export function toInternalMessagesFromApi(
       contentResolved: typeof rawContent === 'object' ? rawContent : undefined,
       ...(message.encryptedValue !== undefined
         ? { encryptedValue: message.encryptedValue }
+        : {}),
+      ...(message.metadata !== undefined
+        ? { metadata: cloneMetadata(message.metadata) }
         : {}),
       toolCallIds:
         message.toolCalls

--- a/packages/core/src/models/view.models.ts
+++ b/packages/core/src/models/view.models.ts
@@ -51,6 +51,9 @@ export type ToolCall<ToolUnion extends AnyTool> = Prettify<
            * Hashbrown does not inspect or display this value.
            */
           encryptedValue?: string;
+
+          /** Provider metadata preserved across AG-UI runs. */
+          metadata?: Record<string, unknown>;
         }
       | {
           role: 'tool';
@@ -65,6 +68,9 @@ export type ToolCall<ToolUnion extends AnyTool> = Prettify<
            * Hashbrown does not inspect or display this value.
            */
           encryptedValue?: string;
+
+          /** Provider metadata preserved across AG-UI runs. */
+          metadata?: Record<string, unknown>;
         }
     : never
 >;
@@ -87,6 +93,9 @@ export interface AssistantMessage<Output, ToolUnion extends AnyTool> {
    * Hashbrown does not inspect or display this value.
    */
   encryptedValue?: string;
+
+  /** Provider metadata preserved across AG-UI runs. */
+  metadata?: Record<string, unknown>;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value

--- a/packages/core/src/models/view.models.ts
+++ b/packages/core/src/models/view.models.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ReasoningMessage } from '@ag-ui/core';
+import type { Metadata, ReasoningMessage } from '@ag-ui/core';
 import { s } from '../schema';
 import { JsonValue, Prettify } from '../utils';
 
@@ -53,7 +53,7 @@ export type ToolCall<ToolUnion extends AnyTool> = Prettify<
           encryptedValue?: string;
 
           /** Provider metadata preserved across AG-UI runs. */
-          metadata?: Record<string, unknown>;
+          metadata?: Metadata;
         }
       | {
           role: 'tool';
@@ -70,7 +70,7 @@ export type ToolCall<ToolUnion extends AnyTool> = Prettify<
           encryptedValue?: string;
 
           /** Provider metadata preserved across AG-UI runs. */
-          metadata?: Record<string, unknown>;
+          metadata?: Metadata;
         }
     : never
 >;
@@ -95,7 +95,7 @@ export interface AssistantMessage<Output, ToolUnion extends AnyTool> {
   encryptedValue?: string;
 
   /** Provider metadata preserved across AG-UI runs. */
-  metadata?: Record<string, unknown>;
+  metadata?: Metadata;
 
   /**
    * Human-readable reasoning. When `reasoningDetails` is present, this value

--- a/packages/core/src/reducers/streaming-message.reducer.spec.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.spec.ts
@@ -382,7 +382,71 @@ test('finalizes AG-UI tool arguments only once across tool and run completion', 
   }
 });
 
-test('preserves Hashbrown tool metadata from later AG-UI tool events', () => {
+test('merges cloned text metadata shallowly across start content and end', () => {
+  const startMetadata = {
+    stable: 'start',
+    replaced: { start: true },
+    list: ['start'],
+  };
+  const contentMetadata = {
+    replaced: { content: true },
+    list: ['content'],
+    contentOnly: true,
+  };
+  const endMetadata = {
+    stable: 'end',
+    endOnly: true,
+  };
+  let state = startState();
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'message-1',
+      role: 'assistant',
+      metadata: startMetadata,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'message-1',
+      delta: 'Answer',
+      metadata: contentMetadata,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'message-1',
+      metadata: endMetadata,
+    },
+  ]);
+  startMetadata.replaced.start = false;
+  startMetadata.list.push('mutated');
+  contentMetadata.replaced.content = false;
+  contentMetadata.list.push('mutated');
+  endMetadata.stable = 'mutated';
+
+  expect(state.message?.content).toBe('Answer');
+  expect(state.message?.metadata).toEqual({
+    stable: 'end',
+    replaced: { content: true },
+    list: ['content'],
+    contentOnly: true,
+    endOnly: true,
+  });
+});
+
+test('merges cloned tool metadata shallowly across start arguments and end', () => {
+  const startMetadata = {
+    stable: 'start',
+    replaced: { start: true },
+  };
+  const argumentsMetadata = {
+    replaced: { arguments: true },
+    argumentsOnly: true,
+  };
+  const endMetadata = {
+    stable: 'end',
+    endOnly: true,
+  };
   let state = startState();
 
   state = reduceEvents(state, [
@@ -391,28 +455,60 @@ test('preserves Hashbrown tool metadata from later AG-UI tool events', () => {
       toolCallId: 'call-1',
       toolCallName: 'search',
       parentMessageId: 'message-1',
-      rawEvent: {
-        hashbrown: {
-          metadata: { initial: 'preserved' },
-        },
-      },
+      metadata: startMetadata,
     },
     {
       type: EventType.TOOL_CALL_ARGS,
       toolCallId: 'call-1',
       delta: '',
-      rawEvent: {
-        hashbrown: {
-          metadata: { signature: 'opaque' },
-        },
-      },
+      metadata: argumentsMetadata,
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: 'call-1',
+      metadata: endMetadata,
     },
   ]);
+  startMetadata.replaced.start = false;
+  argumentsMetadata.replaced.arguments = false;
+  endMetadata.stable = 'mutated';
 
+  expect(state.toolCalls[0]?.arguments).toBe('');
   expect(state.toolCalls[0]?.metadata).toEqual({
-    initial: 'preserved',
-    signature: 'opaque',
+    stable: 'end',
+    replaced: { arguments: true },
+    argumentsOnly: true,
+    endOnly: true,
   });
+});
+
+test('preserves canonical metadata from text and tool chunk events', () => {
+  const textMetadata = { provider: { textStep: 1 } };
+  const toolMetadata = { provider: { toolStep: 2 } };
+  let state = startState();
+
+  state = reduceEvents(state, [
+    {
+      type: EventType.TEXT_MESSAGE_CHUNK,
+      messageId: 'message-1',
+      role: 'assistant',
+      delta: 'Answer',
+      metadata: textMetadata,
+    },
+    {
+      type: EventType.TOOL_CALL_CHUNK,
+      toolCallId: 'call-1',
+      toolCallName: 'search',
+      parentMessageId: 'message-1',
+      delta: '{}',
+      metadata: toolMetadata,
+    },
+  ]);
+  textMetadata.provider.textStep = 99;
+  toolMetadata.provider.toolStep = 100;
+
+  expect(state.message?.metadata).toEqual({ provider: { textStep: 1 } });
+  expect(state.toolCalls[0]?.metadata).toEqual({ provider: { toolStep: 2 } });
 });
 
 test('streams multiple AG-UI tool calls keyed by toolCallId', () => {

--- a/packages/core/src/reducers/streaming-message.reducer.ts
+++ b/packages/core/src/reducers/streaming-message.reducer.ts
@@ -143,26 +143,15 @@ function warnRecoveredTrailingTokenFromSource(
   warnRecoveredTrailingToken(parsedData, source.slice(parserError.index));
 }
 
-function getToolCallMetadata(rawEvent: unknown) {
-  if (!rawEvent || typeof rawEvent !== 'object' || Array.isArray(rawEvent)) {
-    return undefined;
-  }
-
-  const hashbrown = (rawEvent as Record<string, unknown>)['hashbrown'];
-  if (!hashbrown || typeof hashbrown !== 'object' || Array.isArray(hashbrown)) {
-    return undefined;
-  }
-
-  const metadata = (hashbrown as Record<string, unknown>)['metadata'];
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return undefined;
-  }
-
-  return metadata as Record<string, unknown>;
-}
-
 function cloneMetadata(metadata: Metadata | undefined) {
   return metadata === undefined ? undefined : structuredClone(metadata);
+}
+
+function mergeClonedMetadata(
+  existing: Metadata | undefined,
+  incoming: Metadata | undefined,
+) {
+  return mergeMetadata(existing, cloneMetadata(incoming));
 }
 
 function withStreamError(
@@ -385,16 +374,36 @@ function startTextMessage(
   }
 
   if (state.message && state.messageId === event.messageId) {
-    return state;
+    if (event.metadata === undefined) {
+      return state;
+    }
+
+    const metadata = mergeClonedMetadata(
+      state.message.metadata,
+      event.metadata,
+    );
+    return {
+      ...state,
+      message: {
+        ...state.message,
+        ...(metadata !== undefined ? { metadata } : {}),
+      },
+    };
   }
+
+  const message = state.message ?? {
+    role: 'assistant' as const,
+    content: '',
+    toolCallIds: state.toolCalls.map((toolCall) => toolCall.id),
+  };
+  const metadata = mergeClonedMetadata(message.metadata, event.metadata);
 
   return {
     ...state,
     messageId: event.messageId,
-    message: state.message ?? {
-      role: 'assistant',
-      content: '',
-      toolCallIds: state.toolCalls.map((toolCall) => toolCall.id),
+    message: {
+      ...message,
+      ...(metadata !== undefined ? { metadata } : {}),
     },
   };
 }
@@ -406,22 +415,24 @@ function appendTextContent(
   if (
     !state.message ||
     state.messageId !== event.messageId ||
-    event.delta.length === 0
+    (event.delta.length === 0 && event.metadata === undefined)
   ) {
     return state;
   }
 
   const responseSchema = state.configSnapshot?.responseSchema;
   const content = (state.message.content ?? '') + event.delta;
+  const metadata = mergeClonedMetadata(state.message.metadata, event.metadata);
   let message: Chat.Internal.AssistantMessage = {
     ...state.message,
     content,
+    ...(metadata !== undefined ? { metadata } : {}),
   };
   let outputParserState = state.outputParserState;
   let outputCache = state.outputCache;
   let error = state.error;
 
-  if (responseSchema) {
+  if (responseSchema && event.delta.length > 0) {
     outputParserState = push(ensureParserState(outputParserState), event.delta);
     const output = resolveSchemaValue(
       responseSchema,
@@ -449,15 +460,69 @@ function appendTextContent(
   };
 }
 
+function endTextMessage(
+  state: StreamingMessageState,
+  event: Extract<AGUIEvent, { type: EventType.TEXT_MESSAGE_END }>,
+): StreamingMessageState {
+  if (
+    !state.message ||
+    state.messageId !== event.messageId ||
+    event.metadata === undefined
+  ) {
+    return state;
+  }
+
+  const metadata = mergeClonedMetadata(state.message.metadata, event.metadata);
+  return {
+    ...state,
+    message: {
+      ...state.message,
+      ...(metadata !== undefined ? { metadata } : {}),
+    },
+  };
+}
+
 function startToolCall(
   state: StreamingMessageState,
   event: Extract<AGUIEvent, { type: EventType.TOOL_CALL_START }>,
 ): StreamingMessageState {
-  if (state.toolCalls.some((toolCall) => toolCall.id === event.toolCallId)) {
-    return state.activeToolCallId === event.toolCallId
-      ? state
-      : { ...state, activeToolCallId: event.toolCallId };
+  const existingToolCallIndex = state.toolCalls.findIndex(
+    (toolCall) => toolCall.id === event.toolCallId,
+  );
+  if (existingToolCallIndex !== -1) {
+    const existingToolCall = state.toolCalls[existingToolCallIndex];
+    if (!existingToolCall) {
+      return state;
+    }
+    if (
+      state.activeToolCallId === event.toolCallId &&
+      event.metadata === undefined
+    ) {
+      return state;
+    }
+
+    const metadata = mergeClonedMetadata(
+      existingToolCall.metadata,
+      event.metadata,
+    );
+    return {
+      ...state,
+      activeToolCallId: event.toolCallId,
+      toolCalls:
+        event.metadata === undefined
+          ? state.toolCalls
+          : state.toolCalls.map((toolCall, index) =>
+              index === existingToolCallIndex
+                ? {
+                    ...toolCall,
+                    ...(metadata !== undefined ? { metadata } : {}),
+                  }
+                : toolCall,
+            ),
+    };
   }
+
+  const metadata = mergeClonedMetadata(undefined, event.metadata);
 
   const toolCalls = [
     ...state.toolCalls,
@@ -466,7 +531,7 @@ function startToolCall(
       name: event.toolCallName,
       arguments: '',
       status: 'pending' as const,
-      metadata: getToolCallMetadata(event.rawEvent),
+      ...(metadata !== undefined ? { metadata } : {}),
     },
   ];
   const message = state.message ?? {
@@ -503,15 +568,13 @@ function appendToolArguments(
     return state;
   }
 
-  const incomingMetadata = getToolCallMetadata(event.rawEvent);
-  if (event.delta.length === 0 && !incomingMetadata) {
+  const incomingMetadata = cloneMetadata(event.metadata);
+  if (event.delta.length === 0 && incomingMetadata === undefined) {
     return state;
   }
 
   const argumentsString = toolCall.arguments + event.delta;
-  const metadata = incomingMetadata
-    ? { ...(toolCall.metadata ?? {}), ...incomingMetadata }
-    : toolCall.metadata;
+  const metadata = mergeMetadata(toolCall.metadata, incomingMetadata);
   const tool = state.configSnapshot?.toolsByName[toolCall.name];
   let argumentsResolved = toolCall.argumentsResolved;
   let toolParserStateById = state.toolParserStateById;
@@ -560,7 +623,7 @@ function appendToolArguments(
           ...current,
           arguments: argumentsString,
           argumentsResolved,
-          metadata,
+          ...(metadata !== undefined ? { metadata } : {}),
         }
       : current,
   );
@@ -591,6 +654,7 @@ function applyTextMessageChunk(
       messageId,
       role: event.role ?? 'assistant',
       name: event.name,
+      metadata: event.metadata,
       rawEvent: event.rawEvent,
       timestamp: event.timestamp,
     });
@@ -604,6 +668,7 @@ function applyTextMessageChunk(
     type: EventType.TEXT_MESSAGE_CONTENT,
     messageId,
     delta: event.delta,
+    metadata: event.metadata,
     rawEvent: event.rawEvent,
     timestamp: event.timestamp,
   });
@@ -631,6 +696,7 @@ function applyToolCallChunk(
       toolCallId,
       toolCallName: event.toolCallName,
       parentMessageId: event.parentMessageId,
+      metadata: event.metadata,
       rawEvent: event.rawEvent,
       timestamp: event.timestamp,
     });
@@ -638,7 +704,11 @@ function applyToolCallChunk(
     next = { ...state, activeToolCallId: toolCallId };
   }
 
-  if (event.delta === undefined && event.rawEvent === undefined) {
+  if (
+    event.delta === undefined &&
+    event.metadata === undefined &&
+    event.rawEvent === undefined
+  ) {
     return next;
   }
 
@@ -646,6 +716,7 @@ function applyToolCallChunk(
     type: EventType.TOOL_CALL_ARGS,
     toolCallId,
     delta: event.delta ?? '',
+    metadata: event.metadata,
     rawEvent: event.rawEvent,
     timestamp: event.timestamp,
   });
@@ -809,6 +880,8 @@ function reduceEvent(
       return startTextMessage(state, event);
     case EventType.TEXT_MESSAGE_CONTENT:
       return appendTextContent(state, event);
+    case EventType.TEXT_MESSAGE_END:
+      return endTextMessage(state, event);
     case EventType.TEXT_MESSAGE_CHUNK:
       return applyTextMessageChunk(state, event);
     case EventType.TOOL_CALL_START:
@@ -818,7 +891,15 @@ function reduceEvent(
     case EventType.TOOL_CALL_CHUNK:
       return applyToolCallChunk(state, event);
     case EventType.TOOL_CALL_END:
-      return finalizeToolCalls(state, new Set([event.toolCallId]));
+      return finalizeToolCalls(
+        appendToolArguments(state, {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: event.toolCallId,
+          delta: '',
+          metadata: event.metadata,
+        }),
+        new Set([event.toolCallId]),
+      );
     case EventType.RUN_FINISHED:
       return finishRun(state);
     case EventType.RUN_ERROR:

--- a/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
@@ -115,7 +115,11 @@ test('clones assistant and tool-call metadata into the next run input', () => {
   ];
 
   const input = createInput({ messages });
-  metadata.google.steps[0]!.index = 99;
+  const [sourceStep] = metadata.google.steps;
+  if (!sourceStep) {
+    throw new Error('Expected source metadata step.');
+  }
+  sourceStep.index = 99;
   const assistant = input.messages.find(
     (message): message is Extract<Message, { role: 'assistant' }> =>
       message.role === 'assistant',
@@ -126,9 +130,11 @@ test('clones assistant and tool-call metadata into the next run input', () => {
   const toolMetadata = assistant?.toolCalls?.[0]?.metadata as {
     google: { steps: { index: number }[] };
   };
-  if (assistantMetadata) {
-    assistantMetadata.google.steps[0]!.index = 100;
+  const [assistantStep] = assistantMetadata.google.steps;
+  if (!assistantStep) {
+    throw new Error('Expected assistant metadata step.');
   }
+  assistantStep.index = 100;
 
   expect(input.messages.map((message) => message.role)).toEqual([
     'reasoning',

--- a/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.spec.ts
@@ -62,7 +62,6 @@ test('omits absent assistant and tool-call encrypted values', () => {
             name: 'getWeather',
             arguments: '{"city":"Paris"}',
           },
-          metadata: { provider: 'opaque' },
         },
       ],
     },
@@ -87,6 +86,82 @@ test('omits absent assistant and tool-call encrypted values', () => {
       ],
     },
   ] satisfies Message[]);
+});
+
+test('clones assistant and tool-call metadata into the next run input', () => {
+  const metadata = { google: { steps: [{ index: 1 }] } };
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'assistant',
+      content: 'Checking.',
+      metadata,
+      reasoningDetails: [
+        {
+          id: 'reasoning-1',
+          role: 'reasoning',
+          content: 'Need a lookup.',
+        },
+      ],
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-lookup',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{}' },
+          metadata,
+        },
+      ],
+    },
+  ];
+
+  const input = createInput({ messages });
+  metadata.google.steps[0]!.index = 99;
+  const assistant = input.messages.find(
+    (message): message is Extract<Message, { role: 'assistant' }> =>
+      message.role === 'assistant',
+  );
+  const assistantMetadata = assistant?.metadata as {
+    google: { steps: { index: number }[] };
+  };
+  const toolMetadata = assistant?.toolCalls?.[0]?.metadata as {
+    google: { steps: { index: number }[] };
+  };
+  if (assistantMetadata) {
+    assistantMetadata.google.steps[0]!.index = 100;
+  }
+
+  expect(input.messages.map((message) => message.role)).toEqual([
+    'reasoning',
+    'assistant',
+  ]);
+  expect(assistantMetadata).toEqual({ google: { steps: [{ index: 100 }] } });
+  expect(toolMetadata).toEqual({ google: { steps: [{ index: 1 }] } });
+});
+
+test('omits absent assistant and tool-call metadata from the next run input', () => {
+  const messages: Chat.Api.Message[] = [
+    {
+      role: 'assistant',
+      content: '',
+      toolCalls: [
+        {
+          index: 0,
+          id: 'call-lookup',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{}' },
+        },
+      ],
+    },
+  ];
+
+  const input = createInput({ messages });
+  const assistant = input.messages.find(
+    (message): message is Extract<Message, { role: 'assistant' }> =>
+      message.role === 'assistant',
+  );
+
+  expect(assistant).not.toHaveProperty('metadata');
+  expect(assistant?.toolCalls?.[0]).not.toHaveProperty('metadata');
 });
 
 test('emits ordered reasoning details before the assistant and its tool results', () => {

--- a/packages/core/src/transport/hashbrown-run-agent-input.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.ts
@@ -1,5 +1,6 @@
 import type {
   Message,
+  Metadata,
   ReasoningMessage,
   RunAgentInput,
   Tool,
@@ -69,9 +70,7 @@ function normalizeRejection(reason: unknown): string {
   return normalizeValue(reason);
 }
 
-function cloneMetadata(
-  metadata: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
+function cloneMetadata(metadata: Metadata | undefined): Metadata | undefined {
   return metadata === undefined ? undefined : structuredClone(metadata);
 }
 

--- a/packages/core/src/transport/hashbrown-run-agent-input.ts
+++ b/packages/core/src/transport/hashbrown-run-agent-input.ts
@@ -69,13 +69,19 @@ function normalizeRejection(reason: unknown): string {
   return normalizeValue(reason);
 }
 
+function cloneMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return metadata === undefined ? undefined : structuredClone(metadata);
+}
+
 function cloneReasoningMessage(
   reasoning: Readonly<ReasoningMessage>,
 ): ReasoningMessage {
   return {
     ...reasoning,
-    ...(reasoning.metadata
-      ? { metadata: structuredClone(reasoning.metadata) }
+    ...(reasoning.metadata !== undefined
+      ? { metadata: cloneMetadata(reasoning.metadata) }
       : {}),
   };
 }
@@ -98,6 +104,9 @@ function mapMessage(
         ...(message.encryptedValue !== undefined
           ? { encryptedValue: message.encryptedValue }
           : {}),
+        ...(message.metadata !== undefined
+          ? { metadata: cloneMetadata(message.metadata) }
+          : {}),
         ...(message.toolCalls !== undefined
           ? {
               toolCalls: message.toolCalls.map((toolCall) => ({
@@ -105,6 +114,9 @@ function mapMessage(
                 type: 'function' as const,
                 ...(toolCall.encryptedValue !== undefined
                   ? { encryptedValue: toolCall.encryptedValue }
+                  : {}),
+                ...(toolCall.metadata !== undefined
+                  ? { metadata: cloneMetadata(toolCall.metadata) }
                   : {}),
                 function: {
                   name: toolCall.function.name,

--- a/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
@@ -69,11 +69,17 @@ function createContinuationMessages(
       role: 'assistant',
       content: '',
       encryptedValue: 'fixture-assistant-opaque-value',
+      metadata: {
+        provider: { assistantSteps: [{ index: 0 }] },
+      },
       toolCalls: [
         {
           id: 'call-weather',
           type: 'function',
           encryptedValue: 'fixture-tool-opaque-value',
+          metadata: {
+            provider: { toolSteps: [{ index: 1 }] },
+          },
           function: {
             name: 'getWeather',
             arguments: '{"city":"Paris"}',
@@ -174,42 +180,59 @@ function createToolContinuationEvents(
         timestamp: 1_700_000_002_004,
       },
       {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: `${input.threadId}:message:1`,
+        role: 'assistant',
+        timestamp: 1_700_000_002_005,
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: `${input.threadId}:message:1`,
+        metadata: {
+          provider: { assistantSteps: [{ index: 0 }] },
+        },
+        timestamp: 1_700_000_002_006,
+      },
+      {
         type: EventType.TOOL_CALL_START,
         toolCallId: 'call-weather',
         toolCallName: 'getWeather',
         parentMessageId: `${input.threadId}:message:1`,
-        timestamp: 1_700_000_002_005,
+        timestamp: 1_700_000_002_007,
       },
       {
         type: EventType.REASONING_ENCRYPTED_VALUE,
         subtype: 'message',
         entityId: `${input.threadId}:message:1`,
         encryptedValue: 'fixture-assistant-opaque-value',
-        timestamp: 1_700_000_002_006,
+        timestamp: 1_700_000_002_008,
       },
       {
         type: EventType.REASONING_ENCRYPTED_VALUE,
         subtype: 'tool-call',
         entityId: 'call-weather',
         encryptedValue: 'fixture-tool-opaque-value',
-        timestamp: 1_700_000_002_007,
+        timestamp: 1_700_000_002_009,
       },
       {
         type: EventType.TOOL_CALL_ARGS,
         toolCallId: 'call-weather',
         delta: '{"city":"Paris"}',
-        timestamp: 1_700_000_002_008,
+        timestamp: 1_700_000_002_010,
       },
       {
         type: EventType.TOOL_CALL_END,
         toolCallId: 'call-weather',
-        timestamp: 1_700_000_002_009,
+        metadata: {
+          provider: { toolSteps: [{ index: 1 }] },
+        },
+        timestamp: 1_700_000_002_011,
       },
       {
         type: EventType.RUN_FINISHED,
         threadId: input.threadId,
         runId: input.runId,
-        timestamp: 1_700_000_002_010,
+        timestamp: 1_700_000_002_012,
       },
     ];
   }
@@ -303,6 +326,12 @@ test('executes a tool once and automatically continues the run', async ({
     'fixture-assistant-opaque-value',
   );
   expect(continuationToolCall.encryptedValue).toBe('fixture-tool-opaque-value');
+  expect(continuationAssistant.metadata).toEqual({
+    provider: { assistantSteps: [{ index: 0 }] },
+  });
+  expect(continuationToolCall.metadata).toEqual({
+    provider: { toolSteps: [{ index: 1 }] },
+  });
   expect(firstInput).toEqual({
     threadId: firstInput.threadId,
     runId: firstInput.runId,


### PR DESCRIPTION
## Summary

- add AG-UI `Metadata` to assistant messages and tool calls across the API, internal, and view models
- accumulate canonical event metadata throughout text and tool-call streaming lifecycles using AG-UI merge semantics
- preserve and isolate metadata across model conversions and continuation request serialization
- verify metadata survives tool execution and the subsequent model run

## Breaking Change

Hashbrown no longer reads metadata from `rawEvent.hashbrown.metadata`. Event producers must provide metadata through the canonical AG-UI event `metadata` field.

## Testing

- [x] affected builds, tests, lint, and API reports across 29 projects
- [x] 529 core tests
- [x] 24 runtime smoke unit tests
- [x] runtime smoke TypeScript verification
- [x] 24 Playwright scenarios across Angular and React
- [x] complete tool-call continuation with metadata isolation
