### PR TITLE
feat(azure): migrate provider to AG-UI

### DIFF
--- a/packages/azure/README.md
+++ b/packages/azure/README.md
@@ -16,30 +16,45 @@
 ## Getting Started
 
 ```sh
-npm install @hashbrownai/azure --save
+npm install @hashbrownai/azure openai @ag-ui/core @ag-ui/encoder --save
 ```
 
-Deploy an express server with a single /chat endpoint to use Hashbrown with Azure OpenAI.
+Deploy an Express server with a `/run` endpoint to use Hashbrown with Azure OpenAI.
 
 ```ts
-import { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 
-app.post('/chat', async (req, res) => {
-  const request = req.body as Chat.CompletionCreateParams;
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAzure.stream.text({
-    apiKey: AZURE_API_KEY,
-    endpoint: AZURE_ENDPOINT,
-    request,
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk);
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 ```
 

--- a/packages/azure/jest.config.ts
+++ b/packages/azure/jest.config.ts
@@ -7,5 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/azure',
-  testPathIgnorePatterns: ['(?!.*integration).*\\.ts$'],
+  testPathIgnorePatterns: ['/integration\\.spec\\.ts$'],
 };

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -12,10 +12,10 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
+    "@ag-ui/core": "0.0.59",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@hashbrownai/core": "0.5.0",
     "openai": "^6.9.0"
   },
   "sideEffects": false,

--- a/packages/azure/src/index.ts
+++ b/packages/azure/src/index.ts
@@ -1,10 +1,23 @@
+import type { AGUIEvent } from '@ag-ui/core';
 import { text } from './stream/text.fn';
+import type { AzureTextStreamOptions } from './stream/types';
+
+export type {
+  AzureHashbrownRunAgentInput,
+  AzureTextStreamOptions,
+} from './stream/types';
 
 /**
  * Hashbrown adapter for Azure OpenAI.
  * @public
  */
-export const HashbrownAzure = {
+export const HashbrownAzure: {
+  readonly stream: {
+    readonly text: (
+      options: AzureTextStreamOptions,
+    ) => AsyncIterable<AGUIEvent>;
+  };
+} = {
   stream: {
     text,
   },

--- a/packages/azure/src/integration.spec.ts
+++ b/packages/azure/src/integration.spec.ts
@@ -1,224 +1,216 @@
 import { resolve } from 'node:path';
-import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
-import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { runProviderAGUIWithAimock } from '@hashbrownai/testing/aimock';
 import { HashbrownAzure } from './index';
-import type { AzureCompletionCreateParams } from './stream/text.fn';
+import type { AzureHashbrownRunAgentInput } from './stream/types';
 
-const AZURE_MODEL = 'gpt-4o@2025-01-01-preview';
+const AZURE_MODEL = 'gpt-4o';
+const AZURE_API_VERSION = '2025-01-01-preview';
 
 function fixturePath(name: string): string {
   return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
 }
 
-function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
-  return frames.filter(
-    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
-  );
-}
-
-function streamedContent(frames: Frame[]): string {
-  return generationChunks(frames)
-    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
-    .join('');
-}
-
-function baseRequest(userMessage: string): AzureCompletionCreateParams {
+function baseInput(userMessage: string): AzureHashbrownRunAgentInput {
   return {
-    operation: 'generate',
-    model: AZURE_MODEL,
-    system: 'You are a deterministic test assistant.',
-    messages: [{ role: 'user', content: userMessage }],
+    threadId: 'thread-azure',
+    runId: 'run-azure',
+    messages: [
+      {
+        id: 'system-azure',
+        role: 'system',
+        content: 'You are a deterministic test assistant.',
+      },
+      {
+        id: 'user-azure',
+        role: 'user',
+        content: userMessage,
+      },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   };
 }
 
-async function consumeProviderStream(
-  stream: AsyncIterable<Uint8Array>,
-): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-  }
+async function runFixture(
+  fixtureName: string,
+  input: AzureHashbrownRunAgentInput,
+): Promise<AGUIEvent[]> {
+  return runProviderAGUIWithAimock({
+    fixturePath: fixturePath(fixtureName),
+    createStream: (aimock, signal) =>
+      HashbrownAzure.stream.text({
+        clientOptions: {
+          apiKey: 'test-not-used',
+          endpoint: aimock.url,
+          apiVersion: AZURE_API_VERSION,
+          deployment: AZURE_MODEL,
+        },
+        model: AZURE_MODEL,
+        input,
+        signal,
+      }),
+  });
 }
 
-test('Azure JSON response format mode requests JSON object output', async () => {
-  let capturedResponseFormat: unknown;
+function contentEvents(events: AGUIEvent[]) {
+  return events.filter(
+    (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+  );
+}
 
-  await consumeProviderStream(
-    HashbrownAzure.stream.text({
-      apiKey: 'test-api-key',
-      endpoint: 'https://example.openai.azure.com/',
-      request: {
-        ...baseRequest('Hello'),
-        system: 'Respond with JSON.',
-        responseFormatMode: 'json',
-      },
-      transformRequestOptions: (options) => {
-        capturedResponseFormat = options.response_format;
-        throw new Error('stop');
-      },
-    }),
+function streamedContent(events: AGUIEvent[]): string {
+  return contentEvents(events)
+    .map((event) => event.delta)
+    .join('');
+}
+
+test('Azure OpenAI consumes AG-UI input and emits a canonical text run', async () => {
+  const events = await runFixture('text.json', baseInput('say hi briefly'));
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-azure:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-azure:assistant',
+      delta: 'Hello from aimock.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-azure:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+  ]);
+});
+
+test('Azure OpenAI preserves streamed text across multiple AG-UI events', async () => {
+  const events = await runFixture(
+    'streaming.json',
+    baseInput('stream deterministic text'),
   );
 
-  expect(capturedResponseFormat).toEqual({ type: 'json_object' });
-});
-
-test('Azure OpenAI text streaming emits Hashbrown generation frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
-      HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: baseRequest('say hi briefly'),
-      }),
-  });
-
-  expect(frames[0].type).toBe('generation-start');
-  expect(frames.at(-1)?.type).toBe('generation-finish');
-  expect(streamedContent(frames)).toBe('Hello from aimock.');
-});
-
-test('Azure OpenAI streaming preserves chunked content across multiple frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('streaming.json'),
-    createStream: (aimock) =>
-      HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: baseRequest('stream deterministic text'),
-      }),
-  });
-
-  expect(generationChunks(frames).length).toBeGreaterThan(1);
-  expect(streamedContent(frames)).toContain(
+  expect(contentEvents(events).length).toBeGreaterThan(1);
+  expect(streamedContent(events)).toContain(
     'Streaming fixture response with enough text',
   );
 });
 
-test('Azure OpenAI tool calling emits tool call deltas', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('tool-call.json'),
-    createStream: (aimock) =>
-      HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: {
-          ...baseRequest('call the lookup tool'),
-          tools: [
-            {
-              name: 'lookup',
-              description: 'Lookup deterministic fixture data.',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
-              },
-            },
-          ],
-          toolChoice: 'required',
-        },
-      }),
-  });
+test('Azure OpenAI emits complete AG-UI tool call lifecycles', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
 
-  const toolCallDeltas = generationChunks(frames).flatMap(
-    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  const events = await runFixture('tool-call.json', input);
+  const start = events.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
   );
+  const args = events
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+  const end = events.find((event) => event.type === EventType.TOOL_CALL_END);
 
-  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
-  expect(
-    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
-  ).toBe(true);
-  expect(
-    toolCallDeltas
-      .map((toolCall) => toolCall.function?.arguments ?? '')
-      .join(''),
-  ).toContain('"query":"hashbrown"');
+  expect(start).toMatchObject({
+    type: EventType.TOOL_CALL_START,
+    toolCallName: 'lookup',
+    parentMessageId: 'run-azure:assistant',
+  });
+  expect(args).toContain('"query":"hashbrown"');
+  expect(end).toMatchObject({
+    type: EventType.TOOL_CALL_END,
+    toolCallId:
+      start?.type === EventType.TOOL_CALL_START
+        ? start.toolCallId
+        : 'missing-tool-call',
+  });
 });
 
-test('Azure OpenAI structured output emits JSON text content', async () => {
-  const frames = await runProviderTextWithAimock({
+test('Azure OpenAI maps the Hashbrown response schema to native structured output', async () => {
+  const input = baseInput('return structured output');
+  input.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        ok: { type: 'boolean' },
+      },
+      required: ['text', 'ok'],
+    },
+  };
+  let capturedResponseFormat: unknown;
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('structured-output.json'),
-    createStream: (aimock) =>
+    createStream: (aimock, signal) =>
       HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: {
-          ...baseRequest('return structured output'),
-          responseFormat: {
-            type: 'object',
-            properties: {
-              text: { type: 'string' },
-              ok: { type: 'boolean' },
-            },
-            required: ['text', 'ok'],
-          },
+        clientOptions: {
+          apiKey: 'test-not-used',
+          endpoint: aimock.url,
+          apiVersion: AZURE_API_VERSION,
+          deployment: AZURE_MODEL,
+        },
+        model: AZURE_MODEL,
+        input,
+        signal,
+        transformRequestOptions: (options) => {
+          capturedResponseFormat = options.response_format;
+          return options;
         },
       }),
   });
 
-  expect(JSON.parse(streamedContent(frames))).toEqual({
+  expect(capturedResponseFormat).toEqual({
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: input.hashbrown.responseSchema,
+    },
+  });
+  expect(JSON.parse(streamedContent(events))).toEqual({
     text: 'Hello from structured aimock.',
     ok: true,
   });
 });
 
-test('Azure OpenAI provider errors emit generation-error frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('error.json'),
-    createStream: (aimock) =>
-      HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: baseRequest('return provider error'),
-      }),
-  });
+test('Azure OpenAI provider errors emit a canonical run error', async () => {
+  const input = baseInput('return provider error');
 
-  expect(frames).toEqual([
-    { type: 'generation-start' },
+  const events = await runFixture('error.json', input);
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    },
     expect.objectContaining({
-      type: 'generation-error',
-      error: expect.stringContaining('Deterministic provider error'),
+      type: EventType.RUN_ERROR,
+      message: expect.stringContaining('Deterministic provider error'),
     }),
   ]);
-});
-
-test('Azure OpenAI thread persistence wraps generation with thread frames', async () => {
-  const savedThreads: Chat.Api.Message[][] = [];
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
-      HashbrownAzure.stream.text({
-        apiKey: 'test-not-used',
-        endpoint: aimock.url,
-        request: {
-          ...baseRequest('say hi briefly'),
-          threadId: 'azure-thread',
-        },
-        loadThread: async () => [
-          {
-            role: 'user',
-            content: 'previous message',
-          },
-        ],
-        saveThread: async (thread) => {
-          savedThreads.push(thread);
-          return 'azure-thread';
-        },
-      }),
-  });
-
-  expect(frames.map((frame) => frame.type)).toEqual([
-    'thread-load-start',
-    'thread-load-success',
-    'generation-start',
-    ...generationChunks(frames).map((frame) => frame.type),
-    'generation-finish',
-    'thread-save-start',
-    'thread-save-success',
-  ]);
-  expect(savedThreads).toHaveLength(1);
-  expect(savedThreads[0].map((message) => message.content)).toContain(
-    'Hello from aimock.',
-  );
 });

--- a/packages/azure/src/stream/azure-events.spec.ts
+++ b/packages/azure/src/stream/azure-events.spec.ts
@@ -1,0 +1,135 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import type OpenAI from 'openai';
+import { mapAzureEvents } from './azure-events';
+
+async function* source(
+  chunks: OpenAI.Chat.Completions.ChatCompletionChunk[],
+): AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk> {
+  yield* chunks;
+}
+
+async function collectEvents(
+  chunks: OpenAI.Chat.Completions.ChatCompletionChunk[],
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of mapAzureEvents({
+    events: source(chunks),
+    messageId: 'run-azure:assistant',
+  })) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  return events;
+}
+
+test('maps Azure OpenAI text and refusal deltas into one AG-UI lifecycle', async () => {
+  const chunks = [
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 1,
+          delta: { content: 'Alternative.' },
+          finish_reason: null,
+        },
+        {
+          index: 0,
+          delta: { content: 'Accepted. ', refusal: 'Declined.' },
+          finish_reason: null,
+        },
+      ],
+    },
+  ] as OpenAI.Chat.Completions.ChatCompletionChunk[];
+
+  const events = await collectEvents(chunks);
+
+  expect(events).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-azure:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-azure:assistant',
+      delta: 'Accepted. ',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-azure:assistant',
+      delta: 'Declined.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-azure:assistant',
+    },
+  ]);
+});
+
+test('maps fragmented Azure OpenAI tool calls into complete AG-UI lifecycles', async () => {
+  const chunks = [
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call-azure',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{"query":' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '"hashbrown"}' } }],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    },
+  ] as OpenAI.Chat.Completions.ChatCompletionChunk[];
+
+  const events = await collectEvents(chunks);
+
+  expect(events).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-azure',
+      toolCallName: 'lookup',
+      parentMessageId: 'run-azure:assistant',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-azure',
+      delta: '{"query":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-azure',
+      delta: '"hashbrown"}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'call-azure' },
+  ]);
+});

--- a/packages/azure/src/stream/azure-events.ts
+++ b/packages/azure/src/stream/azure-events.ts
@@ -1,0 +1,201 @@
+import {
+  type AGUIEvent,
+  EventType,
+  type TextMessageContentEvent,
+  type TextMessageStartEvent,
+} from '@ag-ui/core';
+import type OpenAI from 'openai';
+
+interface PendingToolCall {
+  readonly index: number;
+  readonly id?: string;
+  readonly name?: string;
+  readonly pendingArguments: string;
+  readonly started: boolean;
+}
+
+/** Inputs for mapping Azure OpenAI chunks to canonical AG-UI events. */
+export interface MapAzureEventsOptions {
+  events: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>;
+  messageId: string;
+  signal?: AbortSignal;
+}
+
+function createTextDeltaEvents(
+  messageId: string,
+  delta: string | null | undefined,
+  started: boolean,
+): Array<TextMessageStartEvent | TextMessageContentEvent> {
+  if (!delta) {
+    return [];
+  }
+
+  const contentEvent: TextMessageContentEvent = {
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId,
+    delta,
+  };
+  return started
+    ? [contentEvent]
+    : [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId,
+          role: 'assistant',
+        },
+        contentEvent,
+      ];
+}
+
+function mergeToolCall(
+  current: PendingToolCall | undefined,
+  delta: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall,
+): PendingToolCall {
+  return {
+    index: delta.index,
+    id: delta.id ?? current?.id,
+    name: delta.function?.name ?? current?.name,
+    pendingArguments:
+      current?.started === true
+        ? (delta.function?.arguments ?? '')
+        : `${current?.pendingArguments ?? ''}${delta.function?.arguments ?? ''}`,
+    started: current?.started ?? false,
+  };
+}
+
+function startToolCall(
+  toolCall: PendingToolCall,
+): PendingToolCall & { id: string; name: string } {
+  if (!toolCall.id || !toolCall.name) {
+    throw new Error(
+      `Azure OpenAI returned incomplete metadata for tool call at index ${toolCall.index}`,
+    );
+  }
+
+  return {
+    ...toolCall,
+    id: toolCall.id,
+    name: toolCall.name,
+    pendingArguments: '',
+    started: true,
+  };
+}
+
+/**
+ * Maps Azure OpenAI streaming chunks to canonical AG-UI message events.
+ *
+ * @param options - Azure OpenAI stream and AG-UI message identity.
+ * @returns Canonical AG-UI events for the provider response.
+ *
+ * @internal
+ */
+export async function* mapAzureEvents(
+  options: MapAzureEventsOptions,
+): AsyncIterable<AGUIEvent> {
+  let textStarted = false;
+  const toolCalls = new Map<number, PendingToolCall>();
+
+  for await (const chunk of options.events) {
+    if (options.signal?.aborted) {
+      return;
+    }
+
+    for (const choice of chunk.choices) {
+      if (choice.index !== 0) {
+        continue;
+      }
+
+      for (const textDelta of [choice.delta.content, choice.delta.refusal]) {
+        const textEvents = createTextDeltaEvents(
+          options.messageId,
+          textDelta,
+          textStarted,
+        );
+        if (textEvents.length > 0) {
+          textStarted = true;
+        }
+        for (const event of textEvents) {
+          yield event;
+          if (options.signal?.aborted) {
+            return;
+          }
+        }
+      }
+
+      for (const delta of choice.delta.tool_calls ?? []) {
+        let toolCall = mergeToolCall(toolCalls.get(delta.index), delta);
+
+        if (!toolCall.started && toolCall.id && toolCall.name) {
+          const pendingArguments = toolCall.pendingArguments;
+          const startedToolCall = startToolCall(toolCall);
+          yield {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: startedToolCall.id,
+            toolCallName: startedToolCall.name,
+            parentMessageId: options.messageId,
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+          if (pendingArguments) {
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: startedToolCall.id,
+              delta: pendingArguments,
+            };
+            if (options.signal?.aborted) {
+              return;
+            }
+          }
+          toolCall = startedToolCall;
+        } else if (toolCall.started && toolCall.pendingArguments) {
+          yield {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: toolCall.id as string,
+            delta: toolCall.pendingArguments,
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+          toolCall = { ...toolCall, pendingArguments: '' };
+        }
+
+        toolCalls.set(delta.index, toolCall);
+      }
+    }
+  }
+
+  if (options.signal?.aborted) {
+    return;
+  }
+
+  if (textStarted) {
+    yield { type: EventType.TEXT_MESSAGE_END, messageId: options.messageId };
+    if (options.signal?.aborted) {
+      return;
+    }
+  }
+
+  for (const pendingToolCall of toolCalls.values()) {
+    const toolCall = pendingToolCall.started
+      ? pendingToolCall
+      : startToolCall(pendingToolCall);
+    if (toolCall.pendingArguments) {
+      yield {
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId: toolCall.id as string,
+        delta: toolCall.pendingArguments,
+      };
+      if (options.signal?.aborted) {
+        return;
+      }
+    }
+    yield {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: toolCall.id as string,
+    };
+    if (options.signal?.aborted) {
+      return;
+    }
+  }
+}

--- a/packages/azure/src/stream/azure-request.spec.ts
+++ b/packages/azure/src/stream/azure-request.spec.ts
@@ -1,0 +1,136 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { createAzureRequestOptions } from './azure-request';
+
+function createInput(): RunAgentInput & {
+  hashbrown: { responseSchema: object };
+} {
+  return {
+    threadId: 'thread-azure',
+    runId: 'run-azure',
+    messages: [
+      { id: 'system-azure', role: 'system', content: 'System prompt.' },
+      {
+        id: 'developer-azure',
+        role: 'developer',
+        content: 'Developer prompt.',
+      },
+      { id: 'user-azure', role: 'user', content: 'Look it up.' },
+      {
+        id: 'assistant-azure',
+        role: 'assistant',
+        content: 'Checking.',
+        toolCalls: [
+          {
+            id: 'call-azure',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"hashbrown"}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-azure',
+        role: 'tool',
+        toolCallId: 'call-azure',
+        content: '{"result":"fixture"}',
+      },
+      {
+        id: 'reasoning-azure',
+        role: 'reasoning',
+        content: 'Provider-private reasoning.',
+      },
+      {
+        id: 'activity-azure',
+        role: 'activity',
+        activityType: 'status',
+        content: { message: 'Working.' },
+      },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup a value.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    hashbrown: {
+      responseSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+    },
+  };
+}
+
+test('maps AG-UI messages, tools, and structured output to Azure OpenAI', () => {
+  const input = createInput();
+
+  const result = createAzureRequestOptions(input, 'gpt-4.1');
+
+  expect(result).toEqual({
+    stream: true,
+    model: 'gpt-4.1',
+    messages: [
+      { role: 'system', content: 'System prompt.' },
+      { role: 'developer', content: 'Developer prompt.' },
+      { role: 'user', content: 'Look it up.' },
+      {
+        role: 'assistant',
+        content: 'Checking.',
+        tool_calls: [
+          {
+            id: 'call-azure',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"hashbrown"}',
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: '{"result":"fixture"}',
+        tool_call_id: 'call-azure',
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'lookup',
+          description: 'Lookup a value.',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+          strict: true,
+        },
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        strict: true,
+        name: 'schema',
+        description: '',
+        schema: {
+          type: 'object',
+          properties: { answer: { type: 'string' } },
+          required: ['answer'],
+        },
+      },
+    },
+  });
+});

--- a/packages/azure/src/stream/azure-request.ts
+++ b/packages/azure/src/stream/azure-request.ts
@@ -1,0 +1,101 @@
+import type { Message } from '@ag-ui/core';
+import OpenAI from 'openai';
+import type { FunctionParameters } from 'openai/resources/shared';
+import type { AzureHashbrownRunAgentInput } from './types';
+
+function mapMessage(
+  message: Message,
+): OpenAI.ChatCompletionMessageParam | undefined {
+  switch (message.role) {
+    case 'developer':
+    case 'system':
+      return { role: message.role, content: message.content };
+    case 'user':
+      if (typeof message.content !== 'string') {
+        throw new Error(
+          'Azure OpenAI provider currently requires text user content',
+        );
+      }
+
+      return { role: 'user', content: message.content };
+    case 'assistant':
+      return {
+        role: 'assistant',
+        content: message.content ?? null,
+        tool_calls: message.toolCalls?.map((toolCall) => ({
+          id: toolCall.id,
+          type: 'function',
+          function: {
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments,
+          },
+        })),
+      };
+    case 'tool':
+      return {
+        role: 'tool',
+        content: message.content,
+        tool_call_id: message.toolCallId,
+      };
+    case 'activity':
+    case 'reasoning':
+      return undefined;
+  }
+}
+
+function createResponseFormat(
+  responseSchema: object | undefined,
+): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
+  if (!responseSchema) {
+    return undefined;
+  }
+
+  return {
+    type: 'json_schema',
+    json_schema: {
+      strict: true,
+      name: 'schema',
+      description: '',
+      schema: structuredClone(responseSchema) as Record<string, unknown>,
+    },
+  };
+}
+
+/**
+ * Maps an AG-UI run input to Azure OpenAI streaming request options.
+ *
+ * @param input - Standard AG-UI run input with optional Hashbrown metadata.
+ * @param model - Model selected by the server for this endpoint.
+ * @returns Fresh Azure OpenAI request options that do not mutate the input.
+ *
+ * @internal
+ */
+export function createAzureRequestOptions(
+  input: AzureHashbrownRunAgentInput,
+  model: string,
+): OpenAI.Chat.ChatCompletionCreateParamsStreaming {
+  return {
+    stream: true,
+    model,
+    messages: input.messages.flatMap((message) => {
+      const mapped = mapMessage(message);
+      return mapped ? [mapped] : [];
+    }),
+    tools:
+      input.tools.length === 0
+        ? undefined
+        : input.tools.map((tool) => ({
+            type: 'function',
+            function: {
+              name: tool.name,
+              description: tool.description,
+              parameters:
+                tool.parameters === undefined
+                  ? undefined
+                  : (structuredClone(tool.parameters) as FunctionParameters),
+              strict: true,
+            },
+          })),
+    response_format: createResponseFormat(input.hashbrown?.responseSchema),
+  };
+}

--- a/packages/azure/src/stream/text.fn.spec.ts
+++ b/packages/azure/src/stream/text.fn.spec.ts
@@ -1,0 +1,299 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import { AzureOpenAI } from 'openai';
+import type OpenAI from 'openai';
+import { text } from './text.fn';
+import type {
+  AzureHashbrownRunAgentInput,
+  AzureTextStreamOptions,
+} from './types';
+
+jest.mock('openai', () => {
+  const actual = jest.requireActual<typeof import('openai')>('openai');
+  return { ...actual, AzureOpenAI: jest.fn() };
+});
+
+const MockedAzureOpenAI = jest.mocked(AzureOpenAI);
+
+function createInput(): AzureHashbrownRunAgentInput {
+  return {
+    threadId: 'thread-azure',
+    runId: 'run-azure',
+    messages: [{ id: 'user-azure', role: 'user', content: 'Hello.' }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  };
+}
+
+function createOptions(
+  overrides: Partial<AzureTextStreamOptions> = {},
+): AzureTextStreamOptions {
+  return {
+    clientOptions: {
+      apiKey: 'test-api-key',
+      endpoint: 'https://example.openai.azure.com',
+      apiVersion: '2025-01-01-preview',
+      deployment: 'chat-deployment',
+    },
+    model: 'gpt-4.1',
+    input: createInput(),
+    ...overrides,
+  };
+}
+
+function mockProvider(
+  chunks: OpenAI.Chat.Completions.ChatCompletionChunk[],
+  sourceError?: Error,
+) {
+  MockedAzureOpenAI.mockReset();
+  let index = 0;
+  const abort = jest.fn();
+  const iteratorReturn = jest.fn(
+    async (): Promise<
+      IteratorResult<OpenAI.Chat.Completions.ChatCompletionChunk>
+    > => ({ done: true, value: undefined }),
+  );
+  const provider = {
+    abort,
+    async next(): Promise<
+      IteratorResult<OpenAI.Chat.Completions.ChatCompletionChunk>
+    > {
+      const value = chunks[index];
+      index += 1;
+
+      if (value === undefined && sourceError) {
+        throw sourceError;
+      }
+
+      return value === undefined
+        ? { done: true, value: undefined }
+        : { done: false, value };
+    },
+    return: iteratorReturn,
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+  const stream = jest.fn().mockReturnValue(provider);
+  MockedAzureOpenAI.mockImplementation(
+    () => ({ chat: { completions: { stream } } }) as unknown as AzureOpenAI,
+  );
+
+  return { abort, iteratorReturn, stream };
+}
+
+async function collectEvents(
+  options: AzureTextStreamOptions,
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of text(options)) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  return events;
+}
+
+test('streams canonical AG-UI run and text events from Azure OpenAI', async () => {
+  const provider = mockProvider([
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: { content: 'Hello from Azure.' },
+          finish_reason: 'stop',
+        },
+      ],
+    },
+  ] as OpenAI.Chat.Completions.ChatCompletionChunk[]);
+  const options = createOptions();
+
+  const events = await collectEvents(options);
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-azure:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-azure:assistant',
+      delta: 'Hello from Azure.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-azure:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+  ]);
+  expect(MockedAzureOpenAI).toHaveBeenCalledWith(options.clientOptions);
+  expect(provider.stream).toHaveBeenCalledWith(
+    expect.objectContaining({
+      stream: true,
+      model: 'gpt-4.1',
+      messages: [{ role: 'user', content: 'Hello.' }],
+    }),
+    { signal: undefined },
+  );
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('maps an Azure source rejection to one RUN_ERROR and aborts the stream', async () => {
+  const provider = mockProvider([], new Error('Azure source failed'));
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+    { type: EventType.RUN_ERROR, message: 'Azure source failed' },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('maps incomplete Azure tool metadata to RUN_ERROR without terminal events', async () => {
+  const provider = mockProvider([
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                function: { arguments: '{"query":"hashbrown"}' },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    },
+  ] as OpenAI.Chat.Completions.ChatCompletionChunk[]);
+
+  const events = await collectEvents(createOptions());
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+    {
+      type: EventType.RUN_ERROR,
+      message:
+        'Azure OpenAI returned incomplete metadata for tool call at index 0',
+    },
+  ]);
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+});
+
+test('maps transform rejection to one RUN_ERROR without creating a client', async () => {
+  const provider = mockProvider([]);
+  const transformRequestOptions = jest
+    .fn()
+    .mockRejectedValue(new Error('Transform rejected request'));
+
+  const events = await collectEvents(
+    createOptions({ transformRequestOptions }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+    { type: EventType.RUN_ERROR, message: 'Transform rejected request' },
+  ]);
+  expect(MockedAzureOpenAI).not.toHaveBeenCalled();
+  expect(provider.stream).not.toHaveBeenCalled();
+});
+
+test('returns only RUN_STARTED when the signal is already aborted', async () => {
+  const provider = mockProvider([]);
+  const controller = new AbortController();
+  controller.abort();
+
+  const events = await collectEvents(
+    createOptions({ signal: controller.signal }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-azure',
+      runId: 'run-azure',
+    },
+  ]);
+  expect(MockedAzureOpenAI).not.toHaveBeenCalled();
+  expect(provider.stream).not.toHaveBeenCalled();
+});
+
+test('cancellation after content emits no synthetic lifecycle ends', async () => {
+  const provider = mockProvider([
+    {
+      id: 'completion-azure',
+      created: 1,
+      model: 'gpt-4.1',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: { content: 'First fragment.' },
+          finish_reason: null,
+        },
+      ],
+    },
+  ] as OpenAI.Chat.Completions.ChatCompletionChunk[]);
+  const controller = new AbortController();
+  const iterator = text(createOptions({ signal: controller.signal }))[
+    Symbol.asyncIterator
+  ]();
+  const events = [
+    EventSchemas.parse((await iterator.next()).value),
+    EventSchemas.parse((await iterator.next()).value),
+    EventSchemas.parse((await iterator.next()).value),
+  ];
+
+  controller.abort();
+  const done = await iterator.next();
+
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+  ]);
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.TEXT_MESSAGE_END }),
+      expect.objectContaining({ type: EventType.RUN_ERROR }),
+      expect.objectContaining({ type: EventType.RUN_FINISHED }),
+    ]),
+  );
+  expect(provider.abort).toHaveBeenCalledTimes(1);
+  expect(provider.iteratorReturn).toHaveBeenCalledTimes(1);
+});

--- a/packages/azure/src/stream/text.fn.ts
+++ b/packages/azure/src/stream/text.fn.ts
@@ -1,301 +1,70 @@
-import {
-  AzureKnownModelIds,
-  Chat,
-  encodeFrame,
-  Frame,
-  mergeMessagesForThread,
-  updateAssistantMessage,
-} from '@hashbrownai/core';
-import OpenAI, { AzureOpenAI } from 'openai';
-import type { FunctionParameters } from 'openai/resources/shared';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { AzureOpenAI } from 'openai';
+import { mapAzureEvents } from './azure-events';
+import { createAzureRequestOptions } from './azure-request';
+import type { AzureTextStreamOptions } from './types';
 
-type BaseAzureTextStreamOptions = {
-  apiKey: string;
-  endpoint: string;
-  request: AzureCompletionCreateParams;
-  transformRequestOptions?: (
-    options: OpenAI.Chat.ChatCompletionCreateParamsStreaming,
-  ) =>
-    | OpenAI.Chat.ChatCompletionCreateParamsStreaming
-    | Promise<OpenAI.Chat.ChatCompletionCreateParamsStreaming>;
-};
-
-type ThreadPersistenceOptions = {
-  loadThread: (threadId: string) => Promise<Chat.Api.Message[]>;
-  saveThread: (
-    thread: Chat.Api.Message[],
-    threadId?: string,
-  ) => Promise<string>;
-};
-
-type ThreadlessOptions = BaseAzureTextStreamOptions & {
-  loadThread?: undefined;
-  saveThread?: undefined;
-};
-
-type ThreadfulOptions = BaseAzureTextStreamOptions & ThreadPersistenceOptions;
-
-export type AzureTextStreamOptions = ThreadlessOptions | ThreadfulOptions;
-
-export interface AzureCompletionCreateParams extends Omit<
-  Chat.Api.CompletionCreateParams,
-  'model'
-> {
-  model: AzureKnownModelIds;
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
-export function text(options: ThreadfulOptions): AsyncIterable<Uint8Array>;
-export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
-
+/**
+ * Streams canonical AG-UI events from an Azure OpenAI chat completion.
+ *
+ * @param options - Azure SDK configuration and AG-UI run input.
+ * @returns An asynchronous stream of canonical AG-UI events.
+ *
+ * @public
+ */
 export async function* text(
   options: AzureTextStreamOptions,
-): AsyncIterable<Uint8Array> {
-  const {
-    apiKey,
-    endpoint,
-    request,
-    transformRequestOptions,
-    loadThread,
-    saveThread,
-  } = options;
-  const {
-    model: modelAndVersion,
-    tools,
-    responseFormat,
-    responseFormatMode,
-    system,
-    toolChoice,
-  } = request;
-  const threadId = request.threadId;
-  let loadedThread: Chat.Api.Message[] = [];
-  let effectiveThreadId = threadId;
+): AsyncIterable<AGUIEvent> {
+  const { clientOptions, model, input, signal, transformRequestOptions } =
+    options;
+  const { threadId, runId } = input;
+  const messageId = `${runId}:assistant`;
+  let providerStream: ReturnType<
+    AzureOpenAI['chat']['completions']['stream']
+  > | null = null;
 
-  if (!modelAndVersion.includes('@')) {
-    throw new Error(
-      'Model version is required when using Azure OpenAI. Please specify the model version in the `model` string when supplied to any resource.',
-    );
-  }
-
-  const [model, apiVersion] = modelAndVersion.split('@');
-
-  const client = new AzureOpenAI({
-    apiKey,
-    endpoint,
-    apiVersion,
-    deployment: model,
-  });
-
-  const shouldLoadThread = Boolean(request.threadId);
-  const shouldHydrateThreadOnTheClient = Boolean(
-    request.operation === 'load-thread',
-  );
-
-  if (shouldLoadThread) {
-    yield encodeFrame({ type: 'thread-load-start' });
-
-    if (!loadThread) {
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: 'Thread loading is not available for this transport.',
-      });
-      return;
-    }
-
-    try {
-      loadedThread = await loadThread(request.threadId as string);
-      if (shouldHydrateThreadOnTheClient) {
-        yield encodeFrame({
-          type: 'thread-load-success',
-          thread: loadedThread,
-        });
-      } else {
-        yield encodeFrame({ type: 'thread-load-success' });
-      }
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
-  }
-
-  if (request.operation === 'load-thread') {
+  yield { type: EventType.RUN_STARTED, threadId, runId };
+  if (signal?.aborted) {
     return;
   }
-
-  const mergedMessages =
-    request.threadId && shouldLoadThread
-      ? mergeMessagesForThread(loadedThread, request.messages ?? [])
-      : (request.messages ?? []);
-  let assistantMessage: Chat.Api.AssistantMessage | null = null;
 
   try {
-    const baseOptions: OpenAI.Chat.ChatCompletionCreateParamsStreaming = {
-      stream: true,
-      model: model,
-      messages: [
-        {
-          role: 'system',
-          content: system,
-        },
-        ...mergedMessages.map((message): OpenAI.ChatCompletionMessageParam => {
-          if (message.role === 'user') {
-            return {
-              role: message.role,
-              content: message.content,
-            };
-          }
-          if (message.role === 'assistant') {
-            return {
-              role: message.role,
-              content:
-                message.content && typeof message.content !== 'string'
-                  ? JSON.stringify(message.content)
-                  : message.content,
-              tool_calls:
-                message.toolCalls && message.toolCalls.length > 0
-                  ? message.toolCalls.map((toolCall) => ({
-                      ...toolCall,
-                      type: 'function',
-                      function: {
-                        ...toolCall.function,
-                        arguments: JSON.stringify(toolCall.function.arguments),
-                      },
-                    }))
-                  : undefined,
-            };
-          }
-          if (message.role === 'tool') {
-            return {
-              role: message.role,
-              content: JSON.stringify(message.content),
-              tool_call_id: message.toolCallId,
-            };
-          }
-
-          throw new Error(`Invalid message role`);
-        }),
-      ],
-      tools:
-        tools && tools.length > 0
-          ? tools.map((tool) => ({
-              type: 'function',
-              function: {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters as FunctionParameters,
-                strict: true,
-              },
-            }))
-          : undefined,
-      tool_choice: toolChoice,
-      response_format: createResponseFormat(responseFormatMode, responseFormat),
-    };
-
-    const resolvedOptions: OpenAI.Chat.ChatCompletionCreateParams =
-      transformRequestOptions
-        ? await transformRequestOptions(baseOptions)
-        : baseOptions;
-
-    const stream = client.chat.completions.stream(resolvedOptions);
-
-    yield encodeFrame({ type: 'generation-start' });
-
-    for await (const chunk of stream) {
-      const chunkMessage: Chat.Api.CompletionChunk = {
-        choices: chunk.choices.map(
-          (choice): Chat.Api.CompletionChunkChoice => ({
-            index: choice.index,
-            delta: {
-              content: choice.delta?.content,
-              role: choice.delta?.role,
-              toolCalls: choice.delta?.tool_calls,
-            },
-            finishReason: choice.finish_reason,
-          }),
-        ),
-      };
-
-      const frame: Frame = {
-        type: 'generation-chunk',
-        chunk: chunkMessage,
-      };
-
-      assistantMessage = updateAssistantMessage(assistantMessage, chunkMessage);
-
-      yield encodeFrame(frame);
-    }
-
-    yield encodeFrame({ type: 'generation-finish' });
-  } catch (error: unknown) {
-    const { message, stack } = normalizeError(error);
-    const frame: Frame = {
-      type: 'generation-error',
-      error: message,
-      stacktrace: stack,
-    };
-    yield encodeFrame(frame);
-    return;
-  }
-
-  if (saveThread) {
-    const threadToSave = mergeMessagesForThread(mergedMessages, [
-      ...(assistantMessage ? [assistantMessage] : []),
-    ]);
-    yield encodeFrame({ type: 'thread-save-start' });
-    try {
-      const savedThreadId = await saveThread(threadToSave, effectiveThreadId);
-      if (effectiveThreadId && savedThreadId !== effectiveThreadId) {
-        throw new Error(
-          'Save returned a different threadId than the existing thread',
-        );
-      }
-      effectiveThreadId = savedThreadId;
-      yield encodeFrame({
-        type: 'thread-save-success',
-        threadId: savedThreadId,
-      });
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-save-failure',
-        error: message,
-        stacktrace: stack,
-      });
+    const baseRequest = createAzureRequestOptions(input, model);
+    const request = transformRequestOptions
+      ? await transformRequestOptions(baseRequest)
+      : baseRequest;
+    if (signal?.aborted) {
       return;
     }
-  }
-}
 
-function createResponseFormat(
-  responseFormatMode: Chat.Api.ResponseFormatMode | undefined,
-  responseFormat: object | undefined,
-): OpenAI.Chat.ChatCompletionCreateParamsStreaming['response_format'] {
-  if (responseFormatMode === 'json') {
-    return { type: 'json_object' };
-  }
+    const azure = new AzureOpenAI(clientOptions);
+    providerStream = azure.chat.completions.stream(request, { signal });
 
-  if (!responseFormat) {
-    return undefined;
-  }
+    for await (const event of mapAzureEvents({
+      events: providerStream,
+      messageId,
+      signal,
+    })) {
+      yield event;
+      if (signal?.aborted) {
+        return;
+      }
+    }
 
-  return {
-    type: 'json_schema',
-    json_schema: {
-      strict: true,
-      name: 'schema',
-      description: '',
-      schema: responseFormat as Record<string, unknown>,
-    },
-  };
-}
+    if (signal?.aborted) {
+      return;
+    }
 
-function normalizeError(error: unknown): { message: string; stack?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, stack: error.stack };
+    yield { type: EventType.RUN_FINISHED, threadId, runId };
+  } catch (error: unknown) {
+    if (!signal?.aborted) {
+      yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
+    }
+  } finally {
+    providerStream?.abort();
   }
-  return { message: String(error) };
 }

--- a/packages/azure/src/stream/types.ts
+++ b/packages/azure/src/stream/types.ts
@@ -1,0 +1,40 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import type { AzureClientOptions } from 'openai/azure';
+import type OpenAI from 'openai';
+
+/**
+ * Hashbrown extensions accepted alongside a standard AG-UI run input.
+ *
+ * @public
+ */
+export interface AzureHashbrownRunAgentInput extends RunAgentInput {
+  /** Hashbrown semantics layered onto the standard AG-UI run input. */
+  hashbrown?: {
+    /** JSON Schema used for Azure OpenAI native structured output. */
+    responseSchema?: object;
+    /** Whether the run is expected to produce generative UI output. */
+    ui?: boolean;
+  };
+}
+
+/**
+ * Options for streaming an AG-UI run from Azure OpenAI.
+ *
+ * @public
+ */
+export interface AzureTextStreamOptions {
+  /** Official Azure OpenAI SDK client configuration. */
+  clientOptions: AzureClientOptions;
+  /** Model selected by the server for this endpoint. */
+  model: string;
+  /** Standard AG-UI run input plus optional Hashbrown semantics. */
+  input: AzureHashbrownRunAgentInput;
+  /** Cancels the provider request when the HTTP request is abandoned. */
+  signal?: AbortSignal;
+  /** Customize the Azure OpenAI request after AG-UI input is mapped. */
+  transformRequestOptions?: (
+    options: OpenAI.Chat.ChatCompletionCreateParamsStreaming,
+  ) =>
+    | OpenAI.Chat.ChatCompletionCreateParamsStreaming
+    | Promise<OpenAI.Chat.ChatCompletionCreateParamsStreaming>;
+}

--- a/packages/azure/tsconfig.docs.json
+++ b/packages/azure/tsconfig.docs.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      "@hashbrownai/core": ["dist/packages/core/"]
-    }
-  }
+  "extends": "./tsconfig.json"
 }

--- a/samples/kitchen-sink/server/src/main.ts
+++ b/samples/kitchen-sink/server/src/main.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { RunAgentInput } from '@ag-ui/core';
 import { EventEncoder } from '@ag-ui/encoder';
 import { Chat } from '@hashbrownai/core';
@@ -18,6 +17,9 @@ const OPENAI_BASE_URL = process.env['OPENAI_BASE_URL'];
 const OPENAI_MODEL = process.env['OPENAI_MODEL'] ?? 'gpt-5-nano';
 const AZURE_API_KEY = process.env['AZURE_API_KEY'] ?? '';
 const AZURE_ENDPOINT = process.env['AZURE_ENDPOINT'] ?? '';
+const AZURE_API_VERSION = process.env['AZURE_API_VERSION'] ?? '';
+const AZURE_DEPLOYMENT = process.env['AZURE_DEPLOYMENT'];
+const AZURE_MODEL = process.env['AZURE_MODEL'] ?? '';
 const GOOGLE_API_KEY = process.env['GOOGLE_API_KEY'] ?? '';
 const GOOGLE_MODEL = process.env['GOOGLE_MODEL'] ?? 'gemini-2.5-flash';
 const OLLAMA_API_KEY = process.env['OLLAMA_API_KEY'] ?? '';
@@ -53,6 +55,37 @@ app.post('/chat', async (req, res) => {
     apiKey: OPENAI_API_KEY,
     baseURL: OPENAI_BASE_URL,
     model: OPENAI_MODEL,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
+  });
+  const encoder = new EventEncoder();
+
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
+  }
+
+  if (!res.writableEnded) {
+    res.end();
+  }
+});
+
+app.post('/azure/chat', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
+  const stream = HashbrownAzure.stream.text({
+    clientOptions: {
+      apiKey: AZURE_API_KEY,
+      endpoint: AZURE_ENDPOINT,
+      apiVersion: AZURE_API_VERSION,
+      deployment: AZURE_DEPLOYMENT,
+    },
+    model: AZURE_MODEL,
     input: req.body as RunAgentInput,
     signal: abortController.signal,
   });

--- a/www/analog/project.json
+++ b/www/analog/project.json
@@ -27,6 +27,9 @@
         }
       }
     },
+    "typecheck": {
+      "dependsOn": ["collect-docs"]
+    },
     "serve": {
       "executor": "@analogjs/platform:vite-dev-server",
       "defaultConfiguration": "development",

--- a/www/analog/src/app/pages/docs/angular/platform/azure.md
+++ b/www/analog/src/app/pages/docs/angular/platform/azure.md
@@ -1,80 +1,129 @@
 ---
-title: 'Microsoft Azure: Hashbrown Angular Docs'
+title: 'Microsoft Azure OpenAI: Hashbrown Angular Docs'
 meta:
   - name: description
-    content: 'First, install the Microsoft Azure adapter package:'
+    content: 'Hashbrown’s Microsoft Azure OpenAI adapter maps AG-UI runs to the Azure OpenAI SDK and streams canonical AG-UI events.'
 ---
-# Microsoft Azure
 
-First, install the Microsoft Azure adapter package:
+# Microsoft Azure OpenAI
 
-```shell
-npm install @hashbrownai/azure
+Install the Azure adapter, the Azure OpenAI SDK, and the AG-UI SSE encoder:
+
+```sh
+npm install @hashbrownai/azure openai @ag-ui/core @ag-ui/encoder
+```
+
+## Client Configuration
+
+Pass the official SDK's `AzureClientOptions` directly as `clientOptions`. This supports API keys, Microsoft Entra token providers, Azure endpoints, custom base URLs, deployment aliases, retries, and custom fetch implementations without Hashbrown wrapping those options. The model remains server configuration and is not read from the client run input.
+
+**API key:**
+
+```ts
+HashbrownAzure.stream.text({
+  clientOptions: {
+    apiKey: process.env.AZURE_API_KEY!,
+    endpoint: process.env.AZURE_ENDPOINT!,
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+});
+```
+
+**Microsoft Entra token provider:**
+
+```ts
+HashbrownAzure.stream.text({
+  clientOptions: {
+    azureADTokenProvider,
+    endpoint: process.env.AZURE_ENDPOINT!,
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+});
 ```
 
 ## Streaming Text Responses
 
-Hashbrown's Azure adapter lets you **stream chat completions** from Azure OpenAI Service, with support for Azure-specific configuration like endpoints and API versions.
+`HashbrownAzure.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. Encode those events as AG-UI SSE at your HTTP boundary.
 
 ### API Reference
 
-#### `HashbrownAzure.stream.text(options)`
+| Name                      | Type                                    | Description                                                                          |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `clientOptions`           | `AzureClientOptions`                    | Official Azure OpenAI SDK configuration, passed through unchanged.                   |
+| `model`                   | `string`                                | Server-selected Azure OpenAI model.                                                  |
+| `input`                   | `AzureHashbrownRunAgentInput`           | AG-UI run input, including messages and tools.                                       |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Azure OpenAI request when the HTTP client disconnects.      |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final OpenAI chat-completions streaming request options. |
 
-Streams an Azure OpenAI chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, tool results, and native structured output. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Azure OpenAI native JSON schema output:
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your Azure OpenAI API Key.                                                     |
-| `endpoint`                | `string`                                | Your Azure OpenAI endpoint URL.                                                |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Azure request before it is sent.  |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Supports Azure OpenAI function calling, including `toolCalls` and strict function schemas.
-- **Response Format:** Optionally specify a JSON schema for structured output.
-- **System Prompt:** Included as the first message if provided.
-- **Function Calling:** Handles Azure OpenAI function calling modes and emits tool call frames.
-- **Streaming:** Each chunk is encoded into a resilient streaming format.
-
-### How It Works
-
-- **Messages:** Translated to Azure OpenAI's message format, supporting all roles and tool calls.
-- **Tools/Functions:** Tools are passed as Azure OpenAI function definitions, using your JSON schemas as `parameters`.
-- **Response Format:** Pass a JSON schema in `responseFormat` for Azure OpenAI to validate the model output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -85,25 +134,41 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -114,27 +179,48 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownAzure } from '@hashbrownai/azure';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownAzure.stream.text({
-      apiKey: process.env.AZURE_API_KEY!,
-      endpoint: process.env.AZURE_ENDPOINT!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      clientOptions: {
+        apiKey: process.env.AZURE_API_KEY!,
+        endpoint: process.env.AZURE_ENDPOINT!,
+        apiVersion: process.env.AZURE_API_VERSION!,
+        deployment: process.env.AZURE_DEPLOYMENT,
+      },
+      model: process.env.AZURE_MODEL!,
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -144,34 +230,44 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
-    }
+    },
   );
 });
 
@@ -182,201 +278,29 @@ export default app;
 
 </hb-backend-code-example>
 
-
-
----
-
----
-
 ### Transform Request Options
 
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to Azure OpenAI. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
-
-<hb-backend-code-example>
-
-<div backend="express">
+`transformRequestOptions` receives the final Azure OpenAI SDK request after AG-UI input has been mapped. Use it for server-owned provider settings.
 
 ```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownAzure.stream.text({
+const stream = HashbrownAzure.stream.text({
+  clientOptions: {
     apiKey: process.env.AZURE_API_KEY!,
     endpoint: process.env.AZURE_ENDPOINT!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    temperature: 0.2,
+    messages: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      ...options.messages,
+    ],
+  }),
 });
 ```
-
-</div>
-
-<div backend="fastify">
-
-```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
-});
-```
-
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownAzure } from '@hashbrownai/azure';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownAzure.stream.text({
-      apiKey: process.env.AZURE_API_KEY!,
-      endpoint: process.env.AZURE_ENDPOINT!,
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust temperature based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
-  const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
-    },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/angular/concept/transform-request-options)
-
----
-
-## Model Versions
-
-Azure requires model versions to be supplied when making a request. To do this, specify the model version in the `model` string when supplied to any resource:
-
-```ts
-completionResource({
-  model: 'gpt-4o@2025-01-01-preview',
-  // ...
-});
-```

--- a/www/analog/src/app/pages/docs/react/platform/azure.md
+++ b/www/analog/src/app/pages/docs/react/platform/azure.md
@@ -1,80 +1,129 @@
 ---
-title: 'Microsoft Azure: Hashbrown React Docs'
+title: 'Microsoft Azure OpenAI: Hashbrown React Docs'
 meta:
   - name: description
-    content: 'First, install the Microsoft Azure adapter package:'
+    content: 'Hashbrown’s Microsoft Azure OpenAI adapter maps AG-UI runs to the Azure OpenAI SDK and streams canonical AG-UI events.'
 ---
-# Microsoft Azure
 
-First, install the Microsoft Azure adapter package:
+# Microsoft Azure OpenAI
 
-```shell
-npm install @hashbrownai/azure
+Install the Azure adapter, the Azure OpenAI SDK, and the AG-UI SSE encoder:
+
+```sh
+npm install @hashbrownai/azure openai @ag-ui/core @ag-ui/encoder
+```
+
+## Client Configuration
+
+Pass the official SDK's `AzureClientOptions` directly as `clientOptions`. This supports API keys, Microsoft Entra token providers, Azure endpoints, custom base URLs, deployment aliases, retries, and custom fetch implementations without Hashbrown wrapping those options. The model remains server configuration and is not read from the client run input.
+
+**API key:**
+
+```ts
+HashbrownAzure.stream.text({
+  clientOptions: {
+    apiKey: process.env.AZURE_API_KEY!,
+    endpoint: process.env.AZURE_ENDPOINT!,
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+});
+```
+
+**Microsoft Entra token provider:**
+
+```ts
+HashbrownAzure.stream.text({
+  clientOptions: {
+    azureADTokenProvider,
+    endpoint: process.env.AZURE_ENDPOINT!,
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+});
 ```
 
 ## Streaming Text Responses
 
-Hashbrown's Azure adapter lets you **stream chat completions** from Azure OpenAI Service, with support for Azure-specific configuration like endpoints and API versions.
+`HashbrownAzure.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. Encode those events as AG-UI SSE at your HTTP boundary.
 
 ### API Reference
 
-#### `HashbrownAzure.stream.text(options)`
+| Name                      | Type                                    | Description                                                                          |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `clientOptions`           | `AzureClientOptions`                    | Official Azure OpenAI SDK configuration, passed through unchanged.                   |
+| `model`                   | `string`                                | Server-selected Azure OpenAI model.                                                  |
+| `input`                   | `AzureHashbrownRunAgentInput`           | AG-UI run input, including messages and tools.                                       |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Azure OpenAI request when the HTTP client disconnects.      |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final OpenAI chat-completions streaming request options. |
 
-Streams an Azure OpenAI chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, tool results, and native structured output. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Azure OpenAI native JSON schema output:
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your Azure OpenAI API Key.                                                     |
-| `endpoint`                | `string`                                | Your Azure OpenAI endpoint URL.                                                |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final Azure request before it is sent.  |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Supports Azure OpenAI tool calling, including `toolCalls` and strict function schemas.
-- **Response Format:** Optionally specify a JSON schema for structured output.
-- **System Prompt:** Included as the first message if provided.
-- **Tool Calling:** Handles Azure OpenAI tool calling modes and emits tool call frames.
-- **Streaming:** Each chunk is encoded into a resilient streaming format.
-
-### How It Works
-
-- **Messages:** Translated to Azure OpenAI's message format, supporting all roles and tool calls.
-- **Tools/Functions:** Tools are passed as Azure OpenAI function definitions, using your JSON schemas as `parameters`.
-- **Response Format:** Pass a JSON schema in `responseFormat` for Azure OpenAI to validate the model output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -85,25 +134,41 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -114,27 +179,48 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownAzure } from '@hashbrownai/azure';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownAzure.stream.text({
-      apiKey: process.env.AZURE_API_KEY!,
-      endpoint: process.env.AZURE_ENDPOINT!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      clientOptions: {
+        apiKey: process.env.AZURE_API_KEY!,
+        endpoint: process.env.AZURE_ENDPOINT!,
+        apiVersion: process.env.AZURE_API_VERSION!,
+        deployment: process.env.AZURE_DEPLOYMENT,
+      },
+      model: process.env.AZURE_MODEL!,
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -144,34 +230,44 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: {
+      apiKey: process.env.AZURE_API_KEY!,
+      endpoint: process.env.AZURE_ENDPOINT!,
+      apiVersion: process.env.AZURE_API_VERSION!,
+      deployment: process.env.AZURE_DEPLOYMENT,
+    },
+    model: process.env.AZURE_MODEL!,
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
-    }
+    },
   );
 });
 
@@ -182,204 +278,29 @@ export default app;
 
 </hb-backend-code-example>
 
-
-
----
-
----
-
 ### Transform Request Options
 
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to Azure OpenAI. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
-
-<hb-backend-code-example>
-
-<div backend="express">
+`transformRequestOptions` receives the final Azure OpenAI SDK request after AG-UI input has been mapped. Use it for server-owned provider settings.
 
 ```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownAzure.stream.text({
+const stream = HashbrownAzure.stream.text({
+  clientOptions: {
     apiKey: process.env.AZURE_API_KEY!,
     endpoint: process.env.AZURE_ENDPOINT!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+    apiVersion: process.env.AZURE_API_VERSION!,
+    deployment: process.env.AZURE_DEPLOYMENT,
+  },
+  model: process.env.AZURE_MODEL!,
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    temperature: 0.2,
+    messages: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      ...options.messages,
+    ],
+  }),
 });
 ```
-
-</div>
-
-<div backend="fastify">
-
-```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
-});
-```
-
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownAzure } from '@hashbrownai/azure';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownAzure.stream.text({
-      apiKey: process.env.AZURE_API_KEY!,
-      endpoint: process.env.AZURE_ENDPOINT!,
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust temperature based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownAzure } from '@hashbrownai/azure';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
-  const stream = HashbrownAzure.stream.text({
-    apiKey: process.env.AZURE_API_KEY!,
-    endpoint: process.env.AZURE_ENDPOINT!,
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
-    },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/react/concept/transform-request-options)
-
----
-
-## Model Versions
-
-Azure requires model versions to be supplied when making a request. To do this, specify the model version in the `model` string when using any React Hashbrown hook or resource:
-
-```ts
-import { useCompletion } from '@hashbrownai/react';
-
-const { output, isReceiving } = useCompletion({
-  model: 'gpt-4.1@2025-01-01-preview',
-  input: 'Hello, world!',
-  system: 'You are a helpful assistant.',
-});
-```


### PR DESCRIPTION
## Summary

- replace the Azure provider's binary frame stream with canonical AG-UI events
- accept standard AG-UI run input while keeping the model and official `AzureClientOptions` under server control
- map messages, tools, native JSON Schema structured output, text, refusals, tool calls, cancellation, and provider errors
- replace the legacy Azure E2E suite with deterministic aimock fixtures
- update the Azure package README, React and Angular docs, and kitchen-sink server route for AG-UI SSE

## Breaking changes

- `HashbrownAzure.stream.text()` now returns `AsyncIterable<AGUIEvent>` instead of encoded Hashbrown frames
- callers pass `input`, `model`, and `clientOptions` instead of `request`, `apiKey`, and `endpoint`
- Azure API version and deployment are configured through the official SDK options; `model@apiVersion` parsing is removed
- provider-owned thread loading and saving are removed
- JSON emulation and `responseFormatMode` are removed; structured output uses `input.hashbrown.responseSchema` and Azure OpenAI native JSON Schema output

## Verification

- `npx nx build azure --skip-nx-cache`
- `npx nx test azure --skip-nx-cache` (9 tests)
- `npx nx lint azure --skip-nx-cache`
- `npx nx build-api-report azure --skip-nx-cache`
- `npx nx e2e azure --skip-nx-cache` (5 aimock fixtures)
- `npx nx build kitchen-sink-server`
- `npx nx build www`
- `npx nx test www` (5 tests)
- local runtime smoke: `POST /azure/chat` returned HTTP 200 AG-UI SSE with the canonical run and text lifecycle against aimock
