### PR TITLE
feat(bedrock): stream canonical AG-UI events

### DIFF
--- a/.github/workflows/bedrock-runtime.yml
+++ b/.github/workflows/bedrock-runtime.yml
@@ -1,0 +1,63 @@
+name: Bedrock Runtime Verification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: bedrock-runtime-verification
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify real Bedrock streaming
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Validate configuration
+        env:
+          HASHBROWN_BEDROCK_ROLE_ARN: ${{ vars.HASHBROWN_BEDROCK_ROLE_ARN }}
+          HASHBROWN_BEDROCK_REGION: ${{ vars.HASHBROWN_BEDROCK_REGION }}
+          HASHBROWN_BEDROCK_MODEL_ID: ${{ vars.HASHBROWN_BEDROCK_MODEL_ID }}
+        run: |
+          missing=0
+          for name in HASHBROWN_BEDROCK_ROLE_ARN HASHBROWN_BEDROCK_REGION HASHBROWN_BEDROCK_MODEL_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing required GitHub variable: $name"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.HASHBROWN_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ vars.HASHBROWN_BEDROCK_REGION }}
+          role-session-name: hashbrown-bedrock-runtime
+          role-duration-seconds: 900
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify Bedrock runtime
+        run: npx nx runtime-verification bedrock --skip-nx-cache
+        env:
+          AWS_REGION: ${{ vars.HASHBROWN_BEDROCK_REGION }}
+          BEDROCK_MODEL_ID: ${{ vars.HASHBROWN_BEDROCK_MODEL_ID }}

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -16,47 +16,41 @@
 ## Getting Started
 
 ```sh
-npm install @hashbrownai/bedrock --save
+npm install @hashbrownai/bedrock @aws-sdk/client-bedrock-runtime @ag-ui/core @ag-ui/encoder --save
 ```
 
-Deploy an express server with a single /chat endpoint to use Hashbrown with Amazon Bedrock.
+Deploy an Express server with a `/run` endpoint to use Hashbrown with Amazon Bedrock.
 
 ```ts
-import { Chat } from '@hashbrownai/core';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 
-app.post('/chat', async (req, res) => {
-  const request = req.body as Chat.Api.CompletionCreateParams;
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION!,
-    request,
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk);
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
-```
-
-In the UI package for your chosen framework, set the emulateStructuredOutput flag to true.
-
-In Angular:
-
-```
-import { provideHashbrown } from '@hashbrownai/angular';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideHashbrown({
-      baseUrl: '/api/chat',
-      emulateStructuredOutput: true,
-    }),
-  ],
-};
 ```
 
 ## Docs

--- a/packages/bedrock/jest.config.ts
+++ b/packages/bedrock/jest.config.ts
@@ -7,5 +7,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/bedrock',
-  testPathIgnorePatterns: ['(?!.*integration).*\\.ts$'],
+  testPathIgnorePatterns: ['integration\\.spec\\.ts$'],
 };

--- a/packages/bedrock/jest.runtime.config.ts
+++ b/packages/bedrock/jest.runtime.config.ts
@@ -1,0 +1,11 @@
+export default {
+  displayName: 'bedrock-runtime-verification',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js'],
+  testMatch: ['<rootDir>/**/*.runtime.ts'],
+  maxWorkers: 1,
+};

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -12,12 +12,11 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.0",
-    "@aws-sdk/types": "3.922.0"
+    "@ag-ui/core": "0.0.59",
+    "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@hashbrownai/core": "0.5.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.936.0"
+    "@aws-sdk/client-bedrock-runtime": "^3.1106.0"
   },
   "sideEffects": false,
   "publishConfig": {
@@ -31,6 +30,6 @@
     "typescript"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/bedrock/project.json
+++ b/packages/bedrock/project.json
@@ -53,6 +53,13 @@
         "passWithNoTests": true
       }
     },
+    "runtime-verification": {
+      "executor": "@nx/jest:jest",
+      "options": {
+        "jestConfig": "packages/bedrock/jest.runtime.config.ts",
+        "runInBand": true
+      }
+    },
     "nx-release-publish": {
       "executor": "@nx/js:release-publish",
       "dependsOn": ["^nx-release-publish"],

--- a/packages/bedrock/src/bedrock.runtime.ts
+++ b/packages/bedrock/src/bedrock.runtime.ts
@@ -1,0 +1,165 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import { HashbrownBedrock } from './index';
+import type { BedrockHashbrownRunAgentInput } from './stream/types';
+
+const region = requiredEnvironmentVariable('AWS_REGION');
+const model = requiredEnvironmentVariable('BEDROCK_MODEL_ID');
+
+jest.setTimeout(120_000);
+
+function requiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required for Bedrock runtime verification`);
+  }
+
+  return value;
+}
+
+function input(runId: string, content: string): BedrockHashbrownRunAgentInput {
+  return {
+    threadId: 'bedrock-runtime-verification',
+    runId,
+    messages: [
+      {
+        id: `${runId}:system`,
+        role: 'system',
+        content: 'Follow the user instructions exactly and answer briefly.',
+      },
+      { id: `${runId}:user`, role: 'user', content },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  };
+}
+
+async function run(
+  value: BedrockHashbrownRunAgentInput,
+  transformRequestOptions?: Parameters<
+    typeof HashbrownBedrock.stream.text
+  >[0]['transformRequestOptions'],
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of HashbrownBedrock.stream.text({
+    clientOptions: { region },
+    model,
+    input: value,
+    transformRequestOptions: (options) => {
+      const bounded = {
+        ...options,
+        inferenceConfig: { maxTokens: 96, temperature: 0 },
+      };
+      return transformRequestOptions
+        ? transformRequestOptions(bounded)
+        : bounded;
+    },
+  })) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  const error = events.find((event) => event.type === EventType.RUN_ERROR);
+  if (error?.type === EventType.RUN_ERROR) {
+    throw new Error(error.message);
+  }
+  expect(events[0]?.type).toBe(EventType.RUN_STARTED);
+  expect(events.at(-1)?.type).toBe(EventType.RUN_FINISHED);
+
+  return events;
+}
+
+function textContent(events: AGUIEvent[]): string {
+  return events
+    .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+    .map((event) => event.delta)
+    .join('');
+}
+
+test('streams a real Bedrock text response as canonical AG-UI', async () => {
+  const events = await run(
+    input(
+      'bedrock-runtime-text',
+      'Reply with exactly this marker: hashbrown-bedrock-smoke',
+    ),
+  );
+
+  expect(textContent(events).toLowerCase()).toContain(
+    'hashbrown-bedrock-smoke',
+  );
+  expect(events).toContainEqual(
+    expect.objectContaining({ type: EventType.TEXT_MESSAGE_END }),
+  );
+});
+
+test('streams a real Bedrock tool call as canonical AG-UI', async () => {
+  const value = input(
+    'bedrock-runtime-tool',
+    'Call lookup with query set to hashbrown. Do not answer with text.',
+  );
+  value.tools = [
+    {
+      name: 'lookup',
+      description: 'Look up one exact query.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', enum: ['hashbrown'] },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+    },
+  ];
+
+  const events = await run(value, (options) => ({
+    ...options,
+    toolConfig: options.toolConfig
+      ? { ...options.toolConfig, toolChoice: { any: {} } }
+      : undefined,
+  }));
+  const start = events.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
+  );
+  const argumentsText = events
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
+
+  expect(start).toMatchObject({
+    type: EventType.TOOL_CALL_START,
+    toolCallName: 'lookup',
+  });
+  expect(JSON.parse(argumentsText)).toEqual({ query: 'hashbrown' });
+  expect(events).toContainEqual(
+    expect.objectContaining({
+      type: EventType.TOOL_CALL_END,
+      toolCallId:
+        start?.type === EventType.TOOL_CALL_START
+          ? start.toolCallId
+          : 'missing-tool-call',
+    }),
+  );
+});
+
+test('streams real Bedrock native structured output as canonical AG-UI text', async () => {
+  const value = input(
+    'bedrock-runtime-structured-output',
+    'Return the object required by the response schema.',
+  );
+  value.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', enum: ['runtime-ok'] },
+      },
+      required: ['status'],
+      additionalProperties: false,
+    },
+  };
+
+  const events = await run(value);
+
+  expect(JSON.parse(textContent(events))).toEqual({ status: 'runtime-ok' });
+});

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -1,10 +1,23 @@
+import type { AGUIEvent } from '@ag-ui/core';
 import { text } from './stream/text.fn';
+import type { BedrockTextStreamOptions } from './stream/types';
+
+export type {
+  BedrockHashbrownRunAgentInput,
+  BedrockTextStreamOptions,
+} from './stream/types';
 
 /**
  * Hashbrown adapter for AWS Bedrock.
  * @public
  */
-export const HashbrownBedrock = {
+export const HashbrownBedrock: {
+  readonly stream: {
+    readonly text: (
+      options: BedrockTextStreamOptions,
+    ) => AsyncIterable<AGUIEvent>;
+  };
+} = {
   stream: {
     text,
   },

--- a/packages/bedrock/src/integration.spec.ts
+++ b/packages/bedrock/src/integration.spec.ts
@@ -1,11 +1,15 @@
 import { resolve } from 'node:path';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
-import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
-import { type AimockHandle, runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
+import {
+  type AimockHandle,
+  runProviderAGUIWithAimock,
+} from '@hashbrownai/testing/aimock';
 import { HashbrownBedrock } from './index';
+import type { BedrockHashbrownRunAgentInput } from './stream/types';
 
-const BEDROCK_MODEL_ID = 'anthropic.claude-3-5-sonnet-20240620-v1:0';
+const BEDROCK_MODEL = 'anthropic.claude-3-5-sonnet-20240620-v1:0';
 
 function fixturePath(name: string): string {
   return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
@@ -23,172 +27,213 @@ function createBedrockClient(aimock: AimockHandle): BedrockRuntimeClient {
   });
 }
 
-function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
-  return frames.filter(
-    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
-  );
-}
-
-function streamedContent(frames: Frame[]): string {
-  return generationChunks(frames)
-    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
-    .join('');
-}
-
-function baseRequest(
-  userMessage: string,
-): Chat.Api.CompletionCreateParams {
+function baseInput(userMessage: string): BedrockHashbrownRunAgentInput {
   return {
-    operation: 'generate',
-    model: BEDROCK_MODEL_ID,
-    system: 'You are a deterministic test assistant.',
-    messages: [{ role: 'user', content: userMessage }],
+    threadId: 'thread-bedrock',
+    runId: 'run-bedrock',
+    messages: [
+      {
+        id: 'system-bedrock',
+        role: 'system',
+        content: 'You are a deterministic test assistant.',
+      },
+      { id: 'user-bedrock', role: 'user', content: userMessage },
+    ],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   };
 }
 
-test('Amazon Bedrock text streaming emits Hashbrown generation frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+async function runFixture(
+  fixtureName: string,
+  input: BedrockHashbrownRunAgentInput,
+  transformRequestOptions?: Parameters<
+    typeof HashbrownBedrock.stream.text
+  >[0]['transformRequestOptions'],
+): Promise<AGUIEvent[]> {
+  return runProviderAGUIWithAimock({
+    fixturePath: fixturePath(fixtureName),
+    createStream: (aimock, signal) =>
       HashbrownBedrock.stream.text({
         client: createBedrockClient(aimock),
-        request: baseRequest('say hi briefly'),
+        model: BEDROCK_MODEL,
+        input,
+        signal,
+        transformRequestOptions,
       }),
   });
+}
 
-  expect(frames[0].type).toBe('generation-start');
-  expect(frames.at(-1)?.type).toBe('generation-finish');
-  expect(streamedContent(frames)).toBe('Hello from aimock.');
+function streamedContent(events: AGUIEvent[]): string {
+  return events
+    .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+    .map((event) => event.delta)
+    .join('');
+}
+
+test('Bedrock consumes AG-UI input and emits a canonical text run', async () => {
+  const input = baseInput('say hi briefly');
+
+  const events = await runFixture('text.json', input);
+
+  expect(events[0]).toEqual({
+    type: EventType.RUN_STARTED,
+    threadId: input.threadId,
+    runId: input.runId,
+  });
+  expect(streamedContent(events)).toBe('Hello from aimock.');
+  expect(events).toContainEqual({
+    type: EventType.TEXT_MESSAGE_END,
+    messageId: 'run-bedrock:assistant',
+  });
+  expect(events.at(-1)).toEqual({
+    type: EventType.RUN_FINISHED,
+    threadId: input.threadId,
+    runId: input.runId,
+  });
 });
 
-test('Amazon Bedrock streaming preserves chunked content across multiple frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('streaming.json'),
-    createStream: (aimock) =>
-      HashbrownBedrock.stream.text({
-        client: createBedrockClient(aimock),
-        request: baseRequest('stream deterministic text'),
-      }),
-  });
+test('Bedrock preserves streamed text across multiple AG-UI events', async () => {
+  const input = baseInput('stream deterministic text');
 
-  expect(generationChunks(frames).length).toBeGreaterThan(1);
-  expect(streamedContent(frames)).toContain(
+  const events = await runFixture('streaming.json', input);
+  const contentEvents = events.filter(
+    (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+  );
+
+  expect(contentEvents.length).toBeGreaterThan(1);
+  expect(streamedContent(events)).toContain(
     'Streaming fixture response with enough text',
   );
 });
 
-test('Amazon Bedrock tool calling emits tool call deltas', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('tool-call.json'),
-    createStream: (aimock) =>
-      HashbrownBedrock.stream.text({
-        client: createBedrockClient(aimock),
-        request: {
-          ...baseRequest('call the lookup tool'),
-          tools: [
-            {
-              name: 'lookup',
-              description: 'Lookup deterministic fixture data.',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
-              },
-            },
-          ],
-          toolChoice: 'required',
-        },
-      }),
-  });
+test('Bedrock emits complete AG-UI tool call lifecycles', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
 
-  const toolCallDeltas = generationChunks(frames).flatMap(
-    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  const events = await runFixture('tool-call.json', input, (options) => ({
+    ...options,
+    toolConfig: options.toolConfig
+      ? { ...options.toolConfig, toolChoice: { any: {} } }
+      : undefined,
+  }));
+  const start = events.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
   );
+  const args = events
+    .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+    .map((event) => event.delta)
+    .join('');
 
-  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
-  expect(
-    toolCallDeltas.some(
-      (toolCall) => toolCall.function?.name === 'lookup',
-    ),
-  ).toBe(true);
-  expect(
-    toolCallDeltas
-      .map((toolCall) => toolCall.function?.arguments ?? '')
-      .join(''),
-  ).toContain('"query":"hashbrown"');
+  expect(start).toMatchObject({
+    type: EventType.TOOL_CALL_START,
+    toolCallName: 'lookup',
+    parentMessageId: 'run-bedrock:assistant',
+  });
+  expect(JSON.parse(args)).toEqual({ query: 'hashbrown' });
+  expect(events).toContainEqual({
+    type: EventType.TOOL_CALL_END,
+    toolCallId:
+      start?.type === EventType.TOOL_CALL_START
+        ? start.toolCallId
+        : 'missing-tool-call',
+  });
 });
 
-test('Amazon Bedrock structured output fixture emits JSON text content', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('structured-output.json'),
-    createStream: (aimock) =>
-      HashbrownBedrock.stream.text({
-        client: createBedrockClient(aimock),
-        request: baseRequest('return structured output'),
-      }),
-  });
+test('Bedrock maps the Hashbrown response schema to native structured output', async () => {
+  const input = baseInput('return structured output');
+  input.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        ok: { type: 'boolean' },
+      },
+      required: ['text', 'ok'],
+      additionalProperties: false,
+    },
+  };
+  let outputConfig: unknown;
 
-  expect(JSON.parse(streamedContent(frames))).toEqual({
+  const events = await runFixture(
+    'structured-output.json',
+    input,
+    (options) => {
+      outputConfig = options.outputConfig;
+      return options;
+    },
+  );
+
+  expect(JSON.parse(streamedContent(events))).toEqual({
     text: 'Hello from structured aimock.',
     ok: true,
   });
+  expect(outputConfig).toEqual({
+    textFormat: {
+      type: 'json_schema',
+      structure: {
+        jsonSchema: {
+          schema: JSON.stringify(input.hashbrown.responseSchema),
+        },
+      },
+    },
+  });
 });
 
-test('Amazon Bedrock provider errors emit generation-error frames', async () => {
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('error.json'),
-    createStream: (aimock) =>
-      HashbrownBedrock.stream.text({
-        client: createBedrockClient(aimock),
-        request: baseRequest('return provider error'),
-      }),
-  });
+test('Bedrock provider errors emit an AG-UI RUN_ERROR', async () => {
+  const events = await runFixture(
+    'error.json',
+    baseInput('return provider error'),
+  );
 
-  expect(frames).toEqual([
-    expect.objectContaining({
-      type: 'generation-error',
-      error: expect.any(String),
-    }),
-  ]);
+  expect(events[0]?.type).toBe(EventType.RUN_STARTED);
+  expect(events.at(-1)).toMatchObject({
+    type: EventType.RUN_ERROR,
+    message: expect.any(String),
+  });
+  expect(events).not.toContainEqual(
+    expect.objectContaining({ type: EventType.RUN_FINISHED }),
+  );
 });
 
-test('Amazon Bedrock thread persistence wraps generation with thread frames', async () => {
-  const savedThreads: Chat.Api.Message[][] = [];
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+test('Bedrock cancellation stops without synthetic terminal events', async () => {
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    chunkSize: 8,
+    createStream: (aimock, signal) =>
       HashbrownBedrock.stream.text({
         client: createBedrockClient(aimock),
-        request: {
-          ...baseRequest('say hi briefly'),
-          threadId: 'bedrock-thread',
-        },
-        loadThread: async () => [
-          {
-            role: 'user',
-            content: 'previous message',
-          },
-        ],
-        saveThread: async (thread) => {
-          savedThreads.push(thread);
-          return 'bedrock-thread';
-        },
+        model: BEDROCK_MODEL,
+        input: baseInput('stream deterministic text'),
+        signal,
       }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+        controls.abort();
+      }
+    },
   });
 
-  expect(frames.map((frame) => frame.type)).toEqual([
-    'thread-load-start',
-    'thread-load-success',
-    'generation-start',
-    ...generationChunks(frames).map((frame) => frame.type),
-    'generation-finish',
-    'thread-save-start',
-    'thread-save-success',
-  ]);
-  expect(savedThreads).toHaveLength(1);
-  expect(savedThreads[0].map((message) => message.content)).toContain(
-    'Hello from aimock.',
+  expect(
+    events.some((event) => event.type === EventType.TEXT_MESSAGE_CONTENT),
+  ).toBe(true);
+  expect(events).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: EventType.TEXT_MESSAGE_END }),
+      expect.objectContaining({ type: EventType.RUN_FINISHED }),
+      expect.objectContaining({ type: EventType.RUN_ERROR }),
+    ]),
   );
 });

--- a/packages/bedrock/src/stream/bedrock-events.spec.ts
+++ b/packages/bedrock/src/stream/bedrock-events.spec.ts
@@ -1,0 +1,378 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import type { ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime';
+import { mapBedrockEvents } from './bedrock-events';
+
+async function* source(
+  events: ConverseStreamOutput[],
+): AsyncIterable<ConverseStreamOutput> {
+  yield* events;
+}
+
+async function collectEvents(
+  events: ConverseStreamOutput[],
+): Promise<AGUIEvent[]> {
+  const result: AGUIEvent[] = [];
+
+  for await (const event of mapBedrockEvents({
+    events: source(events),
+    messageId: 'run-bedrock:assistant',
+  })) {
+    result.push(EventSchemas.parse(event));
+  }
+
+  return result;
+}
+
+test('maps streamed Bedrock text into one AG-UI assistant lifecycle', async () => {
+  const events = await collectEvents([
+    { messageStart: { role: 'assistant' } },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { text: 'Hello ' },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { text: 'world.' },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 0 } },
+    { messageStop: { stopReason: 'end_turn' } },
+  ]);
+
+  expect(events).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-bedrock:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-bedrock:assistant',
+      delta: 'Hello ',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-bedrock:assistant',
+      delta: 'world.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-bedrock:assistant',
+    },
+  ]);
+});
+
+test('maps fragmented Bedrock tool input into one AG-UI tool lifecycle', async () => {
+  const events = await collectEvents([
+    {
+      contentBlockStart: {
+        contentBlockIndex: 1,
+        start: {
+          toolUse: { toolUseId: 'call-bedrock', name: 'lookup' },
+        },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: { toolUse: { input: '{"query":' } },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: { toolUse: { input: '"hashbrown"}' } },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 1 } },
+  ]);
+
+  expect(events).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'call-bedrock',
+      toolCallName: 'lookup',
+      parentMessageId: 'run-bedrock:assistant',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-bedrock',
+      delta: '{"query":',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'call-bedrock',
+      delta: '"hashbrown"}',
+    },
+    { type: EventType.TOOL_CALL_END, toolCallId: 'call-bedrock' },
+  ]);
+});
+
+test('supplies an empty object when Bedrock emits no tool input', async () => {
+  const events = await collectEvents([
+    {
+      contentBlockStart: {
+        contentBlockIndex: 0,
+        start: { toolUse: { toolUseId: 'call-empty', name: 'now' } },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 0 } },
+  ]);
+
+  expect(events).toContainEqual({
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId: 'call-empty',
+    delta: '{}',
+  });
+});
+
+test('maps Bedrock reasoning text, signature, and redacted content', async () => {
+  const events = await collectEvents([
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { text: 'Thinking.' } },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { signature: 'signature' } },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 0 } },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: {
+          reasoningContent: { redactedContent: new Uint8Array([1, 2, 3]) },
+        },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 1 } },
+  ]);
+
+  expect(events).toEqual([
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: 'run-bedrock:assistant:reasoning:0',
+      role: 'reasoning',
+      metadata: { bedrock: { blockType: 'reasoning_text' } },
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: 'run-bedrock:assistant:reasoning:0',
+      delta: 'Thinking.',
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: 'run-bedrock:assistant:reasoning:0',
+      encryptedValue: 'signature',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: 'run-bedrock:assistant:reasoning:0',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: 'run-bedrock:assistant:reasoning:1',
+      role: 'reasoning',
+      metadata: { bedrock: { blockType: 'redacted_content' } },
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: 'run-bedrock:assistant:reasoning:1',
+      encryptedValue: 'AQID',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: 'run-bedrock:assistant:reasoning:1',
+    },
+  ]);
+});
+
+test('reassembles fragmented Bedrock reasoning continuation values', async () => {
+  const events = await collectEvents([
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { text: 'Thinking.' } },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { signature: 'sig-' } },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { signature: 'value' } },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 0 } },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: {
+          reasoningContent: { redactedContent: new Uint8Array([1, 2]) },
+        },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: {
+          reasoningContent: { redactedContent: new Uint8Array([3, 4]) },
+        },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 1 } },
+  ]);
+  const encryptedValues = events.filter(
+    (event) => event.type === EventType.REASONING_ENCRYPTED_VALUE,
+  );
+
+  expect(encryptedValues).toEqual([
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: 'run-bedrock:assistant:reasoning:0',
+      encryptedValue: 'sig-value',
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: 'run-bedrock:assistant:reasoning:1',
+      encryptedValue: 'AQIDBA==',
+    },
+  ]);
+});
+
+test('preserves metadata and noncanonical deltas as Bedrock raw events', async () => {
+  const metadata = {
+    usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+    metrics: { latencyMs: 10 },
+  };
+  const citation = { source: 'https://example.com' };
+
+  const events = await collectEvents([
+    { metadata },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { citation },
+      },
+    },
+  ]);
+
+  expect(events).toEqual([
+    {
+      type: EventType.RAW,
+      source: 'bedrock',
+      event: { metadata },
+    },
+    {
+      type: EventType.RAW,
+      source: 'bedrock',
+      event: {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { citation },
+        },
+      },
+    },
+  ]);
+});
+
+test('throws Bedrock stream exception events', async () => {
+  const result = collectEvents([
+    {
+      throttlingException: {
+        name: 'ThrottlingException',
+        $fault: 'client',
+        $metadata: {},
+        message: 'rate limited',
+      },
+    },
+  ]);
+
+  await expect(result).rejects.toThrow('rate limited');
+});
+
+test('closes the Bedrock iterator when mapping is cancelled', async () => {
+  const controller = new AbortController();
+  const iteratorReturn = jest.fn(async () => ({
+    done: true as const,
+    value: undefined,
+  }));
+  const events = {
+    [Symbol.asyncIterator]() {
+      let emitted = false;
+      return {
+        async next(): Promise<IteratorResult<ConverseStreamOutput>> {
+          if (!emitted) {
+            emitted = true;
+            return {
+              done: false,
+              value: {
+                contentBlockDelta: {
+                  contentBlockIndex: 0,
+                  delta: { text: 'First.' },
+                },
+              },
+            };
+          }
+          return new Promise(() => undefined);
+        },
+        return: iteratorReturn,
+      };
+    },
+  };
+  const iterator = mapBedrockEvents({
+    events,
+    messageId: 'run-bedrock:assistant',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  await iterator.next();
+  controller.abort();
+  const done = await iterator.next();
+
+  expect(done).toEqual({ done: true, value: undefined });
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+});
+
+test('preserves a Bedrock source failure when iterator cleanup also fails', async () => {
+  const sourceError = new Error('Bedrock source failed');
+  const events = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<ConverseStreamOutput>> {
+          throw sourceError;
+        },
+        async return(): Promise<IteratorResult<ConverseStreamOutput>> {
+          throw new Error('Bedrock cleanup failed');
+        },
+      };
+    },
+  };
+
+  const result = (async () => {
+    for await (const event of mapBedrockEvents({
+      events,
+      messageId: 'run-bedrock:assistant',
+    })) {
+      void event;
+    }
+  })();
+
+  await expect(result).rejects.toBe(sourceError);
+});

--- a/packages/bedrock/src/stream/bedrock-events.ts
+++ b/packages/bedrock/src/stream/bedrock-events.ts
@@ -1,0 +1,361 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type { ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime';
+
+const ABORTED = Symbol('aborted');
+
+interface ToolState {
+  readonly kind: 'tool';
+  readonly id: string;
+  receivedInput: boolean;
+}
+
+interface ReasoningState {
+  readonly kind: 'reasoning';
+  readonly messageId: string;
+  readonly blockType: 'reasoning_text' | 'redacted_content';
+  readonly redactedContent: Uint8Array[];
+  signature: string;
+}
+
+type BlockState = ToolState | ReasoningState;
+
+/**
+ * Inputs for mapping Bedrock ConverseStream output to AG-UI events.
+ *
+ * @internal
+ */
+export interface MapBedrockEventsOptions {
+  readonly events: AsyncIterable<ConverseStreamOutput>;
+  readonly messageId: string;
+  readonly signal?: AbortSignal;
+}
+
+function rawEvent(event: ConverseStreamOutput): AGUIEvent {
+  return {
+    type: EventType.RAW,
+    source: 'bedrock',
+    event: structuredClone(event),
+  };
+}
+
+function providerError(event: ConverseStreamOutput): Error | undefined {
+  const value =
+    event.internalServerException ??
+    event.modelStreamErrorException ??
+    event.validationException ??
+    event.throttlingException ??
+    event.serviceUnavailableException;
+  if (!value) {
+    return undefined;
+  }
+
+  return new Error(value.message ?? value.name ?? 'Bedrock stream failed');
+}
+
+function reasoningEncryptedValue(block: ReasoningState): AGUIEvent | undefined {
+  if (block.blockType === 'reasoning_text') {
+    return block.signature
+      ? {
+          type: EventType.REASONING_ENCRYPTED_VALUE,
+          subtype: 'message',
+          entityId: block.messageId,
+          encryptedValue: block.signature,
+        }
+      : undefined;
+  }
+
+  const byteLength = block.redactedContent.reduce(
+    (total, value) => total + value.byteLength,
+    0,
+  );
+  if (byteLength === 0) {
+    return undefined;
+  }
+  const value = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of block.redactedContent) {
+    value.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return {
+    type: EventType.REASONING_ENCRYPTED_VALUE,
+    subtype: 'message',
+    entityId: block.messageId,
+    encryptedValue: Buffer.from(value).toString('base64'),
+  };
+}
+
+async function nextWithCancellation(
+  iterator: AsyncIterator<ConverseStreamOutput>,
+  signal: AbortSignal | undefined,
+): Promise<IteratorResult<ConverseStreamOutput> | typeof ABORTED> {
+  const nextPromise = iterator.next();
+  void nextPromise.catch(() => undefined);
+  if (!signal) {
+    return nextPromise;
+  }
+  if (signal.aborted) {
+    return ABORTED;
+  }
+
+  let onAbort!: () => void;
+  const abortPromise = new Promise<typeof ABORTED>((resolve) => {
+    onAbort = () => resolve(ABORTED);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+
+  try {
+    return await Promise.race([nextPromise, abortPromise]);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+  }
+}
+
+/**
+ * Maps Bedrock ConverseStream output to canonical AG-UI events.
+ *
+ * @param options - Bedrock stream, stable assistant ID, and cancellation signal.
+ * @returns Canonical AG-UI message, tool, reasoning, and raw events.
+ *
+ * @internal
+ */
+export async function* mapBedrockEvents(
+  options: MapBedrockEventsOptions,
+): AsyncIterable<AGUIEvent> {
+  const iterator = options.events[Symbol.asyncIterator]();
+  const activeBlocks = new Map<number, BlockState>();
+  let textStarted = false;
+  let reasoningIndex = 0;
+  let completed = false;
+  let mappingFailed = false;
+  let mappingError: unknown;
+  let cleanupFailed = false;
+  let cleanupError: unknown;
+
+  try {
+    while (!options.signal?.aborted) {
+      const next = await nextWithCancellation(iterator, options.signal);
+      if (next === ABORTED) {
+        return;
+      }
+      if (next.done) {
+        completed = true;
+        break;
+      }
+
+      const event = next.value;
+      const error = providerError(event);
+      if (error) {
+        throw error;
+      }
+
+      if (event.contentBlockStart) {
+        const index = event.contentBlockStart.contentBlockIndex;
+        const toolUse = event.contentBlockStart.start?.toolUse;
+        if (index !== undefined && toolUse?.toolUseId && toolUse.name) {
+          activeBlocks.set(index, {
+            kind: 'tool',
+            id: toolUse.toolUseId,
+            receivedInput: false,
+          });
+          yield {
+            type: EventType.TOOL_CALL_START,
+            toolCallId: toolUse.toolUseId,
+            toolCallName: toolUse.name,
+            parentMessageId: options.messageId,
+          };
+        } else {
+          yield rawEvent(event);
+        }
+        continue;
+      }
+
+      if (event.contentBlockDelta) {
+        const index = event.contentBlockDelta.contentBlockIndex;
+        const delta = event.contentBlockDelta.delta;
+        if (delta?.text !== undefined) {
+          if (!textStarted) {
+            textStarted = true;
+            yield {
+              type: EventType.TEXT_MESSAGE_START,
+              messageId: options.messageId,
+              role: 'assistant',
+            };
+          }
+          yield {
+            type: EventType.TEXT_MESSAGE_CONTENT,
+            messageId: options.messageId,
+            delta: delta.text,
+          };
+          continue;
+        }
+
+        if (delta?.toolUse && index !== undefined) {
+          const block = activeBlocks.get(index);
+          if (block?.kind === 'tool' && delta.toolUse.input !== undefined) {
+            block.receivedInput = true;
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: block.id,
+              delta: delta.toolUse.input,
+            };
+          } else {
+            yield rawEvent(event);
+          }
+          continue;
+        }
+
+        if (delta?.reasoningContent && index !== undefined) {
+          let block = activeBlocks.get(index);
+          if (block?.kind !== 'reasoning') {
+            const messageId = `${options.messageId}:reasoning:${reasoningIndex}`;
+            const blockType =
+              delta.reasoningContent.redactedContent === undefined
+                ? 'reasoning_text'
+                : 'redacted_content';
+            reasoningIndex += 1;
+            block = {
+              kind: 'reasoning',
+              messageId,
+              blockType,
+              signature: '',
+              redactedContent: [],
+            };
+            activeBlocks.set(index, block);
+            yield {
+              type: EventType.REASONING_MESSAGE_START,
+              messageId,
+              role: 'reasoning',
+              metadata: {
+                bedrock: {
+                  blockType,
+                },
+              },
+            };
+          }
+
+          if (delta.reasoningContent.text !== undefined) {
+            yield {
+              type: EventType.REASONING_MESSAGE_CONTENT,
+              messageId: block.messageId,
+              delta: delta.reasoningContent.text,
+            };
+          } else if (delta.reasoningContent.signature !== undefined) {
+            block.signature += delta.reasoningContent.signature;
+          } else if (delta.reasoningContent.redactedContent !== undefined) {
+            block.redactedContent.push(delta.reasoningContent.redactedContent);
+          } else {
+            yield rawEvent(event);
+          }
+          continue;
+        }
+
+        yield rawEvent(event);
+        continue;
+      }
+
+      if (event.contentBlockStop) {
+        const index = event.contentBlockStop.contentBlockIndex;
+        const block = index === undefined ? undefined : activeBlocks.get(index);
+        if (block?.kind === 'tool') {
+          if (!block.receivedInput) {
+            yield {
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: block.id,
+              delta: '{}',
+            };
+          }
+          yield { type: EventType.TOOL_CALL_END, toolCallId: block.id };
+          activeBlocks.delete(index as number);
+        } else if (block?.kind === 'reasoning') {
+          const encryptedValue = reasoningEncryptedValue(block);
+          if (encryptedValue) {
+            yield encryptedValue;
+          }
+          yield {
+            type: EventType.REASONING_MESSAGE_END,
+            messageId: block.messageId,
+          };
+          activeBlocks.delete(index as number);
+        }
+        continue;
+      }
+
+      if (event.messageStop) {
+        if (textStarted) {
+          textStarted = false;
+          yield {
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: options.messageId,
+          };
+        }
+        if (event.messageStop.additionalModelResponseFields !== undefined) {
+          yield rawEvent(event);
+        }
+        continue;
+      }
+
+      if (event.metadata) {
+        yield rawEvent(event);
+        continue;
+      }
+
+      if (!event.messageStart) {
+        yield rawEvent(event);
+      }
+    }
+
+    if (!completed || options.signal?.aborted) {
+      return;
+    }
+
+    for (const block of activeBlocks.values()) {
+      if (block.kind === 'tool') {
+        if (!block.receivedInput) {
+          yield {
+            type: EventType.TOOL_CALL_ARGS,
+            toolCallId: block.id,
+            delta: '{}',
+          };
+        }
+        yield { type: EventType.TOOL_CALL_END, toolCallId: block.id };
+      } else {
+        const encryptedValue = reasoningEncryptedValue(block);
+        if (encryptedValue) {
+          yield encryptedValue;
+        }
+        yield {
+          type: EventType.REASONING_MESSAGE_END,
+          messageId: block.messageId,
+        };
+      }
+    }
+    if (textStarted) {
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: options.messageId,
+      };
+    }
+  } catch (error) {
+    mappingFailed = true;
+    mappingError = error;
+  } finally {
+    try {
+      await iterator.return?.();
+    } catch (error) {
+      cleanupFailed = true;
+      cleanupError = error;
+    }
+  }
+
+  if (mappingFailed) {
+    throw mappingError;
+  }
+  if (cleanupFailed && !options.signal?.aborted) {
+    throw cleanupError;
+  }
+}

--- a/packages/bedrock/src/stream/bedrock-request.spec.ts
+++ b/packages/bedrock/src/stream/bedrock-request.spec.ts
@@ -1,0 +1,208 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { createBedrockRequestOptions } from './bedrock-request';
+
+function createInput(): RunAgentInput & {
+  hashbrown: { responseSchema: object };
+} {
+  return {
+    threadId: 'thread-bedrock',
+    runId: 'run-bedrock',
+    messages: [
+      { id: 'system-bedrock', role: 'system', content: 'System prompt.' },
+      {
+        id: 'developer-bedrock',
+        role: 'developer',
+        content: 'Developer prompt.',
+      },
+      { id: 'user-bedrock', role: 'user', content: 'Look it up.' },
+      {
+        id: 'reasoning-bedrock',
+        role: 'reasoning',
+        content: 'I need a lookup.',
+        encryptedValue: 'reasoning-signature',
+        metadata: { bedrock: { blockType: 'reasoning_text' } },
+      },
+      {
+        id: 'assistant-bedrock',
+        role: 'assistant',
+        content: 'Checking.',
+        toolCalls: [
+          {
+            id: 'call-bedrock',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"hashbrown"}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-bedrock',
+        role: 'tool',
+        toolCallId: 'call-bedrock',
+        content: '{"result":"fixture"}',
+      },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup a value.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    hashbrown: {
+      responseSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+        additionalProperties: false,
+      },
+    },
+  };
+}
+
+test('maps AG-UI messages, tools, reasoning, and structured output to Bedrock', () => {
+  const input = createInput();
+
+  const result = createBedrockRequestOptions(input, 'bedrock-model');
+
+  expect(result).toEqual({
+    modelId: 'bedrock-model',
+    system: [{ text: 'System prompt.' }, { text: 'Developer prompt.' }],
+    messages: [
+      { role: 'user', content: [{ text: 'Look it up.' }] },
+      {
+        role: 'assistant',
+        content: [
+          {
+            reasoningContent: {
+              reasoningText: {
+                text: 'I need a lookup.',
+                signature: 'reasoning-signature',
+              },
+            },
+          },
+          { text: 'Checking.' },
+          {
+            toolUse: {
+              toolUseId: 'call-bedrock',
+              name: 'lookup',
+              input: { query: 'hashbrown' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            toolResult: {
+              toolUseId: 'call-bedrock',
+              content: [{ json: { result: 'fixture' } }],
+            },
+          },
+        ],
+      },
+    ],
+    toolConfig: {
+      tools: [
+        {
+          toolSpec: {
+            name: 'lookup',
+            description: 'Lookup a value.',
+            inputSchema: {
+              json: {
+                type: 'object',
+                properties: { query: { type: 'string' } },
+                required: ['query'],
+              },
+            },
+          },
+        },
+      ],
+      toolChoice: { auto: {} },
+    },
+    outputConfig: {
+      textFormat: {
+        type: 'json_schema',
+        structure: {
+          jsonSchema: {
+            schema: JSON.stringify(input.hashbrown.responseSchema),
+          },
+        },
+      },
+    },
+  });
+});
+
+test('preserves only provider-owned redacted Bedrock reasoning', () => {
+  const input = createInput();
+  input.messages.splice(
+    3,
+    1,
+    {
+      id: 'other-reasoning',
+      role: 'reasoning',
+      content: 'Do not send this.',
+      encryptedValue: 'other-provider-value',
+      metadata: { other: true },
+    },
+    {
+      id: 'redacted-bedrock',
+      role: 'reasoning',
+      content: '',
+      encryptedValue: 'AQID',
+      metadata: { bedrock: { blockType: 'redacted_content' } },
+    },
+  );
+
+  const result = createBedrockRequestOptions(input, 'bedrock-model');
+
+  expect(result.messages?.[1]?.content?.[0]).toEqual({
+    reasoningContent: { redactedContent: new Uint8Array([1, 2, 3]) },
+  });
+  expect(JSON.stringify(result)).not.toContain('Do not send this.');
+});
+
+test('maps tool errors without wrapping valid JSON results', () => {
+  const input = createInput();
+  input.messages[5] = {
+    id: 'tool-bedrock',
+    role: 'tool',
+    toolCallId: 'call-bedrock',
+    content: 'lookup failed',
+    error: 'upstream timeout',
+  };
+
+  const result = createBedrockRequestOptions(input, 'bedrock-model');
+
+  expect(result.messages?.[2]).toEqual({
+    role: 'user',
+    content: [
+      {
+        toolResult: {
+          toolUseId: 'call-bedrock',
+          status: 'error',
+          content: [{ text: 'upstream timeout' }],
+        },
+      },
+    ],
+  });
+});
+
+test('does not mutate AG-UI input while constructing a Bedrock request', () => {
+  const input = createInput();
+  const before = structuredClone(input);
+
+  createBedrockRequestOptions(input, 'bedrock-model');
+
+  expect(input).toEqual(before);
+});

--- a/packages/bedrock/src/stream/bedrock-request.ts
+++ b/packages/bedrock/src/stream/bedrock-request.ts
@@ -1,0 +1,235 @@
+import type { Message, Metadata, Tool } from '@ag-ui/core';
+import type {
+  Message as BedrockMessage,
+  Tool as BedrockTool,
+  ContentBlock,
+  ConverseStreamCommandInput,
+  ReasoningContentBlock,
+  ToolResultContentBlock,
+} from '@aws-sdk/client-bedrock-runtime';
+import type { BedrockHashbrownRunAgentInput } from './types';
+
+type BedrockDocument = Extract<
+  ToolResultContentBlock,
+  { json: unknown }
+>['json'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function bedrockReasoningBlockType(
+  metadata: Metadata | undefined,
+): 'reasoning_text' | 'redacted_content' | undefined {
+  if (!isRecord(metadata) || !isRecord(metadata['bedrock'])) {
+    return undefined;
+  }
+
+  const blockType = metadata['bedrock']['blockType'];
+  return blockType === 'reasoning_text' || blockType === 'redacted_content'
+    ? blockType
+    : undefined;
+}
+
+function mapReasoningMessage(
+  message: Extract<Message, { role: 'reasoning' }>,
+): ReasoningContentBlock | undefined {
+  const blockType = bedrockReasoningBlockType(message.metadata);
+  if (!blockType) {
+    return undefined;
+  }
+  if (!message.encryptedValue) {
+    throw new Error(
+      `Bedrock reasoning message "${message.id}" requires encryptedValue`,
+    );
+  }
+
+  if (blockType === 'redacted_content') {
+    if (message.content !== '') {
+      throw new Error(
+        `Bedrock redacted reasoning message "${message.id}" must have empty content`,
+      );
+    }
+
+    return {
+      redactedContent: Uint8Array.from(
+        Buffer.from(message.encryptedValue, 'base64'),
+      ),
+    };
+  }
+
+  return {
+    reasoningText: {
+      text: message.content,
+      signature: message.encryptedValue,
+    },
+  };
+}
+
+function mapPrecedingReasoning(
+  messages: Message[],
+  assistantIndex: number,
+): ContentBlock[] {
+  let reasoningStart = assistantIndex;
+  while (
+    reasoningStart > 0 &&
+    messages[reasoningStart - 1]?.role === 'reasoning'
+  ) {
+    reasoningStart -= 1;
+  }
+
+  return messages
+    .slice(reasoningStart, assistantIndex)
+    .flatMap((message): ContentBlock[] => {
+      if (message.role !== 'reasoning') {
+        return [];
+      }
+      const reasoningContent = mapReasoningMessage(message);
+      return reasoningContent ? [{ reasoningContent }] : [];
+    });
+}
+
+function mapAssistantMessage(
+  message: Extract<Message, { role: 'assistant' }>,
+  reasoning: ContentBlock[],
+): BedrockMessage | undefined {
+  const content: ContentBlock[] = [
+    ...reasoning,
+    ...(message.content ? [{ text: message.content }] : []),
+    ...(message.toolCalls ?? []).map((toolCall): ContentBlock => ({
+      toolUse: {
+        toolUseId: toolCall.id,
+        name: toolCall.function.name,
+        input: parseJson(toolCall.function.arguments) as BedrockDocument,
+      },
+    })),
+  ];
+
+  return content.length === 0 ? undefined : { role: 'assistant', content };
+}
+
+function mapToolResult(
+  message: Extract<Message, { role: 'tool' }>,
+): BedrockMessage {
+  const content: ToolResultContentBlock[] = [];
+  if (message.error !== undefined) {
+    content.push({ text: message.error });
+  } else {
+    const parsed = parseJson(message.content);
+    content.push(
+      typeof parsed === 'string'
+        ? { text: parsed }
+        : { json: parsed as BedrockDocument },
+    );
+  }
+
+  return {
+    role: 'user',
+    content: [
+      {
+        toolResult: {
+          toolUseId: message.toolCallId,
+          content,
+          ...(message.error === undefined ? {} : { status: 'error' }),
+        },
+      },
+    ],
+  };
+}
+
+function mapMessage(
+  messages: Message[],
+  message: Message,
+  index: number,
+): BedrockMessage | undefined {
+  switch (message.role) {
+    case 'system':
+    case 'developer':
+    case 'activity':
+    case 'reasoning':
+      return undefined;
+    case 'user':
+      if (typeof message.content !== 'string') {
+        throw new Error(
+          'Bedrock provider currently requires text user content',
+        );
+      }
+      return { role: 'user', content: [{ text: message.content }] };
+    case 'assistant':
+      return mapAssistantMessage(
+        message,
+        mapPrecedingReasoning(messages, index),
+      );
+    case 'tool':
+      return mapToolResult(message);
+  }
+}
+
+function mapTool(tool: Tool): BedrockTool.ToolSpecMember {
+  return {
+    toolSpec: {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: {
+        json: structuredClone(
+          tool.parameters ?? { type: 'object', properties: {} },
+        ) as BedrockDocument,
+      },
+    },
+  };
+}
+
+/**
+ * Maps an AG-UI run input to Bedrock ConverseStream request options.
+ *
+ * @param input - Standard AG-UI run input with optional Hashbrown metadata.
+ * @param model - Model or inference profile selected by the server.
+ * @returns Fresh Bedrock request options that do not mutate the run input.
+ *
+ * @internal
+ */
+export function createBedrockRequestOptions(
+  input: BedrockHashbrownRunAgentInput,
+  model: string,
+): ConverseStreamCommandInput {
+  const system = input.messages.flatMap((message) =>
+    message.role === 'system' || message.role === 'developer'
+      ? [{ text: message.content }]
+      : [],
+  );
+  const messages = input.messages.flatMap((message, index) => {
+    const mapped = mapMessage(input.messages, message, index);
+    return mapped ? [mapped] : [];
+  });
+  const tools = input.tools.map(mapTool);
+  const responseSchema = input.hashbrown?.responseSchema;
+
+  return {
+    modelId: model,
+    ...(system.length === 0 ? {} : { system }),
+    messages,
+    ...(tools.length === 0
+      ? {}
+      : { toolConfig: { tools, toolChoice: { auto: {} } } }),
+    ...(responseSchema === undefined
+      ? {}
+      : {
+          outputConfig: {
+            textFormat: {
+              type: 'json_schema',
+              structure: {
+                jsonSchema: { schema: JSON.stringify(responseSchema) },
+              },
+            },
+          },
+        }),
+  };
+}

--- a/packages/bedrock/src/stream/text.fn.spec.ts
+++ b/packages/bedrock/src/stream/text.fn.spec.ts
@@ -1,0 +1,205 @@
+import { type AGUIEvent, EventSchemas, EventType } from '@ag-ui/core';
+import {
+  BedrockRuntimeClient,
+  type ConverseStreamOutput,
+} from '@aws-sdk/client-bedrock-runtime';
+import { text } from './text.fn';
+import type { BedrockHashbrownRunAgentInput } from './types';
+
+function createInput(): BedrockHashbrownRunAgentInput {
+  return {
+    threadId: 'thread-bedrock',
+    runId: 'run-bedrock',
+    messages: [{ id: 'user-bedrock', role: 'user', content: 'Hello.' }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  };
+}
+
+function providerStream(
+  events: ConverseStreamOutput[],
+): AsyncIterable<ConverseStreamOutput> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* events;
+    },
+  };
+}
+
+function createClient(events: ConverseStreamOutput[]) {
+  const send = jest.fn(async () => ({
+    stream: providerStream(events),
+  })) as unknown as BedrockRuntimeClient['send'];
+  const destroy = jest.fn();
+  const client = { send, destroy } as unknown as BedrockRuntimeClient;
+
+  return { client, send, destroy };
+}
+
+async function collectEvents(
+  iterable: AsyncIterable<AGUIEvent>,
+): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+
+  for await (const event of iterable) {
+    events.push(EventSchemas.parse(event));
+  }
+
+  return events;
+}
+
+test('streams canonical AG-UI run and text events from Bedrock', async () => {
+  const provider = createClient([
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 0,
+        delta: { text: 'Hello from Bedrock.' },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 0 } },
+  ]);
+
+  const events = await collectEvents(
+    text({
+      client: provider.client,
+      model: 'bedrock-model',
+      input: createInput(),
+    }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-bedrock',
+      runId: 'run-bedrock',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-bedrock:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-bedrock:assistant',
+      delta: 'Hello from Bedrock.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-bedrock:assistant',
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: 'thread-bedrock',
+      runId: 'run-bedrock',
+    },
+  ]);
+  expect(provider.send).toHaveBeenCalledTimes(1);
+  expect(provider.destroy).not.toHaveBeenCalled();
+});
+
+test('passes transformed request options and the abort signal to Bedrock', async () => {
+  const provider = createClient([]);
+  const controller = new AbortController();
+  const transformRequestOptions = jest.fn((options) => ({
+    ...options,
+    inferenceConfig: { maxTokens: 64, temperature: 0 },
+  }));
+
+  await collectEvents(
+    text({
+      client: provider.client,
+      model: 'bedrock-model',
+      input: createInput(),
+      signal: controller.signal,
+      transformRequestOptions,
+    }),
+  );
+
+  expect(transformRequestOptions).toHaveBeenCalledWith(
+    expect.objectContaining({ modelId: 'bedrock-model' }),
+  );
+  expect(provider.send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      input: expect.objectContaining({
+        inferenceConfig: { maxTokens: 64, temperature: 0 },
+      }),
+    }),
+    { abortSignal: controller.signal },
+  );
+});
+
+test('destroys an internally created Bedrock client after streaming', async () => {
+  const send = jest.spyOn(BedrockRuntimeClient.prototype, 'send');
+  send.mockImplementation((async () => ({
+    stream: providerStream([]),
+  })) as unknown as BedrockRuntimeClient['send']);
+  const destroy = jest
+    .spyOn(BedrockRuntimeClient.prototype, 'destroy')
+    .mockImplementation(() => undefined);
+
+  const events = await collectEvents(
+    text({
+      clientOptions: { region: 'us-east-1' },
+      model: 'bedrock-model',
+      input: createInput(),
+    }),
+  );
+
+  expect(events.at(-1)).toEqual({
+    type: EventType.RUN_FINISHED,
+    threadId: 'thread-bedrock',
+    runId: 'run-bedrock',
+  });
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(destroy).toHaveBeenCalledTimes(1);
+
+  send.mockRestore();
+  destroy.mockRestore();
+});
+
+test('maps provider failures to one AG-UI RUN_ERROR', async () => {
+  const send = jest.fn().mockRejectedValue(new Error('Bedrock failed'));
+  const client = {
+    send,
+    destroy: jest.fn(),
+  } as unknown as BedrockRuntimeClient;
+
+  const events = await collectEvents(
+    text({ client, model: 'bedrock-model', input: createInput() }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-bedrock',
+      runId: 'run-bedrock',
+    },
+    { type: EventType.RUN_ERROR, message: 'Bedrock failed' },
+  ]);
+});
+
+test('returns only RUN_STARTED when the signal is already aborted', async () => {
+  const provider = createClient([]);
+  const controller = new AbortController();
+  controller.abort();
+
+  const events = await collectEvents(
+    text({
+      client: provider.client,
+      model: 'bedrock-model',
+      input: createInput(),
+      signal: controller.signal,
+    }),
+  );
+
+  expect(events).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-bedrock',
+      runId: 'run-bedrock',
+    },
+  ]);
+  expect(provider.send).not.toHaveBeenCalled();
+});

--- a/packages/bedrock/src/stream/text.fn.ts
+++ b/packages/bedrock/src/stream/text.fn.ts
@@ -1,583 +1,80 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import {
   BedrockRuntimeClient,
-  BedrockRuntimeClientConfig,
-  ContentBlock,
-  ContentBlockDelta,
   ConverseStreamCommand,
-  ConverseStreamCommandInput,
-  ToolChoice,
-  ToolConfiguration,
-  ToolResultContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
-import type {
-  Message as BedrockMessage,
-  Tool,
-} from '@aws-sdk/client-bedrock-runtime';
-import { AwsCredentialIdentity, DocumentType, Provider } from '@aws-sdk/types';
-import {
-  Chat,
-  encodeFrame,
-  Frame,
-  mergeMessagesForThread,
-  updateAssistantMessage,
-} from '@hashbrownai/core';
+import { mapBedrockEvents } from './bedrock-events';
+import { createBedrockRequestOptions } from './bedrock-request';
+import type { BedrockTextStreamOptions } from './types';
 
-type BaseBedrockTextStreamOptions = {
-  request: Chat.Api.CompletionCreateParams;
-  /**
-   * Optional pre-configured Bedrock client. If omitted, a client will be created
-   * using the supplied region, and credentials (or ambient AWS env).
-   */
-  client?: BedrockRuntimeClient;
-  region?: string;
-  credentials?: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
-};
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-type ThreadPersistenceOptions = {
-  loadThread: (threadId: string) => Promise<Chat.Api.Message[]>;
-  saveThread: (
-    thread: Chat.Api.Message[],
-    threadId?: string,
-  ) => Promise<string>;
-};
-
-type ThreadlessOptions = BaseBedrockTextStreamOptions & {
-  loadThread?: undefined;
-  saveThread?: undefined;
-};
-
-type ThreadfulOptions = BaseBedrockTextStreamOptions & ThreadPersistenceOptions;
-
-export type BedrockTextStreamOptions = ThreadlessOptions | ThreadfulOptions;
-
-export function text(options: ThreadfulOptions): AsyncIterable<Uint8Array>;
-export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
+/**
+ * Streams canonical AG-UI events from an Amazon Bedrock Converse request.
+ *
+ * @param options - Provider configuration and AG-UI run input.
+ * @returns An asynchronous stream of canonical AG-UI events.
+ *
+ * @public
+ */
 export async function* text(
   options: BedrockTextStreamOptions,
-): AsyncIterable<Uint8Array> {
-  const { request, loadThread, saveThread } = options;
-  const client = getBedrockClient(options);
-  const threadId = request.threadId;
-  let loadedThread: Chat.Api.Message[] = [];
-  let effectiveThreadId = threadId;
+): AsyncIterable<AGUIEvent> {
+  const { model, input, signal, transformRequestOptions } = options;
+  const { threadId, runId } = input;
+  const messageId = `${runId}:assistant`;
+  let ownedClient: BedrockRuntimeClient | undefined;
 
-  const shouldLoadThread = Boolean(request.threadId);
-  const shouldHydrateThreadOnTheClient = Boolean(
-    request.operation === 'load-thread',
-  );
-
-  if (shouldLoadThread) {
-    yield encodeFrame({ type: 'thread-load-start' });
-
-    if (!loadThread) {
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: 'Thread loading is not available for this transport.',
-      });
-      return;
-    }
-
-    try {
-      loadedThread = await loadThread(request.threadId as string);
-      if (shouldHydrateThreadOnTheClient) {
-        yield encodeFrame({
-          type: 'thread-load-success',
-          thread: loadedThread,
-        });
-      } else {
-        yield encodeFrame({ type: 'thread-load-success' });
-      }
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
-  }
-
-  if (request.operation === 'load-thread') {
+  yield { type: EventType.RUN_STARTED, threadId, runId };
+  if (signal?.aborted) {
     return;
   }
 
-  const mergedMessages =
-    request.threadId && shouldLoadThread
-      ? mergeMessagesForThread(loadedThread, request.messages ?? [])
-      : (request.messages ?? []);
-  let assistantMessage: Chat.Api.AssistantMessage | null = null;
-
   try {
-    const baseOptions: ConverseStreamCommandInput = {
-      modelId: request.model as string,
-      system: request.system ? [{ text: request.system }] : undefined,
-      messages: toBedrockMessages(mergedMessages),
-      toolConfig: toToolConfiguration(request.tools, request.toolChoice),
-    };
-
-    const response = await client.send(new ConverseStreamCommand(baseOptions));
-
-    yield encodeFrame({ type: 'generation-start' });
-
-    const stream = response.stream;
-    if (!stream) {
-      throw new Error('Amazon Bedrock did not return a streaming response.');
+    const baseRequest = createBedrockRequestOptions(input, model);
+    const request = transformRequestOptions
+      ? await transformRequestOptions(baseRequest)
+      : baseRequest;
+    if (signal?.aborted) {
+      return;
     }
 
-    const toolCallBlocks = new Map<
-      number,
-      { id: string; index: number; name: string; buffer: string }
-    >();
-    let nextToolCallIndex = 0;
-    let finishReason: string | null = null;
+    const client =
+      options.client ??
+      (ownedClient = new BedrockRuntimeClient(options.clientOptions ?? {}));
+    const command = new ConverseStreamCommand(request);
+    const response = signal
+      ? await client.send(command, { abortSignal: signal })
+      : await client.send(command);
+    if (signal?.aborted) {
+      return;
+    }
+    if (!response.stream) {
+      throw new Error('Amazon Bedrock did not return a streaming response');
+    }
 
-    for await (const event of stream) {
-      if (event.contentBlockStart?.start?.toolUse) {
-        const blockIndex =
-          event.contentBlockStart.contentBlockIndex ?? toolCallBlocks.size;
-        const { toolUseId, name } = event.contentBlockStart.start.toolUse;
-        const toolIndex = nextToolCallIndex++;
-
-        if (!toolUseId || !name) {
-          continue;
-        }
-
-        toolCallBlocks.set(blockIndex, {
-          id: toolUseId,
-          name,
-          index: toolIndex,
-          buffer: '',
-        });
-
-        let shouldProvideEmptyArgumentsObject = false;
-
-        request.tools?.forEach((tool) => {
-          if (tool.name === name) {
-            if (
-              'type' in tool.parameters &&
-              'properties' in tool.parameters &&
-              tool.parameters.type === 'object' &&
-              Object.keys(tool.parameters.properties as any).length === 0
-            ) {
-              shouldProvideEmptyArgumentsObject = true;
-            }
-          }
-        });
-
-        const chunk = createChunk({
-          finishReason,
-          toolCalls: [
-            {
-              id: toolUseId,
-              index: toolIndex,
-              name,
-              arguments: shouldProvideEmptyArgumentsObject ? '{}' : '',
-            },
-          ],
-        });
-
-        yield encodeFrame({
-          type: 'generation-chunk',
-          chunk,
-        });
-
-        assistantMessage = updateAssistantMessage(assistantMessage, chunk);
-
-        continue;
-      }
-
-      if (event.contentBlockDelta) {
-        const { contentBlockIndex, delta } = event.contentBlockDelta;
-
-        if (delta && isTextDelta(delta) && delta.text !== undefined) {
-          const chunk = createChunk({
-            content: delta.text,
-            finishReason,
-          });
-
-          yield encodeFrame({
-            type: 'generation-chunk',
-            chunk,
-          });
-
-          assistantMessage = updateAssistantMessage(assistantMessage, chunk);
-          continue;
-        }
-
-        if (delta && isToolUseDelta(delta) && contentBlockIndex !== undefined) {
-          const block = toolCallBlocks.get(contentBlockIndex);
-          if (block) {
-            block.buffer = delta.toolUse.input ?? '';
-            toolCallBlocks.set(contentBlockIndex, block);
-
-            const chunk = createChunk({
-              finishReason,
-              toolCalls: [
-                {
-                  id: block.id,
-                  index: block.index,
-                  name: block.name,
-                  arguments: block.buffer,
-                },
-              ],
-            });
-
-            yield encodeFrame({
-              type: 'generation-chunk',
-              chunk,
-            });
-
-            assistantMessage = updateAssistantMessage(assistantMessage, chunk);
-          }
-          continue;
-        }
-
-        if (delta && isSerializableDelta(delta)) {
-          const chunk = createChunk({
-            content: JSON.stringify(delta),
-            finishReason,
-          });
-
-          yield encodeFrame({
-            type: 'generation-chunk',
-            chunk,
-          });
-
-          assistantMessage = updateAssistantMessage(assistantMessage, chunk);
-          continue;
-        }
-      }
-
-      if (
-        event.contentBlockStop &&
-        event.contentBlockStop.contentBlockIndex !== undefined
-      ) {
-        toolCallBlocks.delete(event.contentBlockStop.contentBlockIndex);
-        continue;
-      }
-
-      if (event.messageStop) {
-        finishReason = event.messageStop.stopReason ?? null;
-        const chunk = createChunk({ finishReason });
-        yield encodeFrame({
-          type: 'generation-chunk',
-          chunk,
-        });
-        assistantMessage = updateAssistantMessage(assistantMessage, chunk);
-        continue;
-      }
-
-      if (event.internalServerException) {
-        throw event.internalServerException;
-      }
-
-      if (event.modelStreamErrorException) {
-        throw event.modelStreamErrorException;
-      }
-
-      if (event.validationException) {
-        throw event.validationException;
-      }
-
-      if (event.throttlingException) {
-        throw event.throttlingException;
-      }
-
-      if (event.serviceUnavailableException) {
-        throw event.serviceUnavailableException;
+    for await (const event of mapBedrockEvents({
+      events: response.stream,
+      messageId,
+      signal,
+    })) {
+      yield event;
+      if (signal?.aborted) {
+        return;
       }
     }
+    if (signal?.aborted) {
+      return;
+    }
+
+    yield { type: EventType.RUN_FINISHED, threadId, runId };
   } catch (error: unknown) {
-    yield encodeFrame(toErrorFrame(error));
-    return;
-  }
-  // close generation phase after successful streaming
-  yield encodeFrame({ type: 'generation-finish' });
-
-  if (saveThread) {
-    const threadToSave = mergeMessagesForThread(mergedMessages, [
-      ...(assistantMessage ? [assistantMessage] : []),
-    ]);
-    yield encodeFrame({ type: 'thread-save-start' });
-    try {
-      const savedThreadId = await saveThread(threadToSave, effectiveThreadId);
-      if (effectiveThreadId && savedThreadId !== effectiveThreadId) {
-        throw new Error(
-          'Save returned a different threadId than the existing thread',
-        );
-      }
-      effectiveThreadId = savedThreadId;
-      yield encodeFrame({
-        type: 'thread-save-success',
-        threadId: savedThreadId,
-      });
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-save-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
+    if (!signal?.aborted) {
+      yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
     }
+  } finally {
+    ownedClient?.destroy();
   }
-}
-
-function getBedrockClient(
-  options: BedrockTextStreamOptions,
-): BedrockRuntimeClient {
-  if (options.client) {
-    return options.client;
-  }
-
-  const config: BedrockRuntimeClientConfig = {};
-
-  if (options.region) {
-    config.region = options.region;
-  }
-
-  if (options.credentials) {
-    config.credentials = options.credentials;
-  }
-
-  return new BedrockRuntimeClient(config);
-}
-
-function toBedrockMessages(messages: Chat.Api.Message[]): BedrockMessage[] {
-  return messages.map((message): BedrockMessage => {
-    if (message.role === 'user') {
-      return {
-        role: 'user',
-        content: [{ text: message.content }],
-      };
-    }
-
-    if (message.role === 'assistant') {
-      const contentBlocks: ContentBlock[] = [];
-
-      if (message.content !== undefined) {
-        contentBlocks.push({ text: coerceText(message.content) });
-      }
-
-      if (message.toolCalls?.length) {
-        for (const toolCall of message.toolCalls) {
-          contentBlocks.push({
-            toolUse: {
-              toolUseId: toolCall.id,
-              name: toolCall.function.name,
-              input: safeJsonParse(toolCall.function.arguments),
-            },
-          });
-        }
-      }
-
-      if (contentBlocks.length === 0) {
-        contentBlocks.push({ text: '' });
-      }
-
-      return {
-        role: 'assistant',
-        content: contentBlocks,
-      };
-    }
-
-    if (message.role === 'tool') {
-      return {
-        role: 'user',
-        content: [
-          {
-            toolResult: {
-              toolUseId: message.toolCallId,
-              content: toToolResultContent(message.content),
-            },
-          },
-        ],
-      };
-    }
-
-    throw new Error(`Invalid message role: ${message['role'] as string}`);
-  });
-}
-
-function toToolConfiguration(
-  tools: Chat.Api.Tool[] | undefined,
-  toolChoice: Chat.Api.CompletionToolChoiceOption | undefined,
-): ToolConfiguration | undefined {
-  if (!tools?.length || toolChoice === 'none') {
-    return undefined;
-  }
-
-  const config: ToolConfiguration = {
-    tools: tools.map(
-      (tool): Tool.ToolSpecMember => ({
-        toolSpec: {
-          name: tool.name,
-          description: tool.description,
-          inputSchema: {
-            json: (tool.parameters ?? {}) as DocumentType,
-          },
-        },
-      }),
-    ),
-  };
-
-  const mappedChoice = mapToolChoice(toolChoice);
-  if (mappedChoice) {
-    config.toolChoice = mappedChoice;
-  }
-
-  return config;
-}
-
-function mapToolChoice(
-  toolChoice: Chat.Api.CompletionToolChoiceOption | undefined,
-): ToolChoice | undefined {
-  switch (toolChoice) {
-    case 'auto':
-      return { auto: {} };
-    case 'required':
-      return { any: {} };
-    default:
-      return undefined;
-  }
-}
-
-function toToolResultContent(
-  result: PromiseSettledResult<unknown>,
-): ToolResultContentBlock[] {
-  const payload =
-    result.status === 'fulfilled'
-      ? result.value
-      : {
-          error:
-            result.reason instanceof Error
-              ? result.reason.message
-              : String(result.reason),
-        };
-
-  if (typeof payload === 'string') {
-    return [{ text: payload }];
-  }
-
-  if (payload !== null && typeof payload === 'object') {
-    return [{ json: { result: payload } as DocumentType }];
-  }
-
-  return [{ text: String(payload) }];
-}
-
-function safeJsonParse(value: string | undefined): DocumentType {
-  if (!value) {
-    // Bedrock requires an empty JSON object if there are no args
-    return {};
-  }
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-}
-
-function coerceText(value: unknown): string {
-  if (typeof value === 'string') {
-    if (value === '') {
-      // NB: Bedrock doesn't allow empty text if the text field is present
-      return 'tool call';
-    }
-    return value;
-  }
-
-  if (value === null || value === undefined) {
-    // NB: Bedrock doesn't allow empty text if the text field is present
-    return 'tool call';
-  }
-
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
-function isTextDelta(delta: ContentBlockDelta): delta is { text: string } {
-  return Object.prototype.hasOwnProperty.call(delta, 'text');
-}
-
-function isToolUseDelta(
-  delta: ContentBlockDelta,
-): delta is ContentBlockDelta.ToolUseMember {
-  return Object.prototype.hasOwnProperty.call(delta, 'toolUse');
-}
-
-function isSerializableDelta(delta: ContentBlockDelta): boolean {
-  return (
-    Object.prototype.hasOwnProperty.call(delta, 'toolResult') ||
-    Object.prototype.hasOwnProperty.call(delta, 'reasoningContent') ||
-    Object.prototype.hasOwnProperty.call(delta, 'citation')
-  );
-}
-
-function createChunk({
-  content,
-  toolCalls,
-  finishReason,
-}: {
-  content?: string;
-  toolCalls?: Array<{
-    id: string;
-    name: string;
-    index: number;
-    arguments: string;
-  }>;
-  finishReason: string | null;
-}): Chat.Api.CompletionChunk {
-  return {
-    choices: [
-      {
-        index: 0,
-        delta: {
-          role: 'assistant',
-          ...(content !== undefined ? { content } : {}),
-          ...(toolCalls
-            ? {
-                toolCalls: toolCalls.map((call) => ({
-                  id: call.id,
-                  index: call.index,
-                  type: 'function',
-                  function: {
-                    name: call.name,
-                    arguments: call.arguments,
-                  },
-                })),
-              }
-            : {}),
-        },
-        finishReason,
-      },
-    ],
-  };
-}
-
-function toErrorFrame(error: unknown): Frame {
-  if (error instanceof Error) {
-    return {
-      type: 'generation-error',
-      error: error.toString(),
-      stacktrace: error.stack,
-    };
-  }
-
-  return {
-    type: 'generation-error',
-    error: String(error),
-  };
-}
-
-function normalizeError(error: unknown): { message: string; stack?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, stack: error.stack };
-  }
-  return { message: String(error) };
 }

--- a/packages/bedrock/src/stream/types.ts
+++ b/packages/bedrock/src/stream/types.ts
@@ -1,0 +1,52 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import type {
+  BedrockRuntimeClient,
+  BedrockRuntimeClientConfig,
+  ConverseStreamCommandInput,
+} from '@aws-sdk/client-bedrock-runtime';
+
+/**
+ * Hashbrown extensions accepted alongside a standard AG-UI run input.
+ *
+ * @public
+ */
+export interface BedrockHashbrownRunAgentInput extends RunAgentInput {
+  /** Hashbrown semantics layered onto the standard AG-UI run input. */
+  hashbrown?: {
+    /** JSON Schema used for Bedrock native structured output. */
+    responseSchema?: object;
+    /** Whether the run is expected to produce generative UI output. */
+    ui?: boolean;
+  };
+}
+
+/**
+ * Options for streaming an AG-UI run from Amazon Bedrock.
+ *
+ * @public
+ */
+export type BedrockTextStreamOptions = (
+  | {
+      /** Reusable official Bedrock Runtime SDK client. */
+      client: BedrockRuntimeClient;
+      /** Excludes SDK client configuration when a client is supplied. */
+      clientOptions?: never;
+    }
+  | {
+      /** Excludes a supplied client when SDK client configuration is used. */
+      client?: never;
+      /** Official Bedrock Runtime SDK client configuration. */
+      clientOptions?: BedrockRuntimeClientConfig;
+    }
+) & {
+  /** Model or inference profile selected by the server for this endpoint. */
+  model: string;
+  /** Standard AG-UI run input plus optional Hashbrown semantics. */
+  input: BedrockHashbrownRunAgentInput;
+  /** Cancels the provider request when the HTTP request is abandoned. */
+  signal?: AbortSignal;
+  /** Customize the Bedrock request after AG-UI input has been mapped. */
+  transformRequestOptions?: (
+    options: ConverseStreamCommandInput,
+  ) => ConverseStreamCommandInput | Promise<ConverseStreamCommandInput>;
+};

--- a/packages/bedrock/tsconfig.lib.json
+++ b/packages/bedrock/tsconfig.lib.json
@@ -6,7 +6,12 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.runtime.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
   "angularCompilerOptions": {
     "extendedDiagnostics": {
       "checks": {

--- a/www/analog/src/app/pages/docs/angular/platform/bedrock.md
+++ b/www/analog/src/app/pages/docs/angular/platform/bedrock.md
@@ -2,77 +2,93 @@
 title: 'Amazon Bedrock: Hashbrown Angular Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s Amazon Bedrock adapter streams chat completions from AWS Bedrock models with support for tool calling and Hashbrown’s streaming protocol.'
+    content: 'Hashbrown’s Amazon Bedrock adapter maps AG-UI runs to the AWS Bedrock Converse API and streams canonical AG-UI events.'
 ---
+
 # Amazon Bedrock
 
-First, install the Amazon Bedrock adapter package:
+Install the Bedrock adapter, the AWS Bedrock Runtime SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/bedrock
+npm install @hashbrownai/bedrock @aws-sdk/client-bedrock-runtime @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s Bedrock adapter lets you **stream chat completions** from AWS Bedrock models (Claude, Mistral, Meta Llama, etc.) using the same streaming protocol Hashbrown uses for every platform.
+`HashbrownBedrock.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses the AWS SDK's `ConverseStream` API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model or inference profile is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownBedrock.stream.text(options)`
+| Name                      | Type                                    | Description                                                                    |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
+| `model`                   | `string`                                | Server-selected Bedrock model or inference profile ID.                         |
+| `input`                   | `BedrockHashbrownRunAgentInput`         | AG-UI run input, including messages and tools.                                 |
+| `clientOptions`           | `BedrockRuntimeClientConfig`            | _(Optional)_ AWS SDK client configuration. Mutually exclusive with `client`.   |
+| `client`                  | `BedrockRuntimeClient`                  | _(Optional)_ Reusable AWS SDK client. Mutually exclusive with `clientOptions`. |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Bedrock request when the HTTP client disconnects.     |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final Bedrock `ConverseStreamCommandInput`.        |
 
-Streams an Amazon Bedrock chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tools, tool results, and native structured output. Bedrock reasoning text, signatures, and redacted reasoning become AG-UI reasoning records that can be sent back on continuation. Citations, images, response metadata, and unsupported native blocks are preserved as AG-UI `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Bedrock native structured output on a model that supports it:
 
-| Name          | Type                                                      | Description                                                                                     |
-| ------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `request`     | `Chat.Api.CompletionCreateParams`                         | The chat request: model (e.g. `anthropic.claude-3-5-sonnet-20241022-v1:0`), messages, tools, etc. |
-| `region`      | `string`                                                  | _(Optional)_ AWS region for Bedrock (falls back to the AWS SDK default chain if omitted).       |
-| `credentials` | `AwsCredentialIdentity \| Provider<AwsCredentialIdentity>` | _(Optional)_ Explicit AWS credentials if not using the default credential chain.               |
-| `client`      | `BedrockRuntimeClient`                                    | _(Optional)_ Pre-configured Bedrock client to reuse connections, retries, or custom middleware. |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Converts Hashbrown tools into Bedrock `toolConfig` definitions and streams tool call arguments.
-- **System Prompt:** Added as a Bedrock system message when supplied.
-- **Function Calling:** Streams tool call deltas (`toolUse`) and tool results in the order Hashbrown expects.
-- **Streaming:** Emits resilient Hashbrown frames for every text delta, tool call update, finish reason, or error.
-
-### How It Works
-
-- **Messages:** User, assistant, and tool messages are mapped to Bedrock `messages` (tool results become `toolResult` blocks).
-- **Tool Configuration:** Tools are sent via `toolConfig` with the JSON schema you pass in `parameters`.
-- **Tool Call Streaming:** Bedrock’s `toolUse` events are buffered and emitted as incremental Hashbrown tool call frames.
-- **Error Handling:** Any SDK or service error is converted into an error frame before Hashbrown sends `finish`.
-- **Structured Output:** Amazon Bedrock does not yet enforce JSON schemas—Angular apps should enable `emulateStructuredOutput` so Hashbrown validates locally (see below).
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -83,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -111,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownBedrock.stream.text({
-      region: process.env.AWS_REGION ?? 'us-east-1',
-      request: body, // must be Chat.Api.CompletionCreateParams
+      clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+      model: process.env.BEDROCK_MODEL_ID!,
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -140,31 +185,37 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
     },
   );
@@ -177,43 +228,40 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## AWS Credentials and Client Reuse
 
-## AWS Credentials & Client Reuse
-
-The adapter uses the AWS SDK’s [default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). Provide credentials via environment variables, IAM roles, or pass them explicitly:
+`clientOptions` uses the AWS SDK default credential provider chain, including environment variables, shared AWS config, ECS task roles, EC2 instance roles, and web identity credentials.
 
 ```ts
 const stream = HashbrownBedrock.stream.text({
-  request,
-  region: 'us-west-2',
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  clientOptions: {
+    region: 'us-east-1',
   },
+  model: process.env.BEDROCK_MODEL_ID!,
+  input,
 });
 ```
 
-If you already configure retries, logging, or custom middleware on a `BedrockRuntimeClient`, pass it with the `client` option to reuse it.
+Pass a configured `BedrockRuntimeClient` through `client` when you need to reuse connections, retries, or middleware. Hashbrown destroys clients it creates from `clientOptions`; it never destroys a client supplied through `client`.
 
----
+## Transform Request Options
 
-## Structured Output & Angular Providers
-
-Because Bedrock does not validate JSON schemas, enable `emulateStructuredOutput` in your Angular configuration so Hashbrown enforces structured responses on the client:
+Use `transformRequestOptions` for provider-owned inference settings, guardrails, request metadata, performance configuration, or a forced tool choice.
 
 ```ts
-import { ApplicationConfig } from '@angular/core';
-import { provideHashbrown } from '@hashbrownai/angular';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideHashbrown({
-      baseUrl: '/api/chat',
-      emulateStructuredOutput: true,
-    }),
-  ],
-};
+const stream = HashbrownBedrock.stream.text({
+  clientOptions: { region: 'us-east-1' },
+  model: process.env.BEDROCK_MODEL_ID!,
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    inferenceConfig: {
+      maxTokens: 2048,
+      temperature: 0.2,
+    },
+    requestMetadata: {
+      application: 'my-app',
+    },
+  }),
+});
 ```
-
-With this flag, the Angular resources/hooks keep your UI synchronized with tool responses just like the OpenAI/Azure adapters.

--- a/www/analog/src/app/pages/docs/angular/start/platforms.md
+++ b/www/analog/src/app/pages/docs/angular/start/platforms.md
@@ -37,14 +37,14 @@ Can't find your preferred AI provider? [Create a custom adapter](/docs/angular/p
 
 ## Platform Limitations
 
-| Platform         | Limitations                                  |
-| ---------------- | -------------------------------------------- |
-| OpenAI           | None                                         |
-| Microsoft Azure  | None                                         |
-| Anthropic Claude | Requires `@anthropic-ai/sdk` peer dependency |
-| Amazon Bedrock   | Requires emulated structured outputs         |
-| Google Gemini    | Requires emulated structured outputs         |
-| Ollama           | Limited model support                        |
+| Platform         | Limitations                                      |
+| ---------------- | ------------------------------------------------ |
+| OpenAI           | None                                             |
+| Microsoft Azure  | None                                             |
+| Anthropic Claude | Requires `@anthropic-ai/sdk` peer dependency     |
+| Amazon Bedrock   | Native structured output support varies by model |
+| Google Gemini    | Native structured output support varies by model |
+| Ollama           | Limited model support                            |
 
 ## Where is X platform?
 

--- a/www/analog/src/app/pages/docs/react/platform/bedrock.md
+++ b/www/analog/src/app/pages/docs/react/platform/bedrock.md
@@ -2,78 +2,93 @@
 title: 'Amazon Bedrock: Hashbrown React Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s Amazon Bedrock adapter lets you stream chat completions from AWS Bedrock models with built-in tool calling and streaming support.'
+    content: 'Hashbrown’s Amazon Bedrock adapter maps AG-UI runs to the AWS Bedrock Converse API and streams canonical AG-UI events.'
 ---
 
 # Amazon Bedrock
 
-First, install the Amazon Bedrock adapter package:
+Install the Bedrock adapter, the AWS Bedrock Runtime SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/bedrock
+npm install @hashbrownai/bedrock @aws-sdk/client-bedrock-runtime @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s Bedrock adapter lets you **stream chat completions** from any AWS Bedrock model (Claude, Mistral, Meta, Llama, etc.) while preserving tool calling semantics and the Hashbrown streaming frame format.
+`HashbrownBedrock.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses the AWS SDK's `ConverseStream` API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model or inference profile is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownBedrock.stream.text(options)`
+| Name                      | Type                                    | Description                                                                    |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
+| `model`                   | `string`                                | Server-selected Bedrock model or inference profile ID.                         |
+| `input`                   | `BedrockHashbrownRunAgentInput`         | AG-UI run input, including messages and tools.                                 |
+| `clientOptions`           | `BedrockRuntimeClientConfig`            | _(Optional)_ AWS SDK client configuration. Mutually exclusive with `client`.   |
+| `client`                  | `BedrockRuntimeClient`                  | _(Optional)_ Reusable AWS SDK client. Mutually exclusive with `clientOptions`. |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Bedrock request when the HTTP client disconnects.     |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final Bedrock `ConverseStreamCommandInput`.        |
 
-Streams an Amazon Bedrock chat completion as a series of encoded frames. Handles content, tool calls, errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tools, tool results, and native structured output. Bedrock reasoning text, signatures, and redacted reasoning become AG-UI reasoning records that can be sent back on continuation. Citations, images, response metadata, and unsupported native blocks are preserved as AG-UI `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Bedrock native structured output on a model that supports it:
 
-| Name          | Type                                                       | Description                                                                                       |
-| ------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `request`     | `Chat.Api.CompletionCreateParams`                          | The chat request: model (e.g. `anthropic.claude-3-5-sonnet-20241022-v1:0`), messages, tools, etc. |
-| `region`      | `string`                                                   | _(Optional)_ AWS region for Bedrock (falls back to the AWS SDK default chain if omitted).         |
-| `credentials` | `AwsCredentialIdentity \| Provider<AwsCredentialIdentity>` | _(Optional)_ Explicit AWS credentials if not using the default credential chain.                  |
-| `client`      | `BedrockRuntimeClient`                                     | _(Optional)_ Pre-configured Bedrock client to reuse connections, retries, or custom middleware.   |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Converts Hashbrown tools into Bedrock `toolConfig` definitions and streams tool call arguments.
-- **System Prompt:** Added as a Bedrock system message when supplied.
-- **Tool Calling:** Streams tool call deltas (`toolUse`) and tool results in the same order Hashbrown expects.
-- **Streaming:** Emits resilient Hashbrown frames for every text delta, tool call update, finish reason, or error.
-
-### How It Works
-
-- **Messages:** User, assistant, and tool messages are mapped to Bedrock `messages` (tool results become `toolResult` blocks).
-- **Tool Configuration:** Tools are sent via `toolConfig` with the JSON schema you pass in `parameters`.
-- **Tool Call Streaming:** Bedrock’s `toolUse` events are buffered and emitted as incremental Hashbrown tool call frames.
-- **Error Handling:** Any SDK or service error is converted into an error frame before Hashbrown sends `finish`.
-- **Structured Output:** Amazon Bedrock does not yet honor JSON schemas directly—use `emulateStructuredOutput` in your React provider to coerce tool responses (see below).
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -84,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -112,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownBedrock.stream.text({
-      region: process.env.AWS_REGION ?? 'us-east-1',
-      request: body, // must be Chat.Api.CompletionCreateParams
+      clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+      model: process.env.BEDROCK_MODEL_ID!,
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -141,31 +185,37 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownBedrock } from '@hashbrownai/bedrock';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownBedrock.stream.text({
-    region: process.env.AWS_REGION ?? 'us-east-1',
-    request: body, // must be Chat.Api.CompletionCreateParams
+    clientOptions: { region: process.env.AWS_REGION ?? 'us-east-1' },
+    model: process.env.BEDROCK_MODEL_ID!,
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
     },
   );
@@ -178,41 +228,40 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## AWS Credentials and Client Reuse
 
-## AWS Credentials & Client Reuse
-
-The adapter uses the AWS SDK’s [default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html). Provide credentials via environment variables, IAM roles, or pass them explicitly:
+`clientOptions` uses the AWS SDK default credential provider chain, including environment variables, shared AWS config, ECS task roles, EC2 instance roles, and web identity credentials.
 
 ```ts
 const stream = HashbrownBedrock.stream.text({
-  request,
-  region: 'us-west-2',
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  clientOptions: {
+    region: 'us-east-1',
   },
+  model: process.env.BEDROCK_MODEL_ID!,
+  input,
 });
 ```
 
-If you already configure retries, logging, or custom middleware on a `BedrockRuntimeClient`, pass it with the `client` option to reuse it.
+Pass a configured `BedrockRuntimeClient` through `client` when you need to reuse connections, retries, or middleware. Hashbrown destroys clients it creates from `clientOptions`; it never destroys a client supplied through `client`.
 
----
+## Transform Request Options
 
-## Structured Output & React Providers
+Use `transformRequestOptions` for provider-owned inference settings, guardrails, request metadata, performance configuration, or a forced tool choice.
 
-Amazon Bedrock does not currently enforce JSON schemas the way OpenAI or Azure do. Enable `emulateStructuredOutput` to have Hashbrown enforce your schemas client-side:
-
-```tsx
-import { HashbrownProvider } from '@hashbrownai/react';
-
-export function App({ children }: { children: React.ReactNode }) {
-  return (
-    <HashbrownProvider baseUrl="/api/chat" emulateStructuredOutput>
-      {children}
-    </HashbrownProvider>
-  );
-}
+```ts
+const stream = HashbrownBedrock.stream.text({
+  clientOptions: { region: 'us-east-1' },
+  model: process.env.BEDROCK_MODEL_ID!,
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    inferenceConfig: {
+      maxTokens: 2048,
+      temperature: 0.2,
+    },
+    requestMetadata: {
+      application: 'my-app',
+    },
+  }),
+});
 ```
-
-This flag ensures Hashbrown keeps your React components in sync with tool responses even when the provider does not validate the schema.

--- a/www/analog/src/app/pages/docs/react/start/platforms.md
+++ b/www/analog/src/app/pages/docs/react/start/platforms.md
@@ -37,14 +37,14 @@ Can't find your preferred AI provider? [Create a custom adapter](/docs/react/pla
 
 ## Platform Limitations
 
-| Platform         | Limitations                                  |
-| ---------------- | -------------------------------------------- |
-| OpenAI           | None                                         |
-| Microsoft Azure  | None                                         |
-| Anthropic Claude | Requires `@anthropic-ai/sdk` peer dependency |
-| Amazon Bedrock   | Requires emulated structured outputs         |
-| Google Gemini    | Requires emulated structured outputs         |
-| Ollama           | Limited model support                        |
+| Platform         | Limitations                                      |
+| ---------------- | ------------------------------------------------ |
+| OpenAI           | None                                             |
+| Microsoft Azure  | None                                             |
+| Anthropic Claude | Requires `@anthropic-ai/sdk` peer dependency     |
+| Amazon Bedrock   | Native structured output support varies by model |
+| Google Gemini    | Native structured output support varies by model |
+| Ollama           | Limited model support                            |
 
 ## Where is X platform?
 


### PR DESCRIPTION
## Summary

- replace the legacy Bedrock frame stream with canonical AG-UI events over `ConverseStream`
- map AG-UI messages, tools, tool results, reasoning continuation, and native structured output to the official AWS SDK
- add focused unit coverage, aimock end-to-end fixtures, and a bounded real-provider runtime verification target
- convert the Bedrock package and React/Angular docs to POST `/run` with AG-UI SSE
- add a manual and nightly GitHub Action using AWS OIDC

## Breaking changes

- `HashbrownBedrock.stream.text` now accepts a server-selected `model`, AG-UI `input`, and either `client` or `clientOptions`
- the stream emits `AsyncIterable<AGUIEvent>` instead of Hashbrown binary frames
- Node.js 20 or newer is required
- `@ag-ui/core` is a direct dependency and `@aws-sdk/client-bedrock-runtime` `^3.1106.0` is the supported peer

## Verification

- `npx nx build bedrock --skip-nx-cache`
- `npx nx test bedrock --skip-nx-cache` (18 tests)
- `npx nx e2e bedrock --skip-nx-cache` (6 aimock fixtures)
- `npx nx lint bedrock --skip-nx-cache`
- `npx nx build-api-report bedrock --skip-nx-cache`
- `npx nx build www --skip-nx-cache`
- `npx nx test www --skip-nx-cache`
- local HTTP `/run` smoke through AG-UI SSE and the Hashbrown HTTP transport
- real Bedrock text, tool-call, and structured-output verification pending AWS OIDC role setup before marking ready

No release is included.