### PR TITLE
docs: align OpenAI and Anthropic guides with AG-UI

### DIFF
--- a/packages/anthropic/README.md
+++ b/packages/anthropic/README.md
@@ -15,129 +15,43 @@
 
 ## Getting Started
 
-### Installation
-
 ```sh
-npm install @hashbrownai/anthropic --save
+npm install @hashbrownai/anthropic @anthropic-ai/sdk @ag-ui/core @ag-ui/encoder --save
 ```
 
-You'll also need to install the Anthropic SDK as a peer dependency:
-
-```sh
-npm install @anthropic-ai/sdk --save
-```
-
-### Basic Usage
-
-Deploy an express server with a single `/chat` endpoint to use Hashbrown with Anthropic.
+Deploy an Express server with a `/run` endpoint to use Hashbrown with Anthropic.
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 ```
-
-### Advanced Usage with Custom Base URL
-
-```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-
-const stream = HashbrownAnthropic.stream.text({
-  apiKey: process.env.ANTHROPIC_API_KEY!,
-  baseURL: 'https://api.anthropic.com', // Optional custom base URL
-  request: {
-    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
-    system: 'You are a helpful assistant.',
-    messages: [
-      {
-        role: 'user',
-        content: 'Hello, how are you?',
-      },
-    ],
-    // Optional: Add tools for function calling
-    tools: [
-      {
-        name: 'get_weather',
-        description: 'Get the current weather for a location',
-        parameters: {
-          type: 'object',
-          properties: {
-            location: {
-              type: 'string',
-              description: 'The city and state, e.g. San Francisco, CA',
-            },
-          },
-          required: ['location'],
-        },
-      },
-    ],
-    toolChoice: 'auto',
-    // Optional: Add structured output schema
-    responseFormat: {
-      type: 'object',
-      properties: {
-        answer: { type: 'string' },
-        confidence: { type: 'number' },
-      },
-      required: ['answer'],
-    },
-  },
-  // Optional: Transform request options before sending to Anthropic
-  transformRequestOptions: (options) => {
-    // Modify options as needed
-    return {
-      ...options,
-      max_tokens: 1000, // Override max tokens
-    };
-  },
-});
-```
-
-## API Reference
-
-### `HashbrownAnthropic.stream.text(options)`
-
-Creates a streaming text completion using Anthropic's Claude models.
-
-#### Parameters
-
-- `options.apiKey` (string, required): Your Anthropic API key
-- `options.baseURL` (string, optional): Custom base URL for Anthropic API
-- `options.request` (Chat.Api.CompletionCreateParams, required): The completion request parameters
-- `options.transformRequestOptions` (function, optional): Function to modify request options before sending
-
-#### Returns
-
-An async iterable that yields `Uint8Array` chunks encoded with Hashbrown's frame protocol.
-
-## Supported Features
-
-- ✅ **Text Streaming**: Real-time streaming of text completions
-- ✅ **Tool Calling**: Function calling with automatic tool execution
-- ✅ **Structured Output**: JSON schema validation for responses
-- ✅ **System Messages**: Custom system prompts and instructions
-- ✅ **Message History**: Full conversation context support
-- ✅ **Error Handling**: Proper error propagation through the stream
-
-## Models
-
-The adapter supports all Anthropic Claude models. We currently recommend using
-`claude-haiku-4-5-20251001`, which is widely available for streaming and tool
-calling. Switch to newer releases by setting the `ANTHROPIC_MODEL` environment
-variable.
 
 ## Docs
 

--- a/packages/openai/README.md
+++ b/packages/openai/README.md
@@ -16,27 +16,40 @@
 ## Getting Started
 
 ```sh
-npm install @hashbrownai/openai --save
+npm install @hashbrownai/openai openai @ag-ui/core @ag-ui/encoder --save
 ```
 
-Deploy an express server with a single /chat endpoint to use Hashbrown with OpenAI.
+Deploy an Express server with a `/run` endpoint to use Hashbrown with OpenAI.
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 ```
 

--- a/www/analog/src/app/pages/docs/angular/platform/anthropic.md
+++ b/www/analog/src/app/pages/docs/angular/platform/anthropic.md
@@ -2,80 +2,93 @@
 title: 'Anthropic: Hashbrown Angular Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s Anthropic adapter streams Claude completions with tool use, thread persistence, and request transforms for Angular apps.'
+    content: 'Hashbrown’s Anthropic adapter maps AG-UI runs to the Claude Messages API and streams canonical AG-UI events.'
 ---
 
 # Anthropic
 
-First, install the Anthropic adapter (and the required SDK peer dependency):
+Install the Anthropic adapter, the official Anthropic SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/anthropic @anthropic-ai/sdk
+npm install @hashbrownai/anthropic @anthropic-ai/sdk @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s Anthropic adapter lets you **stream Claude chat completions** with support for tool use, request transforms, and optional thread persistence.
+`HashbrownAnthropic.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses Anthropic's streaming Messages API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownAnthropic.stream.text(options)`
+| Name                      | Type                                    | Description                                                                  |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | Anthropic API key.                                                           |
+| `baseURL`                 | `string`                                | _(Optional)_ Anthropic-compatible API base URL.                              |
+| `model`                   | `string`                                | Server-selected Anthropic model.                                             |
+| `input`                   | `AnthropicHashbrownRunAgentInput`       | AG-UI run input, including messages and tools.                               |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Anthropic request when the HTTP client disconnects. |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Messages API request.            |
 
-Streams a Claude completion as encoded frames. Handles content, tool calls, thread load/save signals, and errors; yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, tool results, and native structured output. Claude thinking, signatures, and redacted thinking become AG-UI reasoning records that can be sent back on continuation. Provider metadata and unsupported native events are preserved as AG-UI `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Anthropic native structured output on a model that supports it:
 
-| Name                      | Type                                        | Description                                                                                        |
-| ------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `apiKey`                  | `string`                                    | Your Anthropic API key.                                                                            |
-| `baseURL`                 | `string`                                    | _(Optional)_ Custom Anthropic API origin (self-hosted gateway, proxy, etc.).                       |
-| `request`                 | `Chat.Api.CompletionCreateParams`           | Chat request: model, messages, tools, toolChoice, system, threadId, operation, etc.                |
-| `transformRequestOptions` | `(params) => params \| Promise<params>`     | _(Optional)_ Modify the final Anthropic request before sending (e.g., tune `max_tokens`).          |
-| `loadThread`              | `(threadId) => Promise<Chat.Api.Message[]>` | _(Optional)_ Load a stored thread when `request.threadId` is present.                              |
-| `saveThread`              | `(thread, threadId?) => Promise<string>`    | _(Optional)_ Persist the merged thread after a run; returns the thread id to send back downstream. |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool` (tool results are serialized as Claude `tool_result` blocks).
-- **Tools:** Maps Hashbrown tool schemas to Claude tool definitions; streams `tool_use` blocks and arguments.
-- **Tool Choice:** Supports `auto`, `required` (mapped to Claude `any`), and `none`.
-- **Threading:** Optional `threadId` load/save flow with `thread-load-*` and `thread-save-*` frames for persistence.
-- **Streaming:** Text deltas and tool call deltas are framed as `Uint8Array` chunks; default `max_tokens` is 4096, override in `transformRequestOptions`.
-
-### How It Works
-
-- **Messages:** Hashbrown messages are converted to Claude’s Messages API (assistant text plus `tool_use` blocks; tool results become `tool_result` blocks on the user side).
-- **Tools:** Each tool’s JSON schema is sent as `input_schema`; tool outputs can be streamed via the special `output` tool when present.
-- **Tool Choice:** `toolChoice: 'required'` translates to Claude’s `{ type: 'any' }`; `auto` uses Claude’s auto-selection.
-- **Thread Persistence:** If `request.threadId` is set and `loadThread` is provided, the adapter loads, merges, and (optionally) hydrates the thread. When `saveThread` is provided, it emits save frames after generation to persist history.
-- **Error Handling:** Exceptions are emitted as error frames before termination.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -86,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -114,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownAnthropic.stream.text({
       apiKey: process.env.ANTHROPIC_API_KEY!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -143,31 +185,37 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
     },
   );
@@ -180,152 +228,37 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## Extended Thinking
 
-### Transform Request Options
-
-Use `transformRequestOptions` to adjust the Anthropic request before it is sent. Common tweaks include raising `max_tokens`, injecting a server-side system prompt, or logging.
-
-<hb-backend-code-example>
-
-<div backend="express">
+Enable provider-owned reasoning settings with `transformRequestOptions`. Hashbrown emits Claude thinking and redacted thinking as AG-UI reasoning events and preserves their signatures for subsequent requests.
 
 ```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        system: 'You are a helpful assistant.', // prepend server-side system prompt
-        max_tokens: 6000, // override default 4096
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownAnthropic.stream.text({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_tokens: 4096,
+    thinking: { type: 'enabled', budget_tokens: 1024 },
+  }),
 });
 ```
 
-</div>
+## Transform Request Options
 
-<div backend="fastify">
+Use `transformRequestOptions` for server-owned provider settings such as token limits, service tiers, or a server-side system instruction.
 
 ```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: request.body,
-    transformRequestOptions: (options) => ({
-      ...options,
-      system: 'You are a helpful assistant.',
-      max_tokens: 6000,
-    }),
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
+const stream = HashbrownAnthropic.stream.text({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_tokens: 2048,
+  }),
 });
 ```
 
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Response } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
-    const stream = HashbrownAnthropic.stream.text({
-      apiKey: process.env.ANTHROPIC_API_KEY!,
-      request: body,
-      transformRequestOptions: (options) => ({
-        ...options,
-        system: 'You are a helpful assistant.',
-        max_tokens: 6000,
-      }),
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: body,
-    transformRequestOptions: (options) => ({
-      ...options,
-      system: 'You are a helpful assistant.',
-      max_tokens: 6000,
-    }),
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    },
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
+[Learn more about transformRequestOptions](/docs/angular/concept/transform-request-options)

--- a/www/analog/src/app/pages/docs/angular/platform/openai.md
+++ b/www/analog/src/app/pages/docs/angular/platform/openai.md
@@ -2,77 +2,93 @@
 title: 'OpenAI: Hashbrown Angular Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s OpenAI adapter lets you stream chat completions from OpenAI’s GPT models, including support for function calling, response schemas, and request transforms.'
+    content: 'Hashbrown’s OpenAI adapter maps AG-UI runs to the OpenAI Chat Completions API and streams canonical AG-UI events.'
 ---
+
 # OpenAI
 
-First, install the OpenAI adapter package:
+Install the OpenAI adapter, the official OpenAI SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/openai
+npm install @hashbrownai/openai openai @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s OpenAI adapter lets you **stream chat completions** from OpenAI’s GPT models, including support for function calling, response schemas, and request transforms.
+`HashbrownOpenAI.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses OpenAI's streaming Chat Completions API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownOpenAI.stream.text(options)`
+| Name                      | Type                                    | Description                                                               |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | OpenAI API key.                                                           |
+| `baseURL`                 | `string`                                | _(Optional)_ OpenAI-compatible API base URL.                              |
+| `model`                   | `string`                                | Server-selected OpenAI model.                                             |
+| `input`                   | `OpenAIHashbrownRunAgentInput`          | AG-UI run input, including messages and tools.                            |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the OpenAI request when the HTTP client disconnects. |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Chat Completions request.     |
 
-Streams an OpenAI chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, and tool results. Text and tool calls become canonical AG-UI events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use OpenAI native JSON schema output:
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your OpenAI API Key.                                                           |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final OpenAI request before it is sent. |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Supports OpenAI function calling, including `toolCalls` and strict function schemas.
-- **Response Format:** Optionally specify a JSON schema for structured output (uses OpenAI’s `response_format` parameter).
-- **System Prompt:** Included as the first message if provided.
-- **Function Calling:** Handles OpenAI function calling modes and emits tool call frames.
-- **Streaming:** Each chunk is encoded into a resilient streaming format
-
-### How It Works
-
-- **Messages:** Translated to OpenAI's message format, supporting all roles and tool calls.
-- **Tools/Functions:** Tools are passed as OpenAI function definitions, using your JSON schemas as `parameters`.
-- **Response Format:** Pass a JSON schema in `responseFormat` for OpenAI to validate the model output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -83,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -111,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownOpenAI.stream.text({
       apiKey: process.env.OPENAI_API_KEY!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -140,33 +185,39 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
-    }
+    },
   );
 });
 
@@ -177,193 +228,20 @@ export default app;
 
 </hb-backend-code-example>
 
+## Transform Request Options
 
-
----
-
----
-
-### Transform Request Options
-
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to OpenAI. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
-
-<hb-backend-code-example>
-
-<div backend="express">
+`transformRequestOptions` receives the final OpenAI SDK request after AG-UI input has been mapped. Use it for server-owned provider settings.
 
 ```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownOpenAI.stream.text({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_completion_tokens: 2048,
+  }),
 });
 ```
-
-</div>
-
-<div backend="fastify">
-
-```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
-});
-```
-
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownOpenAI.stream.text({
-      apiKey: process.env.OPENAI_API_KEY!,
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust temperature based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
-    },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/angular/concept/transform-request-options)
-
----
-
-### Advanced: Tools, Function Calling, and Response Schema
-
-- **Tools:** Add tools using OpenAI-style function specs (name, description, parameters).
-- **Function Calling:** Supported via `toolChoice` (`auto`, `required`, `none`, etc.).
-- **Response Format:** Pass a JSON schema in `responseFormat` for OpenAI to return validated structured output.
-

--- a/www/analog/src/app/pages/docs/react/platform/anthropic.md
+++ b/www/analog/src/app/pages/docs/react/platform/anthropic.md
@@ -2,80 +2,93 @@
 title: 'Anthropic: Hashbrown React Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s Anthropic adapter streams Claude completions with tool use, thread persistence, and request transforms for React apps.'
+    content: 'Hashbrown’s Anthropic adapter maps AG-UI runs to the Claude Messages API and streams canonical AG-UI events.'
 ---
 
 # Anthropic
 
-First, install the Anthropic adapter (and the required SDK peer dependency):
+Install the Anthropic adapter, the official Anthropic SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/anthropic @anthropic-ai/sdk
+npm install @hashbrownai/anthropic @anthropic-ai/sdk @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s Anthropic adapter lets you **stream Claude chat completions** with support for tool use, request transforms, and optional thread persistence.
+`HashbrownAnthropic.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses Anthropic's streaming Messages API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownAnthropic.stream.text(options)`
+| Name                      | Type                                    | Description                                                                  |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | Anthropic API key.                                                           |
+| `baseURL`                 | `string`                                | _(Optional)_ Anthropic-compatible API base URL.                              |
+| `model`                   | `string`                                | Server-selected Anthropic model.                                             |
+| `input`                   | `AnthropicHashbrownRunAgentInput`       | AG-UI run input, including messages and tools.                               |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Anthropic request when the HTTP client disconnects. |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Messages API request.            |
 
-Streams a Claude completion as encoded frames. Handles content, tool calls, thread load/save signals, and errors; yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, tool results, and native structured output. Claude thinking, signatures, and redacted thinking become AG-UI reasoning records that can be sent back on continuation. Provider metadata and unsupported native events are preserved as AG-UI `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use Anthropic native structured output on a model that supports it:
 
-| Name                      | Type                                        | Description                                                                                        |
-| ------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `apiKey`                  | `string`                                    | Your Anthropic API key.                                                                            |
-| `baseURL`                 | `string`                                    | _(Optional)_ Custom Anthropic API origin (self-hosted gateway, proxy, etc.).                       |
-| `request`                 | `Chat.Api.CompletionCreateParams`           | Chat request: model, messages, tools, toolChoice, system, threadId, operation, etc.                |
-| `transformRequestOptions` | `(params) => params \| Promise<params>`     | _(Optional)_ Modify the final Anthropic request before sending (e.g., tune `max_tokens`).          |
-| `loadThread`              | `(threadId) => Promise<Chat.Api.Message[]>` | _(Optional)_ Load a stored thread when `request.threadId` is present.                              |
-| `saveThread`              | `(thread, threadId?) => Promise<string>`    | _(Optional)_ Persist the merged thread after a run; returns the thread id to send back downstream. |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool` (tool results are serialized as Claude `tool_result` blocks).
-- **Tools:** Maps Hashbrown tool schemas to Claude tool definitions; streams `tool_use` blocks and arguments.
-- **Tool Choice:** Supports `auto`, `required` (mapped to Claude `any`), and `none`.
-- **Threading:** Optional `threadId` load/save flow with `thread-load-*` and `thread-save-*` frames for persistence.
-- **Streaming:** Text deltas and tool call deltas are framed as `Uint8Array` chunks; default `max_tokens` is 4096, override in `transformRequestOptions`.
-
-### How It Works
-
-- **Messages:** Hashbrown messages are converted to Claude’s Messages API (assistant text plus `tool_use` blocks; tool results become `tool_result` blocks on the user side).
-- **Tools:** Each tool’s JSON schema is sent as `input_schema`; tool outputs can be streamed via the special `output` tool when present.
-- **Tool Choice:** `toolChoice: 'required'` translates to Claude’s `{ type: 'any' }`; `auto` uses Claude’s auto-selection.
-- **Thread Persistence:** If `request.threadId` is set and `loadThread` is provided, the adapter loads, merges, and (optionally) hydrates the thread. When `saveThread` is provided, it emits save frames after generation to persist history.
-- **Error Handling:** Exceptions are emitted as error frames before termination.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -86,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -114,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownAnthropic.stream.text({
       apiKey: process.env.ANTHROPIC_API_KEY!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -143,31 +185,37 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownAnthropic } from '@hashbrownai/anthropic';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownAnthropic.stream.text({
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
     },
   );
@@ -180,152 +228,37 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## Extended Thinking
 
-### Transform Request Options
-
-Use `transformRequestOptions` to adjust the Anthropic request before it is sent. Common tweaks include raising `max_tokens`, injecting a server-side system prompt, or logging.
-
-<hb-backend-code-example>
-
-<div backend="express">
+Enable provider-owned reasoning settings with `transformRequestOptions`. Hashbrown emits Claude thinking and redacted thinking as AG-UI reasoning events and preserves their signatures for subsequent requests.
 
 ```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        system: 'You are a helpful assistant.', // prepend server-side system prompt
-        max_tokens: 6000, // override default 4096
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownAnthropic.stream.text({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_tokens: 4096,
+    thinking: { type: 'enabled', budget_tokens: 1024 },
+  }),
 });
 ```
 
-</div>
+## Transform Request Options
 
-<div backend="fastify">
+Use `transformRequestOptions` for server-owned provider settings such as token limits, service tiers, or a server-side system instruction.
 
 ```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: request.body,
-    transformRequestOptions: (options) => ({
-      ...options,
-      system: 'You are a helpful assistant.',
-      max_tokens: 6000,
-    }),
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
+const stream = HashbrownAnthropic.stream.text({
+  apiKey: process.env.ANTHROPIC_API_KEY!,
+  model: process.env.ANTHROPIC_MODEL ?? 'claude-haiku-4-5-20251001',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_tokens: 2048,
+  }),
 });
 ```
 
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Response } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
-    const stream = HashbrownAnthropic.stream.text({
-      apiKey: process.env.ANTHROPIC_API_KEY!,
-      request: body,
-      transformRequestOptions: (options) => ({
-        ...options,
-        system: 'You are a helpful assistant.',
-        max_tokens: 6000,
-      }),
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownAnthropic } from '@hashbrownai/anthropic';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
-  const stream = HashbrownAnthropic.stream.text({
-    apiKey: process.env.ANTHROPIC_API_KEY!,
-    request: body,
-    transformRequestOptions: (options) => ({
-      ...options,
-      system: 'You are a helpful assistant.',
-      max_tokens: 6000,
-    }),
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    },
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
+[Learn more about transformRequestOptions](/docs/react/concept/transform-request-options)

--- a/www/analog/src/app/pages/docs/react/platform/openai.md
+++ b/www/analog/src/app/pages/docs/react/platform/openai.md
@@ -2,78 +2,93 @@
 title: 'OpenAI: Hashbrown React Docs'
 meta:
   - name: description
-    content: 'Hashbrown’s OpenAI adapter lets you stream chat completions from OpenAI’s GPT models, including support for tool calling, response schemas, and request transforms.'
+    content: 'Hashbrown’s OpenAI adapter maps AG-UI runs to the OpenAI Chat Completions API and streams canonical AG-UI events.'
 ---
 
 # OpenAI
 
-First, install the OpenAI adapter package:
+Install the OpenAI adapter, the official OpenAI SDK, and the AG-UI SSE encoder:
 
 ```sh
-npm install @hashbrownai/openai
+npm install @hashbrownai/openai openai @ag-ui/core @ag-ui/encoder
 ```
 
 ## Streaming Text Responses
 
-Hashbrown’s OpenAI adapter lets you **stream chat completions** from OpenAI’s GPT models, including support for tool calling, response schemas, and request transforms.
+`HashbrownOpenAI.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses OpenAI's streaming Chat Completions API. Encode its events as AG-UI SSE at your HTTP boundary.
+
+The model is server configuration and is not read from the client run input.
 
 ### API Reference
 
-#### `HashbrownOpenAI.stream.text(options)`
+| Name                      | Type                                    | Description                                                               |
+| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| `apiKey`                  | `string`                                | OpenAI API key.                                                           |
+| `baseURL`                 | `string`                                | _(Optional)_ OpenAI-compatible API base URL.                              |
+| `model`                   | `string`                                | Server-selected OpenAI model.                                             |
+| `input`                   | `OpenAIHashbrownRunAgentInput`          | AG-UI run input, including messages and tools.                            |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the OpenAI request when the HTTP client disconnects. |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Chat Completions request.     |
 
-Streams an OpenAI chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+The adapter maps system and developer instructions, message history, tool definitions, and tool results. Text and tool calls become canonical AG-UI events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Options:**
+Set `input.hashbrown.responseSchema` to use OpenAI native JSON schema output:
 
-| Name                      | Type                                    | Description                                                                    |
-| ------------------------- | --------------------------------------- | ------------------------------------------------------------------------------ |
-| `apiKey`                  | `string`                                | Your OpenAI API Key.                                                           |
-| `request`                 | `Chat.Api.CompletionCreateParams`       | The chat request: model, messages, tools, system, responseFormat, etc.         |
-| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transform or override the final OpenAI request before it is sent. |
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+      additionalProperties: false,
+    },
+  },
+};
+```
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Supports OpenAI tool calling, including `toolCalls` and strict function schemas.
-- **Response Format:** Optionally specify a JSON schema for structured output (uses OpenAI’s `response_format` parameter).
-- **System Prompt:** Included as the first message if provided.
-- **Tool Calling:** Handles OpenAI tool calling modes and emits tool call frames.
-- **Streaming:** Each chunk is encoded into a resilient streaming format
-
-### How It Works
-
-- **Messages:** Translated to OpenAI’s message format, supporting all roles and tool calls.
-- **Tools/Functions:** Tools are passed as OpenAI function definitions, using your JSON schemas as `parameters`.
-- **Response Format:** Pass a JSON schema in `responseFormat` for OpenAI to validate the model output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
-### Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -84,24 +99,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -112,26 +139,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownOpenAI.stream.text({
       apiKey: process.env.OPENAI_API_KEY!,
-      request: body, // must be Chat.Api.CompletionCreateParams
+      model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -141,31 +185,37 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownOpenAI.stream.text({
     apiKey: process.env.OPENAI_API_KEY!,
-    request: body, // must be Chat.Api.CompletionCreateParams
+    model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
     },
   );
@@ -178,190 +228,20 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## Transform Request Options
 
----
-
-### Transform Request Options
-
-The `transformRequestOptions` parameter allows you to intercept and modify the request before it's sent to OpenAI. This is useful for server-side prompts, message filtering, logging, and dynamic configuration.
-
-<hb-backend-code-example>
-
-<div backend="express">
+`transformRequestOptions` receives the final OpenAI SDK request after AG-UI input has been mapped. Use it for server-owned provider settings.
 
 ```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import express from 'express';
-
-const app = express();
-app.use(express.json());
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownOpenAI.stream.text({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: process.env.OPENAI_MODEL ?? 'gpt-5-nano',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    max_completion_tokens: 2048,
+  }),
 });
 ```
-
-</div>
-
-<div backend="fastify">
-
-```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
-});
-```
-
-</div>
-
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownOpenAI.stream.text({
-      apiKey: process.env.OPENAI_API_KEY!,
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust temperature based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
-
-```ts
-import { HashbrownOpenAI } from '@hashbrownai/openai';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-
-  const stream = HashbrownOpenAI.stream.text({
-    apiKey: process.env.OPENAI_API_KEY!,
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust temperature based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
-    },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    },
-  );
-});
-```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/react/concept/transform-request-options)
-
----
-
-### Advanced: Tools and Response Schema
-
-- **Tools:** Add tools using OpenAI-style function specs (name, description, parameters).
-- **Tool Calling:** Supported via `toolChoice` (`auto`, `required`, `none`, etc.).
-- **Response Format:** Pass a JSON schema in `responseFormat` for OpenAI to return validated structured output.


### PR DESCRIPTION
## Summary

- update the OpenAI and Anthropic package READMEs for the AG-UI `/run` SSE transport
- replace legacy frame examples in the React and Angular provider guides
- document server-owned model configuration, native structured output, request transforms, cancellation, and Anthropic reasoning records
- retain Express, Fastify, NestJS, and Hono integration examples

## Verification

- `npx nx test www --skip-nx-cache`
- `npx nx build www --skip-nx-cache`
- `npx nx build openai --skip-nx-cache`
- `npx nx build anthropic --skip-nx-cache`
- legacy transport and route scan across all six changed files
- `git diff --check`
