### PR TITLE
feat(ollama): migrate provider to AG-UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "marked-shiki": "^1.2.1",
         "mermaid": "^10.9.6",
         "ngx-markdown": "22.0.0",
-        "ollama": "^0.5.18",
+        "ollama": "0.6.3",
         "quickjs-emscripten-core": "0.31.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -42222,9 +42222,9 @@
       "license": "MIT"
     },
     "node_modules/ollama": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.18.tgz",
-      "integrity": "sha512-lTFqTf9bo7Cd3hpF6CviBe/DEhewjoZYd9N/uCe7O20qYTvGqrNOFOBDj3lbZgFWHUgDv5EeyusYxsZSLS8nvg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
+      "integrity": "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==",
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.20"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "marked-shiki": "^1.2.1",
     "mermaid": "^10.9.6",
     "ngx-markdown": "22.0.0",
-    "ollama": "^0.5.18",
+    "ollama": "0.6.3",
     "quickjs-emscripten-core": "0.31.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/packages/ollama/README.md
+++ b/packages/ollama/README.md
@@ -15,8 +15,49 @@
 
 ## Getting Started
 
+Install the Hashbrown adapter, official Ollama SDK, and AG-UI packages:
+
 ```sh
-npm install @hashbrownai/ollama --save
+npm install @hashbrownai/ollama ollama @ag-ui/core @ag-ui/encoder
+```
+
+`HashbrownOllama.stream.text()` maps an AG-UI run to Ollama and returns canonical AG-UI events. Encode the events as SSE at your HTTP boundary:
+
+```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { HashbrownOllama } from '@hashbrownai/ollama';
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
+  const stream = HashbrownOllama.stream.text({
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
+  });
+  const encoder = new EventEncoder();
+
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
+
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
+  }
+
+  if (!res.writableEnded) {
+    res.end();
+  }
+});
+
+app.listen(3000);
 ```
 
 ## Docs

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -12,11 +12,11 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "dependencies": {
+    "@ag-ui/core": "0.0.59",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "ollama": "^0.5.16",
-    "@hashbrownai/core": "0.5.0"
+    "ollama": "0.6.3"
   },
   "sideEffects": false,
   "publishConfig": {
@@ -30,6 +30,6 @@
     "typescript"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/ollama/src/index.spec.ts
+++ b/packages/ollama/src/index.spec.ts
@@ -1,3 +1,9 @@
-test('it works', () => {
-  expect(true).toBe(true);
+import type { AGUIEvent } from '@ag-ui/core';
+import { HashbrownOllama, type OllamaTextStreamOptions } from './index';
+
+test('exports the Ollama AG-UI stream contract', () => {
+  const text: (options: OllamaTextStreamOptions) => AsyncIterable<AGUIEvent> =
+    HashbrownOllama.stream.text;
+
+  expect(text).toBe(HashbrownOllama.stream.text);
 });

--- a/packages/ollama/src/index.ts
+++ b/packages/ollama/src/index.ts
@@ -1,1 +1,25 @@
-export * as HashbrownOllama from './stream';
+import type { AGUIEvent } from '@ag-ui/core';
+import { text } from './stream/text.fn';
+import type { OllamaTextStreamOptions } from './stream/types';
+
+export type {
+  OllamaHashbrownRunAgentInput,
+  OllamaTextStreamOptions,
+} from './stream/types';
+
+/**
+ * Hashbrown adapter for Ollama models.
+ *
+ * @public
+ */
+export const HashbrownOllama: {
+  readonly stream: {
+    readonly text: (
+      options: OllamaTextStreamOptions,
+    ) => AsyncIterable<AGUIEvent>;
+  };
+} = {
+  stream: {
+    text,
+  },
+};

--- a/packages/ollama/src/integration.spec.ts
+++ b/packages/ollama/src/integration.spec.ts
@@ -1,7 +1,7 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { resolve } from 'node:path';
-import type { Chat, Frame, GenerationChunkFrame } from '@hashbrownai/core';
-import { runProviderTextWithAimock } from '@hashbrownai/testing/aimock';
-import { HashbrownOllama } from './index';
+import { runProviderAGUIWithAimock } from '@hashbrownai/testing/aimock';
+import { HashbrownOllama, type OllamaHashbrownRunAgentInput } from './index';
 
 const OLLAMA_MODEL = 'gpt-oss:120b';
 
@@ -9,177 +9,286 @@ function fixturePath(name: string): string {
   return resolve(__dirname, '../../../tools/testing/aimock/fixtures', name);
 }
 
-function generationChunks(frames: Frame[]): GenerationChunkFrame[] {
-  return frames.filter(
-    (frame): frame is GenerationChunkFrame => frame.type === 'generation-chunk',
-  );
-}
-
-function streamedContent(frames: Frame[]): string {
-  return generationChunks(frames)
-    .map((frame) => frame.chunk.choices[0]?.delta.content ?? '')
-    .join('');
-}
-
-function baseRequest(userMessage: string): Chat.Api.CompletionCreateParams {
+function baseInput(
+  userMessage: string,
+  runId = 'run-ollama',
+): OllamaHashbrownRunAgentInput {
   return {
-    operation: 'generate',
-    model: OLLAMA_MODEL,
-    system: 'You are a deterministic test assistant.',
-    messages: [{ role: 'user', content: userMessage }],
+    threadId: 'thread-ollama',
+    runId,
+    messages: [{ id: `${runId}:user`, role: 'user', content: userMessage }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
   };
 }
 
-test('Ollama text streaming emits Hashbrown generation frames', async () => {
-  const frames = await runProviderTextWithAimock({
+function textContent(events: AGUIEvent[]): string {
+  return events
+    .filter(
+      (
+        event,
+      ): event is Extract<
+        AGUIEvent,
+        { type: EventType.TEXT_MESSAGE_CONTENT }
+      > => event.type === EventType.TEXT_MESSAGE_CONTENT,
+    )
+    .map((event) => event.delta)
+    .join('');
+}
+
+test('Ollama text streaming emits canonical AG-UI events', async () => {
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: baseRequest('say hi briefly'),
+        model: OLLAMA_MODEL,
+        input: baseInput('say hi briefly'),
+        signal,
       }),
   });
 
-  expect(frames[0].type).toBe('generation-start');
-  expect(frames.at(-1)?.type).toBe('generation-finish');
-  expect(streamedContent(frames)).toBe('Hello from aimock.');
+  expect(events.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+    EventType.RAW,
+    EventType.TEXT_MESSAGE_END,
+    EventType.RUN_FINISHED,
+  ]);
+  expect(textContent(events)).toBe('Hello from aimock.');
 });
 
-test('Ollama streaming preserves chunked content across multiple frames', async () => {
-  const frames = await runProviderTextWithAimock({
+test('Ollama preserves content across deterministic stream chunks', async () => {
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('streaming.json'),
-    createStream: (aimock) =>
+    chunkSize: 8,
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: baseRequest('stream deterministic text'),
+        model: OLLAMA_MODEL,
+        input: baseInput('stream deterministic text'),
+        signal,
       }),
   });
+  const contentEvents = events.filter(
+    (event) => event.type === EventType.TEXT_MESSAGE_CONTENT,
+  );
 
-  expect(generationChunks(frames).length).toBeGreaterThan(1);
-  expect(streamedContent(frames)).toContain(
+  expect(contentEvents.length).toBeGreaterThan(1);
+  expect(textContent(events)).toContain(
     'Streaming fixture response with enough text',
   );
 });
 
-test('Ollama tool calling emits tool call deltas', async () => {
-  const frames = await runProviderTextWithAimock({
+test('Ollama tool calling emits canonical tool-call events', async () => {
+  const input = baseInput('call the lookup tool');
+  input.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
+
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('tool-call.json'),
-    createStream: (aimock) =>
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: {
-          ...baseRequest('call the lookup tool'),
-          tools: [
-            {
-              name: 'lookup',
-              description: 'Lookup deterministic fixture data.',
-              parameters: {
-                type: 'object',
-                properties: {
-                  query: { type: 'string' },
-                },
-                required: ['query'],
-              },
-            },
-          ],
-          toolChoice: 'required',
-        },
+        model: OLLAMA_MODEL,
+        input,
+        signal,
       }),
   });
-
-  const toolCallDeltas = generationChunks(frames).flatMap(
-    (frame) => frame.chunk.choices[0]?.delta.toolCalls ?? [],
+  const start = events.find(
+    (event) => event.type === EventType.TOOL_CALL_START,
   );
+  const args = events.find((event) => event.type === EventType.TOOL_CALL_ARGS);
 
-  expect(toolCallDeltas.some((toolCall) => toolCall.id)).toBe(true);
-  expect(
-    toolCallDeltas.some((toolCall) => toolCall.function?.name === 'lookup'),
-  ).toBe(true);
-  expect(
-    toolCallDeltas.find((toolCall) => toolCall.function?.name === 'lookup')
-      ?.function?.arguments as unknown,
-  ).toEqual({ query: 'hashbrown' });
+  expect(start).toEqual(
+    expect.objectContaining({
+      toolCallName: 'lookup',
+      parentMessageId: 'run-ollama:assistant',
+    }),
+  );
+  expect(args).toEqual(
+    expect.objectContaining({ delta: '{"query":"hashbrown"}' }),
+  );
+  expect(events.some((event) => event.type === EventType.TOOL_CALL_END)).toBe(
+    true,
+  );
 });
 
-test('Ollama structured output fixture emits JSON text content', async () => {
-  const frames = await runProviderTextWithAimock({
+test('Ollama structured output streams JSON text through AG-UI', async () => {
+  const input = baseInput('return structured output');
+  input.hashbrown = {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string' },
+        ok: { type: 'boolean' },
+      },
+      required: ['text', 'ok'],
+    },
+  };
+
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('structured-output.json'),
-    createStream: (aimock) =>
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: {
-          ...baseRequest('return structured output'),
-          responseFormat: {
-            type: 'object',
-            properties: {
-              text: { type: 'string' },
-              ok: { type: 'boolean' },
-            },
-            required: ['text', 'ok'],
-          },
-        },
+        model: OLLAMA_MODEL,
+        input,
+        signal,
       }),
   });
 
-  expect(JSON.parse(streamedContent(frames))).toEqual({
+  expect(JSON.parse(textContent(events))).toEqual({
     text: 'Hello from structured aimock.',
     ok: true,
   });
 });
 
-test('Ollama provider errors emit generation-error frames', async () => {
-  const frames = await runProviderTextWithAimock({
+test('Ollama provider errors emit RUN_ERROR without terminal events', async () => {
+  const events = await runProviderAGUIWithAimock({
     fixturePath: fixturePath('error.json'),
-    createStream: (aimock) =>
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: baseRequest('return provider error'),
+        model: OLLAMA_MODEL,
+        input: baseInput('return provider error'),
+        signal,
       }),
   });
 
-  expect(frames).toEqual([
+  expect(events).toEqual([
+    expect.objectContaining({ type: EventType.RUN_STARTED }),
     expect.objectContaining({
-      type: 'generation-error',
-      error: expect.any(String),
+      type: EventType.RUN_ERROR,
+      message: expect.any(String),
     }),
   ]);
 });
 
-test('Ollama thread persistence wraps generation with thread frames', async () => {
-  const savedThreads: Chat.Api.Message[][] = [];
-  const frames = await runProviderTextWithAimock({
-    fixturePath: fixturePath('text.json'),
-    createStream: (aimock) =>
+test('Ollama cancellation stops before message and run completion', async () => {
+  const events = await runProviderAGUIWithAimock({
+    fixturePath: fixturePath('streaming.json'),
+    chunkSize: 1,
+    createStream: (aimock, signal) =>
       HashbrownOllama.stream.text({
         host: aimock.ollamaHost,
-        request: {
-          ...baseRequest('say hi briefly'),
-          threadId: 'ollama-thread',
-        },
-        loadThread: async () => [
-          {
-            role: 'user',
-            content: 'previous message',
+        model: OLLAMA_MODEL,
+        input: baseInput('stream deterministic text'),
+        signal,
+      }),
+    onEvent: (event, controls) => {
+      if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+        controls.abort();
+      }
+    },
+  });
+
+  expect(
+    events.some((event) => event.type === EventType.TEXT_MESSAGE_CONTENT),
+  ).toBe(true);
+  expect(
+    events.some((event) => event.type === EventType.TEXT_MESSAGE_END),
+  ).toBe(false);
+  expect(events.some((event) => event.type === EventType.RUN_FINISHED)).toBe(
+    false,
+  );
+  expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+    false,
+  );
+});
+
+test('Ollama sends tool calls and named tool results back on continuation', async () => {
+  const fixture = fixturePath('ollama/tool-continuation.json');
+  const firstInput = baseInput(
+    'continue after the lookup',
+    'run-ollama-tool-1',
+  );
+  firstInput.tools = [
+    {
+      name: 'lookup',
+      description: 'Lookup deterministic fixture data.',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  ];
+  const firstEvents = await runProviderAGUIWithAimock({
+    fixturePath: fixture,
+    createStream: (aimock, signal) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        model: OLLAMA_MODEL,
+        input: firstInput,
+        signal,
+      }),
+  });
+  const toolStart = firstEvents.find(
+    (event): event is Extract<AGUIEvent, { type: EventType.TOOL_CALL_START }> =>
+      event.type === EventType.TOOL_CALL_START,
+  );
+  const toolArgs = firstEvents.find(
+    (event): event is Extract<AGUIEvent, { type: EventType.TOOL_CALL_ARGS }> =>
+      event.type === EventType.TOOL_CALL_ARGS,
+  );
+  if (!toolStart || !toolArgs) {
+    throw new Error('Expected the first Ollama run to emit a tool call');
+  }
+  const secondInput = baseInput(
+    'continue after the lookup',
+    'run-ollama-tool-2',
+  );
+  secondInput.tools = firstInput.tools;
+  secondInput.messages.push(
+    {
+      id: toolStart.parentMessageId ?? 'run-ollama-tool-1:assistant',
+      role: 'assistant',
+      content: '',
+      toolCalls: [
+        {
+          id: toolStart.toolCallId,
+          type: 'function',
+          function: {
+            name: toolStart.toolCallName,
+            arguments: toolArgs.delta,
           },
-        ],
-        saveThread: async (thread) => {
-          savedThreads.push(thread);
-          return 'ollama-thread';
         },
+      ],
+    },
+    {
+      id: 'tool-result-ollama',
+      role: 'tool',
+      toolCallId: toolStart.toolCallId,
+      content: '{"result":"fixture"}',
+    },
+  );
+
+  const secondEvents = await runProviderAGUIWithAimock({
+    fixturePath: fixture,
+    createStream: (aimock, signal) =>
+      HashbrownOllama.stream.text({
+        host: aimock.ollamaHost,
+        model: OLLAMA_MODEL,
+        input: secondInput,
+        signal,
       }),
   });
 
-  expect(frames.map((frame) => frame.type)).toEqual([
-    'thread-load-start',
-    'thread-load-success',
-    'generation-start',
-    ...generationChunks(frames).map((frame) => frame.type),
-    'generation-finish',
-    'thread-save-start',
-    'thread-save-success',
-  ]);
-  expect(savedThreads).toHaveLength(1);
-  expect(savedThreads[0].map((message) => message.content)).toContain(
-    'Hello from aimock.',
-  );
+  expect(textContent(secondEvents)).toBe('Ollama continuation complete.');
+  expect(
+    secondEvents.some((event) => event.type === EventType.RUN_FINISHED),
+  ).toBe(true);
 });

--- a/packages/ollama/src/stream/index.ts
+++ b/packages/ollama/src/stream/index.ts
@@ -1,1 +1,5 @@
-export * as stream from './text.fn';
+export { text } from './text.fn';
+export type {
+  OllamaHashbrownRunAgentInput,
+  OllamaTextStreamOptions,
+} from './types';

--- a/packages/ollama/src/stream/ollama-events.spec.ts
+++ b/packages/ollama/src/stream/ollama-events.spec.ts
@@ -1,0 +1,276 @@
+import { EventType } from '@ag-ui/core';
+import type { ChatResponse } from 'ollama';
+import { mapOllamaEvents } from './ollama-events';
+
+function createChunk(
+  overrides: Omit<Partial<ChatResponse>, 'message'> & {
+    message?: Partial<ChatResponse['message']>;
+  } = {},
+): ChatResponse {
+  const { message = {}, ...response } = overrides;
+
+  return {
+    model: 'qwen3',
+    created_at: new Date('2026-08-31T00:00:00.000Z'),
+    message: {
+      ...message,
+      role: message.role ?? 'assistant',
+      content: message.content ?? '',
+    },
+    done: false,
+    done_reason: '',
+    total_duration: 0,
+    load_duration: 0,
+    prompt_eval_count: 0,
+    prompt_eval_duration: 0,
+    eval_count: 0,
+    eval_duration: 0,
+    ...response,
+  };
+}
+
+async function* chunks(values: ChatResponse[]): AsyncIterable<ChatResponse> {
+  for (const value of values) {
+    yield value;
+  }
+}
+
+async function collect(values: ChatResponse[]) {
+  return Array.fromAsync(
+    mapOllamaEvents({
+      events: chunks(values),
+      messageId: 'run-ollama:assistant',
+    }),
+  );
+}
+
+test('maps text chunks and preserves terminal metrics as a raw event', async () => {
+  const terminal = createChunk({
+    done: true,
+    done_reason: 'stop',
+    total_duration: 120,
+    eval_count: 4,
+  });
+
+  const result = await collect([
+    createChunk({ message: { content: 'Hello ' } }),
+    createChunk({ message: { content: 'world.' } }),
+    terminal,
+  ]);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-ollama:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-ollama:assistant',
+      delta: 'Hello ',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-ollama:assistant',
+      delta: 'world.',
+    },
+    {
+      type: EventType.RAW,
+      source: 'ollama',
+      event: terminal,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-ollama:assistant',
+    },
+  ]);
+});
+
+test('maps thinking to an Ollama reasoning record before text', async () => {
+  const result = await collect([
+    createChunk({ message: { thinking: 'I should reason. ' } }),
+    createChunk({
+      message: { thinking: 'Then answer.', content: 'The answer.' },
+    }),
+  ]);
+
+  expect(result).toEqual([
+    {
+      type: EventType.REASONING_MESSAGE_START,
+      messageId: 'run-ollama:assistant:reasoning:0',
+      role: 'reasoning',
+      metadata: { ollama: { thinking: true } },
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: 'run-ollama:assistant:reasoning:0',
+      delta: 'I should reason. ',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_CONTENT,
+      messageId: 'run-ollama:assistant:reasoning:0',
+      delta: 'Then answer.',
+    },
+    {
+      type: EventType.REASONING_MESSAGE_END,
+      messageId: 'run-ollama:assistant:reasoning:0',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: 'run-ollama:assistant',
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_CONTENT,
+      messageId: 'run-ollama:assistant',
+      delta: 'The answer.',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: 'run-ollama:assistant',
+    },
+  ]);
+});
+
+test('maps multiple Ollama tool calls with deterministic AG-UI IDs', async () => {
+  const result = await collect([
+    createChunk({
+      message: {
+        tool_calls: [
+          { function: { name: 'lookup', arguments: { query: 'one' } } },
+          { function: { name: 'lookup', arguments: { query: 'two' } } },
+        ],
+      },
+    }),
+  ]);
+
+  expect(result).toEqual([
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'run-ollama:assistant:tool:0',
+      toolCallName: 'lookup',
+      parentMessageId: 'run-ollama:assistant',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'run-ollama:assistant:tool:0',
+      delta: '{"query":"one"}',
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: 'run-ollama:assistant:tool:0',
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: 'run-ollama:assistant:tool:1',
+      toolCallName: 'lookup',
+      parentMessageId: 'run-ollama:assistant',
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: 'run-ollama:assistant:tool:1',
+      delta: '{"query":"two"}',
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: 'run-ollama:assistant:tool:1',
+    },
+  ]);
+});
+
+test('preserves nonterminal log probabilities as a raw event', async () => {
+  const native = createChunk({
+    logprobs: [{ token: 'Hello', logprob: -0.1 }],
+  });
+
+  const result = await collect([native]);
+
+  expect(result).toEqual([
+    {
+      type: EventType.RAW,
+      source: 'ollama',
+      event: native,
+    },
+  ]);
+});
+
+test('rejects malformed Ollama tool calls', async () => {
+  const malformed = createChunk({
+    message: {
+      tool_calls: [
+        { function: { name: '', arguments: { query: 'hashbrown' } } },
+      ],
+    },
+  });
+
+  await expect(collect([malformed])).rejects.toThrow(
+    'Ollama returned a tool call without a name',
+  );
+});
+
+test('aborts and closes the provider iterator when the signal is cancelled', async () => {
+  const abort = jest.fn();
+  const close = jest.fn().mockResolvedValue({ done: true, value: undefined });
+  let nextCount = 0;
+  const provider = {
+    abort,
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          nextCount += 1;
+          if (nextCount === 1) {
+            return Promise.resolve({
+              done: false as const,
+              value: createChunk({ message: { content: 'Hello' } }),
+            });
+          }
+          return new Promise<IteratorResult<ChatResponse>>(() => undefined);
+        },
+        return: close,
+      };
+    },
+  };
+  const controller = new AbortController();
+  const iterator = mapOllamaEvents({
+    events: provider,
+    messageId: 'run-ollama:assistant',
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  await iterator.next();
+  const pending = iterator.next();
+  controller.abort();
+  const result = await pending;
+
+  expect(result.done).toBe(true);
+  expect(abort).toHaveBeenCalledTimes(1);
+  expect(close).toHaveBeenCalledTimes(1);
+});
+
+test('aborts and closes the provider iterator when the consumer returns early', async () => {
+  const abort = jest.fn();
+  const close = jest.fn().mockResolvedValue({ done: true, value: undefined });
+  const provider = {
+    abort,
+    [Symbol.asyncIterator]() {
+      return {
+        next: jest.fn().mockResolvedValue({
+          done: false,
+          value: createChunk({ message: { content: 'Hello' } }),
+        }),
+        return: close,
+      };
+    },
+  };
+  const iterator = mapOllamaEvents({
+    events: provider,
+    messageId: 'run-ollama:assistant',
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  await iterator.return?.();
+
+  expect(abort).toHaveBeenCalledTimes(1);
+  expect(close).toHaveBeenCalledTimes(1);
+});

--- a/packages/ollama/src/stream/ollama-events.ts
+++ b/packages/ollama/src/stream/ollama-events.ts
@@ -1,0 +1,267 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type { ChatResponse } from 'ollama';
+
+const ABORTED = Symbol('aborted');
+
+interface AbortableOllamaStream extends AsyncIterable<ChatResponse> {
+  abort?: () => void;
+}
+
+/**
+ * Inputs for mapping Ollama response chunks to canonical AG-UI events.
+ *
+ * @internal
+ */
+export interface MapOllamaEventsOptions {
+  /** Ollama response stream. */
+  events: AbortableOllamaStream;
+  /** Stable AG-UI assistant message identifier. */
+  messageId: string;
+  /** Optional run cancellation signal. */
+  signal?: AbortSignal;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function rawEvent(event: ChatResponse): AGUIEvent {
+  return {
+    type: EventType.RAW,
+    source: 'ollama',
+    event: structuredClone(event),
+  };
+}
+
+function hasRawData(event: ChatResponse): boolean {
+  return (
+    event.done ||
+    event.logprobs !== undefined ||
+    (event.message.images?.length ?? 0) > 0
+  );
+}
+
+async function nextWithCancellation(
+  iterator: AsyncIterator<ChatResponse>,
+  signal: AbortSignal | undefined,
+): Promise<IteratorResult<ChatResponse> | typeof ABORTED> {
+  const nextPromise = iterator.next();
+  void nextPromise.catch(() => undefined);
+  if (!signal) {
+    return nextPromise;
+  }
+  if (signal.aborted) {
+    return ABORTED;
+  }
+
+  let onAbort!: () => void;
+  const abortPromise = new Promise<typeof ABORTED>((resolve) => {
+    onAbort = () => resolve(ABORTED);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+
+  try {
+    return await Promise.race([nextPromise, abortPromise]);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+  }
+}
+
+/**
+ * Maps Ollama streaming chat chunks to canonical AG-UI events.
+ *
+ * @param options - Ollama stream, stable assistant ID, and cancellation signal.
+ * @returns Canonical AG-UI text, reasoning, tool-call, and raw events.
+ *
+ * @internal
+ */
+export async function* mapOllamaEvents(
+  options: MapOllamaEventsOptions,
+): AsyncIterable<AGUIEvent> {
+  const iterator = options.events[Symbol.asyncIterator]();
+  let textStarted = false;
+  let reasoningId: string | undefined;
+  let reasoningIndex = 0;
+  let toolCallIndex = 0;
+  let completed = false;
+  let providerAborted = false;
+  let mappingFailed = false;
+  let mappingError: unknown;
+  let cleanupFailed = false;
+  let cleanupError: unknown;
+  const abortProvider = () => {
+    if (!providerAborted) {
+      providerAborted = true;
+      options.events.abort?.();
+    }
+  };
+  const onAbort = () => abortProvider();
+
+  options.signal?.addEventListener('abort', onAbort, { once: true });
+  if (options.signal?.aborted) {
+    abortProvider();
+  }
+
+  try {
+    while (!options.signal?.aborted) {
+      const next = await nextWithCancellation(iterator, options.signal);
+      if (next === ABORTED) {
+        return;
+      }
+      if (next.done) {
+        completed = true;
+        break;
+      }
+
+      const chunk = next.value;
+      const thinking = chunk.message.thinking;
+      if (thinking) {
+        if (!reasoningId) {
+          reasoningId = `${options.messageId}:reasoning:${reasoningIndex}`;
+          reasoningIndex += 1;
+          yield {
+            type: EventType.REASONING_MESSAGE_START,
+            messageId: reasoningId,
+            role: 'reasoning',
+            metadata: { ollama: { thinking: true } },
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+        }
+
+        yield {
+          type: EventType.REASONING_MESSAGE_CONTENT,
+          messageId: reasoningId,
+          delta: thinking,
+        };
+        if (options.signal?.aborted) {
+          return;
+        }
+      }
+
+      const content = chunk.message.content;
+      const toolCalls = chunk.message.tool_calls ?? [];
+      if ((content || toolCalls.length > 0) && reasoningId) {
+        yield {
+          type: EventType.REASONING_MESSAGE_END,
+          messageId: reasoningId,
+        };
+        reasoningId = undefined;
+        if (options.signal?.aborted) {
+          return;
+        }
+      }
+
+      if (content) {
+        if (!textStarted) {
+          textStarted = true;
+          yield {
+            type: EventType.TEXT_MESSAGE_START,
+            messageId: options.messageId,
+            role: 'assistant',
+          };
+          if (options.signal?.aborted) {
+            return;
+          }
+        }
+
+        yield {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: options.messageId,
+          delta: content,
+        };
+        if (options.signal?.aborted) {
+          return;
+        }
+      }
+
+      for (const toolCall of toolCalls) {
+        const name = toolCall.function?.name;
+        const args = toolCall.function?.arguments;
+        if (!name) {
+          throw new Error('Ollama returned a tool call without a name');
+        }
+        if (!isRecord(args)) {
+          throw new Error(
+            `Ollama returned non-object arguments for tool call "${name}"`,
+          );
+        }
+
+        const toolCallId = `${options.messageId}:tool:${toolCallIndex}`;
+        toolCallIndex += 1;
+        yield {
+          type: EventType.TOOL_CALL_START,
+          toolCallId,
+          toolCallName: name,
+          parentMessageId: options.messageId,
+        };
+        if (options.signal?.aborted) {
+          return;
+        }
+        yield {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId,
+          delta: JSON.stringify(args),
+        };
+        if (options.signal?.aborted) {
+          return;
+        }
+        yield { type: EventType.TOOL_CALL_END, toolCallId };
+        if (options.signal?.aborted) {
+          return;
+        }
+      }
+
+      if (hasRawData(chunk)) {
+        yield rawEvent(chunk);
+      }
+    }
+
+    if (!completed || options.signal?.aborted) {
+      return;
+    }
+
+    if (reasoningId) {
+      yield {
+        type: EventType.REASONING_MESSAGE_END,
+        messageId: reasoningId,
+      };
+      if (options.signal?.aborted) {
+        return;
+      }
+    }
+    if (textStarted) {
+      yield {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: options.messageId,
+      };
+    }
+  } catch (error: unknown) {
+    if (!options.signal?.aborted) {
+      mappingFailed = true;
+      mappingError = error;
+    }
+  } finally {
+    options.signal?.removeEventListener('abort', onAbort);
+    if (!completed) {
+      abortProvider();
+    }
+    try {
+      await iterator.return?.();
+    } catch (error: unknown) {
+      cleanupFailed = true;
+      cleanupError = error;
+    }
+  }
+
+  if (mappingFailed) {
+    throw mappingError;
+  }
+  if (cleanupFailed && !options.signal?.aborted) {
+    throw cleanupError;
+  }
+}

--- a/packages/ollama/src/stream/ollama-request.spec.ts
+++ b/packages/ollama/src/stream/ollama-request.spec.ts
@@ -1,0 +1,218 @@
+import type { OllamaHashbrownRunAgentInput } from './types';
+import { createOllamaRequestOptions } from './ollama-request';
+
+function createInput(): OllamaHashbrownRunAgentInput {
+  return {
+    threadId: 'thread-ollama',
+    runId: 'run-ollama',
+    messages: [
+      { id: 'system-ollama', role: 'system', content: 'System prompt.' },
+      {
+        id: 'developer-ollama',
+        role: 'developer',
+        content: 'Developer prompt.',
+      },
+      { id: 'user-ollama', role: 'user', content: 'Look it up.' },
+      {
+        id: 'reasoning-ollama',
+        role: 'reasoning',
+        content: 'I need a lookup.',
+        metadata: { ollama: { thinking: true } },
+      },
+      {
+        id: 'assistant-ollama',
+        role: 'assistant',
+        content: 'Checking.',
+        toolCalls: [
+          {
+            id: 'call-ollama',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"hashbrown"}',
+            },
+          },
+        ],
+      },
+      {
+        id: 'tool-ollama',
+        role: 'tool',
+        toolCallId: 'call-ollama',
+        content: '{"result":"fixture"}',
+      },
+    ],
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup a value.',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    hashbrown: {
+      responseSchema: {
+        type: 'object',
+        properties: { answer: { type: 'string' } },
+        required: ['answer'],
+      },
+    },
+  };
+}
+
+test('maps AG-UI messages, tools, reasoning, and structured output to Ollama', () => {
+  const input = createInput();
+
+  const result = createOllamaRequestOptions(input, 'gpt-oss:20b');
+
+  expect(result).toEqual({
+    stream: true,
+    model: 'gpt-oss:20b',
+    messages: [
+      { role: 'system', content: 'System prompt.' },
+      { role: 'system', content: 'Developer prompt.' },
+      { role: 'user', content: 'Look it up.' },
+      {
+        role: 'assistant',
+        content: 'Checking.',
+        thinking: 'I need a lookup.',
+        tool_calls: [
+          {
+            function: {
+              name: 'lookup',
+              arguments: { query: 'hashbrown' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: '{"result":"fixture"}',
+        tool_name: 'lookup',
+      },
+    ],
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'lookup',
+          description: 'Lookup a value.',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      },
+    ],
+    format: {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer'],
+    },
+  });
+});
+
+test('concatenates adjacent Ollama reasoning records for continuation', () => {
+  const input = createInput();
+  const assistantIndex = input.messages.findIndex(
+    (message) => message.id === 'assistant-ollama',
+  );
+  input.messages.splice(assistantIndex, 0, {
+    id: 'reasoning-ollama-2',
+    role: 'reasoning',
+    content: ' Then use the tool.',
+    metadata: { ollama: { thinking: true } },
+  });
+
+  const result = createOllamaRequestOptions(input, 'qwen3');
+
+  expect(result.messages?.[3]?.thinking).toBe(
+    'I need a lookup. Then use the tool.',
+  );
+});
+
+test('ignores reasoning records that are not owned by Ollama', () => {
+  const input = createInput();
+  const reasoning = input.messages.find(
+    (message) => message.id === 'reasoning-ollama',
+  );
+  if (reasoning?.role === 'reasoning') {
+    reasoning.metadata = { google: { thought: true } };
+  }
+
+  const result = createOllamaRequestOptions(input, 'qwen3');
+
+  expect(result.messages?.[3]?.thinking).toBeUndefined();
+});
+
+test('rejects a tool result whose call cannot be resolved', () => {
+  const input = createInput();
+  const toolMessage = input.messages.find(
+    (message) => message.id === 'tool-ollama',
+  );
+  if (toolMessage?.role === 'tool') {
+    toolMessage.toolCallId = 'missing-call';
+  }
+
+  expect(() => createOllamaRequestOptions(input, 'qwen3')).toThrow(
+    'Ollama tool result "tool-ollama" references unknown tool call "missing-call"',
+  );
+});
+
+test('rejects tool-call arguments that are not a JSON object', () => {
+  const input = createInput();
+  const assistant = input.messages.find(
+    (message) => message.id === 'assistant-ollama',
+  );
+  if (assistant?.role === 'assistant' && assistant.toolCalls?.[0]) {
+    assistant.toolCalls[0].function.arguments = 'not-json';
+  }
+
+  expect(() => createOllamaRequestOptions(input, 'qwen3')).toThrow(
+    'Ollama tool call "call-ollama" arguments must be a JSON object',
+  );
+});
+
+test('rejects non-text AG-UI user content', () => {
+  const input = createInput();
+  const user = input.messages.find((message) => message.id === 'user-ollama');
+  if (user?.role === 'user') {
+    user.content = [
+      {
+        type: 'image',
+        source: { type: 'url', value: 'https://example.com/image.png' },
+      },
+    ];
+  }
+
+  expect(() => createOllamaRequestOptions(input, 'qwen3')).toThrow(
+    'Ollama provider currently requires text user content',
+  );
+});
+
+test('does not mutate input messages, tools, schemas, or parsed arguments', () => {
+  const input = createInput();
+  const snapshot = structuredClone(input);
+
+  const result = createOllamaRequestOptions(input, 'qwen3');
+  const requestTool = result.tools?.[0];
+  const requestFormat = result.format as Record<string, unknown>;
+  const requestAssistant = result.messages?.[3];
+  const requestArguments =
+    requestAssistant?.tool_calls?.[0]?.function.arguments;
+  if (requestTool?.function.parameters?.properties) {
+    requestTool.function.parameters.properties['extra'] = { type: 'string' };
+  }
+  requestFormat['extra'] = true;
+  if (requestArguments) {
+    requestArguments['extra'] = true;
+  }
+
+  expect(input).toEqual(snapshot);
+});

--- a/packages/ollama/src/stream/ollama-request.ts
+++ b/packages/ollama/src/stream/ollama-request.ts
@@ -1,0 +1,184 @@
+import type { Message, Metadata, Tool } from '@ag-ui/core';
+import type {
+  ChatRequest,
+  Message as OllamaMessage,
+  Tool as OllamaTool,
+} from 'ollama';
+import type { OllamaHashbrownRunAgentInput } from './types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOllamaThinkingMarker(metadata: Metadata | undefined): boolean {
+  if (!isRecord(metadata)) {
+    return false;
+  }
+
+  const ollama = metadata['ollama'];
+  return isRecord(ollama) && ollama['thinking'] === true;
+}
+
+function parseToolArguments(toolCall: {
+  id: string;
+  function: { arguments: string };
+}): Record<string, unknown> {
+  try {
+    const value: unknown = JSON.parse(toolCall.function.arguments);
+    if (isRecord(value)) {
+      return value;
+    }
+  } catch {
+    // Report the same public mapping error for malformed and non-object JSON.
+  }
+
+  throw new Error(
+    `Ollama tool call "${toolCall.id}" arguments must be a JSON object`,
+  );
+}
+
+function mapPrecedingReasoning(
+  messages: Message[],
+  assistantIndex: number,
+): string | undefined {
+  let reasoningStart = assistantIndex;
+  while (
+    reasoningStart > 0 &&
+    messages[reasoningStart - 1]?.role === 'reasoning'
+  ) {
+    reasoningStart -= 1;
+  }
+
+  const thinking = messages
+    .slice(reasoningStart, assistantIndex)
+    .flatMap((message) =>
+      message.role === 'reasoning' && hasOllamaThinkingMarker(message.metadata)
+        ? [message.content]
+        : [],
+    )
+    .join('');
+
+  return thinking || undefined;
+}
+
+function findToolCallName(
+  messages: Message[],
+  toolCallId: string,
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== 'assistant') {
+      continue;
+    }
+
+    const toolCall = message.toolCalls?.find(
+      (candidate) => candidate.id === toolCallId,
+    );
+    if (toolCall) {
+      return toolCall.function.name;
+    }
+  }
+
+  return undefined;
+}
+
+function mapMessage(
+  messages: Message[],
+  message: Message,
+  index: number,
+): OllamaMessage | undefined {
+  switch (message.role) {
+    case 'system':
+    case 'developer':
+      return { role: 'system', content: message.content };
+    case 'user':
+      if (typeof message.content !== 'string') {
+        throw new Error('Ollama provider currently requires text user content');
+      }
+
+      return { role: 'user', content: message.content };
+    case 'assistant': {
+      const thinking = mapPrecedingReasoning(messages, index);
+      const toolCalls = message.toolCalls?.map((toolCall) => ({
+        function: {
+          name: toolCall.function.name,
+          arguments: parseToolArguments(toolCall),
+        },
+      }));
+      return {
+        role: 'assistant',
+        content: message.content ?? '',
+        ...(thinking === undefined ? {} : { thinking }),
+        ...(toolCalls?.length ? { tool_calls: toolCalls } : {}),
+      };
+    }
+    case 'tool': {
+      const toolName = findToolCallName(
+        messages.slice(0, index),
+        message.toolCallId,
+      );
+      if (!toolName) {
+        throw new Error(
+          `Ollama tool result "${message.id}" references unknown tool call "${message.toolCallId}"`,
+        );
+      }
+
+      return {
+        role: 'tool',
+        content: message.content,
+        tool_name: toolName,
+      };
+    }
+    case 'activity':
+    case 'reasoning':
+      return undefined;
+  }
+}
+
+function mapTool(tool: Tool): OllamaTool {
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      ...(tool.parameters === undefined
+        ? {}
+        : {
+            parameters: structuredClone(
+              tool.parameters,
+            ) as OllamaTool['function']['parameters'],
+          }),
+    },
+  };
+}
+
+/**
+ * Maps an AG-UI run input to Ollama streaming chat request options.
+ *
+ * @param input - Standard AG-UI run input with optional Hashbrown metadata.
+ * @param model - Model selected by the server for this endpoint.
+ * @returns Fresh Ollama request options that do not mutate the run input.
+ *
+ * @internal
+ */
+export function createOllamaRequestOptions(
+  input: OllamaHashbrownRunAgentInput,
+  model: string,
+): ChatRequest & { stream: true } {
+  const messages = input.messages.flatMap((message, index) => {
+    const mapped = mapMessage(input.messages, message, index);
+    return mapped ? [mapped] : [];
+  });
+  const tools = input.tools.map(mapTool);
+  const responseSchema = input.hashbrown?.responseSchema;
+
+  return {
+    stream: true,
+    model,
+    messages,
+    ...(tools.length > 0 ? { tools } : {}),
+    ...(responseSchema === undefined
+      ? {}
+      : { format: structuredClone(responseSchema) }),
+  };
+}

--- a/packages/ollama/src/stream/text.fn.spec.ts
+++ b/packages/ollama/src/stream/text.fn.spec.ts
@@ -1,206 +1,246 @@
-import OllamaClient, { Ollama } from 'ollama';
-import { Chat } from '@hashbrownai/core';
+import { EventType, type RunAgentInput } from '@ag-ui/core';
+import { type ChatResponse, Ollama } from 'ollama';
 import { text } from './text.fn';
 
-jest.mock('ollama', () => {
-  const defaultClient = {
-    chat: jest.fn(),
-  };
-
-  return {
-    __esModule: true,
-    default: defaultClient,
-    Ollama: jest.fn(),
-  };
-});
+jest.mock('ollama', () => ({
+  Ollama: jest.fn(),
+}));
 
 const MockedOllama = jest.mocked(Ollama);
-const mockedDefaultClient = jest.mocked(OllamaClient);
 
-test('uses the default Ollama client when no client options are provided', async () => {
-  resetOllamaMocks();
-  const defaultChat = jest.fn().mockResolvedValue(createOllamaStream());
-  mockedDefaultClient.chat = defaultChat;
-  const request = createRequest();
+function resetOllamaMock(): void {
+  MockedOllama.mockReset();
+}
 
-  await consumeStream(
-    text({
-      request,
-    }),
+function createInput(): RunAgentInput {
+  return {
+    threadId: 'thread-ollama',
+    runId: 'run-ollama',
+    messages: [{ id: 'user-ollama', role: 'user', content: 'Hello' }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  };
+}
+
+function createChunk(content: string, done = false): ChatResponse {
+  return {
+    model: 'qwen3',
+    created_at: new Date('2026-08-31T00:00:00.000Z'),
+    message: { role: 'assistant', content },
+    done,
+    done_reason: done ? 'stop' : '',
+    total_duration: done ? 10 : 0,
+    load_duration: 0,
+    prompt_eval_count: 0,
+    prompt_eval_duration: 0,
+    eval_count: done ? 1 : 0,
+    eval_duration: 0,
+  };
+}
+
+function createProviderStream(values: ChatResponse[]) {
+  const abort = jest.fn();
+  return {
+    abort,
+    async *[Symbol.asyncIterator]() {
+      for (const value of values) {
+        yield value;
+      }
+    },
+  };
+}
+
+test('creates a host client and streams a complete AG-UI run', async () => {
+  resetOllamaMock();
+  const providerStream = createProviderStream([
+    createChunk('Hello'),
+    createChunk('', true),
+  ]);
+  const chat = jest.fn().mockResolvedValue(providerStream);
+  const abort = jest.fn();
+  MockedOllama.mockImplementationOnce(
+    () => ({ chat, abort }) as unknown as Ollama,
   );
 
-  expect(defaultChat).toHaveBeenCalledWith(
-    expect.objectContaining({
-      model: request.model,
-      stream: true,
-    }),
-  );
-  expect(MockedOllama).not.toHaveBeenCalled();
-});
-
-test('creates an Ollama client with the configured host', async () => {
-  resetOllamaMocks();
-  const chat = jest.fn().mockResolvedValue(createOllamaStream());
-  MockedOllama.mockImplementationOnce(() => ({ chat }) as unknown as Ollama);
-  const request = createRequest();
-
-  await consumeStream(
+  const result = await Array.fromAsync(
     text({
       host: 'http://ollama:11434',
-      request,
+      model: 'qwen3',
+      input: createInput(),
     }),
   );
 
   expect(MockedOllama).toHaveBeenCalledWith({
     host: 'http://ollama:11434',
   });
-  expect(chat).toHaveBeenCalledWith(
-    expect.objectContaining({
-      model: request.model,
-      stream: true,
-    }),
-  );
+  expect(chat).toHaveBeenCalledWith({
+    stream: true,
+    model: 'qwen3',
+    messages: [{ role: 'user', content: 'Hello' }],
+  });
+  expect(result.map((event) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.TEXT_MESSAGE_START,
+    EventType.TEXT_MESSAGE_CONTENT,
+    EventType.RAW,
+    EventType.TEXT_MESSAGE_END,
+    EventType.RUN_FINISHED,
+  ]);
 });
 
-test('uses an explicit Ollama client when provided', async () => {
-  resetOllamaMocks();
-  const chat = jest.fn().mockResolvedValue(createOllamaStream());
-  const client = { chat } as unknown as Ollama;
-  const request = createRequest();
+test('uses an explicit client instead of constructing a host client', async () => {
+  resetOllamaMock();
+  const chat = jest
+    .fn()
+    .mockResolvedValue(createProviderStream([createChunk('', true)]));
+  const client = { chat, abort: jest.fn() } as unknown as Ollama;
 
-  await consumeStream(
+  await Array.fromAsync(
     text({
       client,
-      host: 'http://ollama:11434',
-      turbo: { apiKey: 'test-api-key' },
-      request,
+      host: 'http://ignored:11434',
+      model: 'qwen3',
+      input: createInput(),
     }),
   );
 
-  expect(chat).toHaveBeenCalledWith(
-    expect.objectContaining({
-      model: request.model,
-      stream: true,
-    }),
-  );
+  expect(chat).toHaveBeenCalledTimes(1);
   expect(MockedOllama).not.toHaveBeenCalled();
 });
 
-test('creates an Ollama Turbo client before the configured host when turbo is provided', async () => {
-  resetOllamaMocks();
-  const chat = jest.fn().mockResolvedValue(createOllamaStream());
-  MockedOllama.mockImplementationOnce(() => ({ chat }) as unknown as Ollama);
-  const request = createRequest();
-
-  await consumeStream(
-    text({
-      host: 'http://ollama:11434',
-      turbo: { apiKey: 'test-api-key' },
-      request,
-    }),
+test('passes transformed request options to Ollama', async () => {
+  resetOllamaMock();
+  const chat = jest
+    .fn()
+    .mockResolvedValue(createProviderStream([createChunk('', true)]));
+  MockedOllama.mockImplementationOnce(
+    () => ({ chat, abort: jest.fn() }) as unknown as Ollama,
   );
 
-  expect(MockedOllama).toHaveBeenCalledWith({
-    host: 'https://ollama.com',
-    headers: {
-      Authorization: 'Bearer test-api-key',
-    },
-  });
-  expect(chat).toHaveBeenCalledWith(
-    expect.objectContaining({
-      model: request.model,
-      stream: true,
-    }),
-  );
-});
-
-test('passes transformed request options to the selected client', async () => {
-  resetOllamaMocks();
-  const chat = jest.fn().mockResolvedValue(createOllamaStream());
-  mockedDefaultClient.chat = chat;
-
-  await consumeStream(
+  await Array.fromAsync(
     text({
-      request: createRequest(),
-      transformRequestOptions: (options) => ({
-        ...options,
-        options: {
-          temperature: 0,
-        },
+      model: 'gpt-oss:20b',
+      input: createInput(),
+      transformRequestOptions: async (request) => ({
+        ...request,
+        think: 'high',
+        options: { temperature: 0 },
       }),
     }),
   );
 
   expect(chat).toHaveBeenCalledWith(
     expect.objectContaining({
-      options: {
-        temperature: 0,
-      },
+      model: 'gpt-oss:20b',
+      think: 'high',
+      options: { temperature: 0 },
     }),
   );
 });
 
-test('uses Ollama JSON format for JSON response format mode', async () => {
-  resetOllamaMocks();
-  const chat = jest.fn().mockResolvedValue(createOllamaStream());
-  mockedDefaultClient.chat = chat;
+test('maps request and provider failures to one RUN_ERROR event', async () => {
+  resetOllamaMock();
+  const chat = jest.fn().mockRejectedValue(new Error('provider unavailable'));
+  MockedOllama.mockImplementationOnce(
+    () => ({ chat, abort: jest.fn() }) as unknown as Ollama,
+  );
 
-  await consumeStream(
+  const result = await Array.fromAsync(
+    text({ model: 'qwen3', input: createInput() }),
+  );
+
+  expect(result).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-ollama',
+      runId: 'run-ollama',
+    },
+    { type: EventType.RUN_ERROR, message: 'provider unavailable' },
+  ]);
+});
+
+test('does not start an Ollama request when already aborted', async () => {
+  resetOllamaMock();
+  const controller = new AbortController();
+  controller.abort();
+
+  const result = await Array.fromAsync(
     text({
-      request: {
-        ...createRequest(),
-        responseFormatMode: 'json',
-      },
+      model: 'qwen3',
+      input: createInput(),
+      signal: controller.signal,
     }),
   );
 
-  expect(chat).toHaveBeenCalledWith(
-    expect.objectContaining({
-      format: 'json',
-    }),
-  );
+  expect(result).toEqual([
+    {
+      type: EventType.RUN_STARTED,
+      threadId: 'thread-ollama',
+      runId: 'run-ollama',
+    },
+  ]);
+  expect(MockedOllama).not.toHaveBeenCalled();
 });
 
-async function consumeStream(stream: AsyncIterable<Uint8Array>): Promise<void> {
-  for await (const chunk of stream) {
-    void chunk;
-    // Consume the stream so client selection and chat execution happen.
-  }
-}
+test('aborts an owned client while waiting for its stream', async () => {
+  resetOllamaMock();
+  const abort = jest.fn();
+  let resolveStream!: (stream: ReturnType<typeof createProviderStream>) => void;
+  const chat = jest.fn(
+    () =>
+      new Promise<ReturnType<typeof createProviderStream>>((resolve) => {
+        resolveStream = resolve;
+      }),
+  );
+  MockedOllama.mockImplementationOnce(
+    () => ({ chat, abort }) as unknown as Ollama,
+  );
+  const controller = new AbortController();
+  const iterator = text({
+    model: 'qwen3',
+    input: createInput(),
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
 
-function resetOllamaMocks(): void {
-  MockedOllama.mockReset();
-  mockedDefaultClient.chat = jest.fn().mockResolvedValue(createOllamaStream());
-}
+  await iterator.next();
+  const pending = iterator.next();
+  await Promise.resolve();
+  controller.abort();
+  await Promise.resolve();
 
-function createRequest(): Chat.Api.CompletionCreateParams {
-  return {
-    operation: 'generate',
-    model: 'llama3.2',
-    system: 'Respond tersely.',
-    messages: [
-      {
-        role: 'user',
-        content: 'Hello',
-      },
-    ],
-  };
-}
+  expect(abort).toHaveBeenCalledTimes(1);
+  resolveStream(createProviderStream([]));
+  await expect(pending).resolves.toEqual({ done: true, value: undefined });
+});
 
-async function* createOllamaStream() {
-  yield {
-    done: false,
-    message: {
-      role: 'assistant',
-      content: 'Hello',
-    },
-  };
+test('does not globally abort an explicit client while waiting for its stream', async () => {
+  resetOllamaMock();
+  const abort = jest.fn();
+  let resolveStream!: (stream: ReturnType<typeof createProviderStream>) => void;
+  const chat = jest.fn(
+    () =>
+      new Promise<ReturnType<typeof createProviderStream>>((resolve) => {
+        resolveStream = resolve;
+      }),
+  );
+  const client = { chat, abort } as unknown as Ollama;
+  const controller = new AbortController();
+  const iterator = text({
+    client,
+    model: 'qwen3',
+    input: createInput(),
+    signal: controller.signal,
+  })[Symbol.asyncIterator]();
 
-  yield {
-    done: true,
-    message: {
-      role: 'assistant',
-      content: '',
-    },
-  };
-}
+  await iterator.next();
+  const pending = iterator.next();
+  await Promise.resolve();
+  controller.abort();
+  await Promise.resolve();
+
+  expect(abort).not.toHaveBeenCalled();
+  resolveStream(createProviderStream([]));
+  await expect(pending).resolves.toEqual({ done: true, value: undefined });
+});

--- a/packages/ollama/src/stream/text.fn.ts
+++ b/packages/ollama/src/stream/text.fn.ts
@@ -1,313 +1,86 @@
-import {
-  Chat,
-  encodeFrame,
-  Frame,
-  mergeMessagesForThread,
-  updateAssistantMessage,
-} from '@hashbrownai/core';
-import OllamaClient, { ChatRequest, Message, Ollama, ToolCall } from 'ollama';
-import { FunctionParameters } from 'openai/resources/shared';
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { type AbortableAsyncIterator, type ChatResponse, Ollama } from 'ollama';
+import { mapOllamaEvents } from './ollama-events';
+import { createOllamaRequestOptions } from './ollama-request';
+import type { OllamaTextStreamOptions } from './types';
 
-type BaseOllamaTextStreamOptions = {
-  /**
-   * Preconfigured Ollama SDK client for advanced transport settings.
-   * Takes precedence over `turbo` and `host`.
-   */
-  client?: Ollama;
-  /**
-   * Ollama host URL used to create an SDK client when `client` and `turbo`
-   * are omitted.
-   */
-  host?: string;
-  /**
-   * Ollama Turbo credentials. Takes precedence over `host` when `client` is
-   * omitted.
-   */
-  turbo?: { apiKey: string };
-  request: Chat.Api.CompletionCreateParams;
-  transformRequestOptions?: (
-    options: ChatRequest & { stream: true },
-  ) =>
-    (ChatRequest & { stream: true }) | Promise<ChatRequest & { stream: true }>;
-};
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
-type ThreadPersistenceOptions = {
-  loadThread: (threadId: string) => Promise<Chat.Api.Message[]>;
-  saveThread: (
-    thread: Chat.Api.Message[],
-    threadId?: string,
-  ) => Promise<string>;
-};
-
-type ThreadlessOptions = BaseOllamaTextStreamOptions & {
-  loadThread?: undefined;
-  saveThread?: undefined;
-};
-
-type ThreadfulOptions = BaseOllamaTextStreamOptions & ThreadPersistenceOptions;
-
-export type OpenAITextStreamOptions = ThreadlessOptions | ThreadfulOptions;
-
-export function text(options: ThreadfulOptions): AsyncIterable<Uint8Array>;
-export function text(options: ThreadlessOptions): AsyncIterable<Uint8Array>;
-
+/**
+ * Streams canonical AG-UI events from an Ollama chat request.
+ *
+ * @param options - Provider configuration and AG-UI run input.
+ * @returns An asynchronous stream of canonical AG-UI events.
+ *
+ * @public
+ */
 export async function* text(
-  options: OpenAITextStreamOptions,
-): AsyncIterable<Uint8Array> {
-  const { request, transformRequestOptions, loadThread, saveThread } = options;
-  const { model, tools, responseFormat, responseFormatMode, system } = request;
-  const threadId = request.threadId;
-  let loadedThread: Chat.Api.Message[] = [];
-  let effectiveThreadId = threadId;
+  options: OllamaTextStreamOptions,
+): AsyncIterable<AGUIEvent> {
+  const { model, input, signal, transformRequestOptions } = options;
+  const { threadId, runId } = input;
+  const messageId = `${runId}:assistant`;
+  let providerStream: AbortableAsyncIterator<ChatResponse> | undefined;
+  let mappingStarted = false;
 
-  const shouldLoadThread = Boolean(request.threadId);
-  const shouldHydrateThreadOnTheClient = Boolean(
-    request.operation === 'load-thread',
-  );
-
-  if (shouldLoadThread) {
-    yield encodeFrame({ type: 'thread-load-start' });
-
-    if (!loadThread) {
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: 'Thread loading is not available for this transport.',
-      });
-      return;
-    }
-
-    try {
-      loadedThread = await loadThread(request.threadId as string);
-      if (shouldHydrateThreadOnTheClient) {
-        yield encodeFrame({
-          type: 'thread-load-success',
-          thread: loadedThread,
-        });
-      } else {
-        yield encodeFrame({ type: 'thread-load-success' });
-      }
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-load-failure',
-        error: message,
-        stacktrace: stack,
-      });
-      return;
-    }
-  }
-
-  if (request.operation === 'load-thread') {
+  yield { type: EventType.RUN_STARTED, threadId, runId };
+  if (signal?.aborted) {
     return;
   }
-
-  const mergedMessages =
-    request.threadId && shouldLoadThread
-      ? mergeMessagesForThread(loadedThread, request.messages ?? [])
-      : (request.messages ?? []);
-  const mergedMessagesLength = mergedMessages.length;
-  let assistantMessage: Chat.Api.AssistantMessage | null = null;
 
   try {
-    const baseOptions: ChatRequest & { stream: true } = {
-      stream: true,
-      model: model as string,
-      options: {
-        // num_ctx: 32768,
-      },
-      messages: [
-        {
-          role: 'system',
-          content: system,
-        },
-        ...mergedMessages.map((message): Message => {
-          if (message.role === 'user') {
-            return {
-              role: message.role,
-              content: message.content,
-            };
-          }
-          if (message.role === 'assistant') {
-            return {
-              role: message.role,
-              content: message.content ?? '',
-              tool_calls:
-                message.toolCalls && message.toolCalls.length > 0
-                  ? message.toolCalls.map((toolCall): ToolCall => ({
-                      ...toolCall,
-                      function: {
-                        ...toolCall.function,
-                        arguments: normalizeToolArguments(
-                          toolCall.function.arguments,
-                        ),
-                      },
-                    }))
-                  : undefined,
-            };
-          }
-          if (message.role === 'tool') {
-            return {
-              role: message.role,
-              content: JSON.stringify(message.content),
-            };
-          }
-
-          throw new Error(`Invalid message role`);
-        }),
-      ],
-      tools:
-        tools && tools.length > 0
-          ? tools.map((tool) => ({
-              type: 'function',
-              function: {
-                name: tool.name,
-                description: tool.description,
-                parameters: tool.parameters as FunctionParameters,
-                strict: true,
-              },
-            }))
-          : undefined,
-      format: responseFormatMode === 'json' ? 'json' : responseFormat,
-    };
-
-    const resolvedOptions: ChatRequest & { stream: true } =
-      transformRequestOptions
-        ? await transformRequestOptions(baseOptions)
-        : baseOptions;
-
-    const client = getClient(options);
-
-    const stream = await client.chat(resolvedOptions);
-
-    yield encodeFrame({ type: 'generation-start' });
-
-    for await (const chunk of stream) {
-      const chunkMessage: Chat.Api.CompletionChunk = {
-        choices: [
-          {
-            index: 0,
-            delta: {
-              content: chunk.message.content,
-              role: chunk.message.role,
-              toolCalls: chunk.message.tool_calls?.map((toolCall, index) => ({
-                ...toolCall,
-                id: `tool-call-${mergedMessagesLength}-${index}`,
-                index,
-                function: {
-                  ...toolCall.function,
-                  arguments: toolCall.function.arguments as unknown as string,
-                },
-              })),
-            },
-            finishReason: chunk.done ? 'stop' : null,
-          },
-        ],
-      };
-
-      const frame: Frame = {
-        type: 'generation-chunk',
-        chunk: chunkMessage,
-      };
-
-      assistantMessage = updateAssistantMessage(assistantMessage, chunkMessage);
-
-      yield encodeFrame(frame);
-    }
-
-    yield encodeFrame({ type: 'generation-finish' });
-  } catch (error: unknown) {
-    const { message, stack } = normalizeError(error);
-    const frame: Frame = {
-      type: 'generation-error',
-      error: message,
-      stacktrace: stack,
-    };
-
-    yield encodeFrame(frame);
-    return;
-  }
-
-  if (saveThread) {
-    const threadToSave = mergeMessagesForThread(mergedMessages, [
-      ...(assistantMessage ? [assistantMessage] : []),
-    ]);
-    yield encodeFrame({ type: 'thread-save-start' });
-    try {
-      const savedThreadId = await saveThread(threadToSave, effectiveThreadId);
-      if (effectiveThreadId && savedThreadId !== effectiveThreadId) {
-        throw new Error(
-          'Save returned a different threadId than the existing thread',
-        );
-      }
-      effectiveThreadId = savedThreadId;
-      yield encodeFrame({
-        type: 'thread-save-success',
-        threadId: savedThreadId,
-      });
-    } catch (error: unknown) {
-      const { message, stack } = normalizeError(error);
-      yield encodeFrame({
-        type: 'thread-save-failure',
-        error: message,
-        stacktrace: stack,
-      });
+    const baseRequest = createOllamaRequestOptions(input, model);
+    const request = transformRequestOptions
+      ? await transformRequestOptions(baseRequest)
+      : baseRequest;
+    if (signal?.aborted) {
       return;
     }
-  }
-}
 
-function getClient(options: OpenAITextStreamOptions): Ollama {
-  if (options.client) {
-    return options.client;
-  }
-
-  if (options.turbo) {
-    return new Ollama({
-      host: 'https://ollama.com',
-      headers: {
-        Authorization: `Bearer ${options.turbo.apiKey}`,
-      },
-    });
-  }
-
-  if (options.host) {
-    return new Ollama({
-      host: options.host,
-    });
-  }
-
-  return OllamaClient;
-}
-
-function normalizeError(error: unknown): { message: string; stack?: string } {
-  if (error instanceof Error) {
-    return { message: error.message, stack: error.stack };
-  }
-  return { message: String(error) };
-}
-
-function normalizeToolArguments(args: unknown): Record<string, unknown> {
-  if (args && typeof args === 'object') {
-    return args as Record<string, unknown>;
-  }
-
-  if (typeof args === 'string') {
+    const ownsClient = options.client === undefined;
+    const client =
+      options.client ?? new Ollama(options.host ? { host: options.host } : {});
+    const abortPendingRequest = () => {
+      if (ownsClient) {
+        client.abort();
+      }
+    };
+    signal?.addEventListener('abort', abortPendingRequest, { once: true });
     try {
-      let parsed: unknown = JSON.parse(args);
-      if (typeof parsed === 'string') {
-        try {
-          parsed = JSON.parse(parsed);
-        } catch {
-          // Keep the original parsed string if it isn't valid JSON.
-        }
+      providerStream = await client.chat(request);
+    } finally {
+      signal?.removeEventListener('abort', abortPendingRequest);
+    }
+    if (signal?.aborted) {
+      providerStream.abort();
+      return;
+    }
+
+    mappingStarted = true;
+    for await (const event of mapOllamaEvents({
+      events: providerStream,
+      messageId,
+      signal,
+    })) {
+      yield event;
+      if (signal?.aborted) {
+        return;
       }
-      if (parsed && typeof parsed === 'object') {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      // Fall through to empty object when args are not valid JSON.
+    }
+    if (signal?.aborted) {
+      return;
+    }
+
+    yield { type: EventType.RUN_FINISHED, threadId, runId };
+  } catch (error: unknown) {
+    if (!signal?.aborted) {
+      yield { type: EventType.RUN_ERROR, message: normalizeError(error) };
+    }
+  } finally {
+    if (!mappingStarted) {
+      providerStream?.abort();
     }
   }
-
-  return {};
 }

--- a/packages/ollama/src/stream/types.ts
+++ b/packages/ollama/src/stream/types.ts
@@ -1,0 +1,40 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import type { ChatRequest, Ollama } from 'ollama';
+
+/**
+ * Hashbrown extensions accepted alongside a standard AG-UI run input.
+ *
+ * @public
+ */
+export interface OllamaHashbrownRunAgentInput extends RunAgentInput {
+  /** Hashbrown semantics layered onto the standard AG-UI run input. */
+  hashbrown?: {
+    /** JSON Schema used for Ollama native structured output. */
+    responseSchema?: object;
+    /** Whether the run is expected to produce generative UI output. */
+    ui?: boolean;
+  };
+}
+
+/**
+ * Options for streaming an AG-UI run from Ollama.
+ *
+ * @public
+ */
+export interface OllamaTextStreamOptions {
+  /** Preconfigured Ollama SDK client for advanced transport settings. */
+  client?: Ollama;
+  /** Ollama host URL used when creating a client for this run. */
+  host?: string;
+  /** Model selected by the server for this endpoint. */
+  model: string;
+  /** Standard AG-UI run input plus optional Hashbrown semantics. */
+  input: OllamaHashbrownRunAgentInput;
+  /** Cancels the provider request when the HTTP request is abandoned. */
+  signal?: AbortSignal;
+  /** Customize the Ollama request after AG-UI input has been mapped. */
+  transformRequestOptions?: (
+    options: ChatRequest & { stream: true },
+  ) =>
+    (ChatRequest & { stream: true }) | Promise<ChatRequest & { stream: true }>;
+}

--- a/packages/ollama/tsconfig.docs.json
+++ b/packages/ollama/tsconfig.docs.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "paths": {
-      "@hashbrownai/core": ["dist/packages/core/"]
-    }
-  }
+  "extends": "./tsconfig.json"
 }

--- a/samples/kitchen-sink/server/src/main.ts
+++ b/samples/kitchen-sink/server/src/main.ts
@@ -1,6 +1,5 @@
 import type { RunAgentInput } from '@ag-ui/core';
 import { EventEncoder } from '@ag-ui/encoder';
-import { Chat } from '@hashbrownai/core';
 import { HashbrownAzure } from '@hashbrownai/azure';
 import { HashbrownGoogle } from '@hashbrownai/google';
 import { HashbrownOpenAI } from '@hashbrownai/openai';
@@ -22,7 +21,8 @@ const AZURE_DEPLOYMENT = process.env['AZURE_DEPLOYMENT'];
 const AZURE_MODEL = process.env['AZURE_MODEL'] ?? '';
 const GOOGLE_API_KEY = process.env['GOOGLE_API_KEY'] ?? '';
 const GOOGLE_MODEL = process.env['GOOGLE_MODEL'] ?? 'gemini-2.5-flash';
-const OLLAMA_API_KEY = process.env['OLLAMA_API_KEY'] ?? '';
+const OLLAMA_HOST = process.env['OLLAMA_HOST'];
+const OLLAMA_MODEL = process.env['OLLAMA_MODEL'] ?? 'gemma3';
 
 if (!OPENAI_API_KEY) {
   console.warn('OPENAI_API_KEY is not set');
@@ -33,10 +33,6 @@ if (!AZURE_API_KEY) {
 if (!GOOGLE_API_KEY) {
   console.warn('GOOGLE_API_KEY is not set');
 }
-if (!OLLAMA_API_KEY) {
-  console.warn('OLLAMA_API_KEY is not set');
-}
-
 const app = express();
 
 app.use(express.json());
@@ -131,18 +127,28 @@ app.post('/google/chat', async (req, res) => {
   }
 });
 
-app.post('/legacy/chat', async (req, res) => {
-  const request = req.body as Chat.Api.CompletionCreateParams;
+app.post('/ollama/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOllama.stream.text({
-    turbo: { apiKey: OLLAMA_API_KEY },
-    request,
+    host: OLLAMA_HOST,
+    model: OLLAMA_MODEL,
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk);
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });

--- a/tools/testing/aimock/fixtures/ollama/tool-continuation.json
+++ b/tools/testing/aimock/fixtures/ollama/tool-continuation.json
@@ -1,0 +1,29 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "continue after the lookup",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "lookup",
+            "arguments": {
+              "query": "hashbrown"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "userMessage": "continue after the lookup",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Ollama continuation complete."
+      }
+    }
+  ]
+}

--- a/www/analog/src/app/pages/docs/angular/platform/ollama.md
+++ b/www/analog/src/app/pages/docs/angular/platform/ollama.md
@@ -2,91 +2,75 @@
 title: 'Ollama: Hashbrown Angular Docs'
 meta:
   - name: description
-    content: 'First, install the Ollama adapter package:'
+    content: 'Hashbrown maps AG-UI runs to the official Ollama SDK and streams canonical AG-UI events.'
 ---
+
 # Ollama
 
-First, install the Ollama adapter package:
-
-<hb-code-example header="terminal">
+Install the Ollama adapter, official Ollama SDK, and AG-UI SSE packages:
 
 ```sh
-npm install @hashbrownai/ollama
+npm install @hashbrownai/ollama ollama @ag-ui/core @ag-ui/encoder
 ```
 
-</hb-code-example>
+## Streaming Text Responses
 
----
+`HashbrownOllama.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses the official Ollama SDK streaming chat API. Encode its events as AG-UI SSE at your HTTP boundary.
 
-## `HashbrownOllama.stream.text(options)`
+The model is server configuration and is not read from the client run input. By default the official SDK connects to the local Ollama server. Pass `host` for a remote or containerized server, or pass a preconfigured `client` for custom headers and transport settings. An explicit `client` takes precedence over `host`.
 
-Streams an Ollama chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+### API Reference
 
-**Options:**
+| Name                      | Type                                    | Description                                                            |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| `client`                  | `Ollama`                                | _(Optional)_ Preconfigured official Ollama SDK client.                 |
+| `host`                    | `string`                                | _(Optional)_ Ollama host URL used when creating a client for this run. |
+| `model`                   | `string`                                | Server-selected Ollama model.                                          |
+| `input`                   | `OllamaHashbrownRunAgentInput`          | AG-UI run input, including messages and tools.                         |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Ollama request when the client disconnects.   |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Ollama `ChatRequest`.      |
 
-| Name                       | Type                              | Description                                                                                        |
-| -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `host`                     | `string`                          | _(Optional)_ Ollama host URL, such as `http://localhost:11434` or a container host.                |
-| `client`                   | `Ollama`                          | _(Optional)_ Preconfigured Ollama SDK client for advanced transport settings.                      |
-| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key.                                             |
-| `request`                  | `Chat.Api.CompletionCreateParams` | The chat request: model, messages, tools, system, `responseFormat`, etc.                           |
-| `transformRequestOptions`  | `function`                        | _(Optional)_ Async function to transform Ollama request options before sending (e.g., for `think` parameter). |
+The adapter maps system and developer instructions, text message history, tool definitions, tool calls, and tool results. Text and tool calls become canonical AG-UI events. Ollama thinking becomes AG-UI reasoning records and is restored as `thinking` when that assistant message is sent back for continuation. Terminal response details, including metrics and log probabilities, are preserved as Ollama `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Function calling with strict function schemas
-- **Response Format:** Optionally specify a JSON schema in `responseFormat` (forwarded to Ollama `format`)
-- **System Prompt:** Included as the first message if provided
-- **Streaming:** Each chunk is encoded into a resilient streaming format
-- **Local, Hosted, or Turbo:** Connects to the default Ollama client, a configured `host`, an explicit `client`, or Ollama Turbo
-
----
-
-## How It Works
-
-- **Messages:** Translated to Ollama’s message format, supporting `user`, `assistant`, and `tool` roles. Tool results are stringified as tool messages.
-- **Tools/Functions:** Tools are passed as function definitions with `name`, `description`, and JSON Schema `parameters` (`strict: true`).
-- **Response Format:** Pass a JSON schema in `responseFormat`; forwarded to Ollama as `format` for structured output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Client Selection:**
-  - `client`: use a preconfigured Ollama SDK client
-  - `turbo.apiKey`: route requests through Ollama Turbo
-  - `host`: create an Ollama SDK client for the configured host URL
-  - Default: use the default `ollama` Node client
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
----
-
-## Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOllama.stream.text({
-    // Optional: connect to a remote or containerized Ollama server
-    // host: 'http://ollama:11434',
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -97,25 +81,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownOllama.stream.text({
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -126,27 +121,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownOllama.stream.text({
-      // Optional: use Ollama Turbo
-      // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-      request: body, // must be Chat.Api.CompletionCreateParams
+      host: process.env.OLLAMA_HOST,
+      model: process.env.OLLAMA_MODEL ?? 'gemma3',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -156,34 +167,39 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownOllama.stream.text({
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
-    }
+    },
   );
 });
 
@@ -194,216 +210,81 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## Structured Output
 
----
+Set `input.hashbrown.responseSchema` to use Ollama native structured output. Hashbrown forwards a cloned JSON Schema as the Ollama `format` request field; it does not emulate or prevalidate provider support.
 
-### Transform Request Options
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+    },
+  },
+};
+```
 
-The `transformRequestOptions` parameter allows you to intercept and modify the chat request before it's sent to Ollama. Use `host` or `client` for transport settings such as the Ollama server URL.
+Ollama Cloud does not currently support structured outputs. Use a local or self-hosted model that supports `format` when setting `responseSchema`.
 
-<hb-backend-code-example>
+## Ollama Cloud
 
-<div backend="express">
+Configure the official SDK client with the Ollama Cloud host and authorization header, then pass it to Hashbrown:
 
 ```ts
 import { HashbrownOllama } from '@hashbrownai/ollama';
-import express from 'express';
+import { Ollama } from 'ollama';
 
-const app = express();
-app.use(express.json());
+const client = new Ollama({
+  host: 'https://ollama.com',
+  headers: {
+    Authorization: `Bearer ${process.env.OLLAMA_API_KEY!}`,
+  },
+});
 
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOllama.stream.text({
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownOllama.stream.text({
+  client,
+  model: process.env.OLLAMA_MODEL ?? 'gpt-oss:120b',
+  input,
 });
 ```
 
-</div>
+## Thinking
 
-<div backend="fastify">
+Use `transformRequestOptions` to enable thinking on a compatible model. Thinking chunks are emitted as AG-UI reasoning records and are included in provider continuation messages.
 
 ```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownOllama.stream.text({
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
+const stream = HashbrownOllama.stream.text({
+  model: process.env.OLLAMA_MODEL ?? 'deepseek-r1',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    think: true,
+  }),
 });
 ```
 
-</div>
+## Transform Request Options
 
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownOllama.stream.text({
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust parameters based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
+`transformRequestOptions` receives the final Ollama SDK request after AG-UI input has been mapped. Use it for server-owned model settings.
 
 ```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
-  const stream = HashbrownOllama.stream.text({
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
+const stream = HashbrownOllama.stream.text({
+  model: process.env.OLLAMA_MODEL ?? 'gemma3',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    options: {
+      ...options.options,
+      temperature: 0.2,
+      num_predict: 2048,
     },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  );
+  }),
 });
 ```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/angular/concept/transform-request-options)
-
----
-
-## Advanced: Tools, Function Calling, and Response Schema
-
-- **Tools:** Add tools using function specs (name, description, parameters as JSON Schema). The adapter forwards them to Ollama with `strict` mode enabled.
-- **Function Calling:** Ollama can return `tool_calls` which are streamed as frames; execute your tool and continue the conversation by sending a `tool` message.
-- **Response Format:** Pass a JSON schema in `responseFormat` to request validated structured output from models that support it.
-
----
-
-## Using Extended Thinking with DeepSeek Models
-
-DeepSeek R1 and similar models support an extended thinking mode via the `think` parameter. You can enable this using `transformRequestOptions`:
-
-```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOllama.stream.text({
-    request: req.body,
-    transformRequestOptions: async (options) => ({
-      ...options,
-      think: true, // Enable extended thinking for DeepSeek R1
-    }),
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-  res.end();
-});
-```
-
-The `think` parameter accepts:
-- `true` - Enable thinking
-- `false` - Disable thinking (default)

--- a/www/analog/src/app/pages/docs/react/platform/ollama.md
+++ b/www/analog/src/app/pages/docs/react/platform/ollama.md
@@ -2,91 +2,75 @@
 title: 'Ollama: Hashbrown React Docs'
 meta:
   - name: description
-    content: 'First, install the Ollama adapter package:'
+    content: 'Hashbrown maps AG-UI runs to the official Ollama SDK and streams canonical AG-UI events.'
 ---
+
 # Ollama
 
-First, install the Ollama adapter package:
-
-<hb-code-example header="terminal">
+Install the Ollama adapter, official Ollama SDK, and AG-UI SSE packages:
 
 ```sh
-npm install @hashbrownai/ollama
+npm install @hashbrownai/ollama ollama @ag-ui/core @ag-ui/encoder
 ```
 
-</hb-code-example>
+## Streaming Text Responses
 
----
+`HashbrownOllama.stream.text(options)` accepts an AG-UI `RunAgentInput` and returns an `AsyncIterable<AGUIEvent>`. The adapter uses the official Ollama SDK streaming chat API. Encode its events as AG-UI SSE at your HTTP boundary.
 
-## `HashbrownOllama.stream.text(options)`
+The model is server configuration and is not read from the client run input. By default the official SDK connects to the local Ollama server. Pass `host` for a remote or containerized server, or pass a preconfigured `client` for custom headers and transport settings. An explicit `client` takes precedence over `host`.
 
-Streams an Ollama chat completion as a series of encoded frames. Handles content, tool calls, and errors, and yields each frame as a `Uint8Array`.
+### API Reference
 
-**Options:**
+| Name                      | Type                                    | Description                                                            |
+| ------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| `client`                  | `Ollama`                                | _(Optional)_ Preconfigured official Ollama SDK client.                 |
+| `host`                    | `string`                                | _(Optional)_ Ollama host URL used when creating a client for this run. |
+| `model`                   | `string`                                | Server-selected Ollama model.                                          |
+| `input`                   | `OllamaHashbrownRunAgentInput`          | AG-UI run input, including messages and tools.                         |
+| `signal`                  | `AbortSignal`                           | _(Optional)_ Cancels the Ollama request when the client disconnects.   |
+| `transformRequestOptions` | `(params) => params \| Promise<params>` | _(Optional)_ Transforms the final streaming Ollama `ChatRequest`.      |
 
-| Name                       | Type                              | Description                                                                                        |
-| -------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `host`                     | `string`                          | _(Optional)_ Ollama host URL, such as `http://localhost:11434` or a container host.                |
-| `client`                   | `Ollama`                          | _(Optional)_ Preconfigured Ollama SDK client for advanced transport settings.                      |
-| `turbo.apiKey`             | `string`                          | _(Optional)_ Use Ollama Turbo by providing an API key.                                             |
-| `request`                  | `Chat.Api.CompletionCreateParams` | The chat request: model, messages, tools, system, `responseFormat`, etc.                           |
-| `transformRequestOptions`  | `function`                        | _(Optional)_ Async function to transform Ollama request options before sending (e.g., for `think` parameter). |
+The adapter maps system and developer instructions, text message history, tool definitions, tool calls, and tool results. Text and tool calls become canonical AG-UI events. Ollama thinking becomes AG-UI reasoning records and is restored as `thinking` when that assistant message is sent back for continuation. Terminal response details, including metrics and log probabilities, are preserved as Ollama `RAW` events. Provider and mapping failures are emitted as `RUN_ERROR` events.
 
-**Supported Features:**
-
-- **Roles:** `user`, `assistant`, `tool`
-- **Tools:** Function calling with strict function schemas
-- **Response Format:** Optionally specify a JSON schema in `responseFormat` (forwarded to Ollama `format`)
-- **System Prompt:** Included as the first message if provided
-- **Streaming:** Each chunk is encoded into a resilient streaming format
-- **Local, Hosted, or Turbo:** Connects to the default Ollama client, a configured `host`, an explicit `client`, or Ollama Turbo
-
----
-
-## How It Works
-
-- **Messages:** Translated to Ollama’s message format, supporting `user`, `assistant`, and `tool` roles. Tool results are stringified as tool messages.
-- **Tools/Functions:** Tools are passed as function definitions with `name`, `description`, and JSON Schema `parameters` (`strict: true`).
-- **Response Format:** Pass a JSON schema in `responseFormat`; forwarded to Ollama as `format` for structured output.
-- **Streaming:** All data is sent as a stream of encoded frames (`Uint8Array`). Chunks may contain text, tool calls, errors, or finish signals.
-- **Client Selection:**
-  - `client`: use a preconfigured Ollama SDK client
-  - `turbo.apiKey`: route requests through Ollama Turbo
-  - `host`: create an Ollama SDK client for the configured host URL
-  - Default: use the default `ollama` Node client
-- **Error Handling:** Any thrown errors are sent as error frames before the stream ends.
-
----
-
-## Example: Node.js Server Integration
+### Node.js Server Integration
 
 <hb-backend-code-example>
 
 <div backend="express">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import express from 'express';
 
 const app = express();
 app.use(express.json());
 
-app.post('/chat', async (req, res) => {
+app.post('/run', async (req, res) => {
+  const abortController = new AbortController();
+  req.once('aborted', () => abortController.abort());
+  res.once('close', () => abortController.abort());
   const stream = HashbrownOllama.stream.text({
-    // Optional: connect to a remote or containerized Ollama server
-    // host: 'http://ollama:11434',
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: req.body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input: req.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  res.header('Content-Type', 'application/octet-stream');
+  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.header('Content-Type', encoder.getContentType());
+  res.header('Connection', 'keep-alive');
+  res.flushHeaders();
 
-  for await (const chunk of stream) {
-    res.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    res.write(encoder.encodeSSE(event));
   }
 
-  res.end();
+  if (!res.writableEnded) {
+    res.end();
+  }
 });
 
 app.listen(3000);
@@ -97,25 +81,36 @@ app.listen(3000);
 <div backend="fastify">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import Fastify from 'fastify';
 
 const fastify = Fastify();
 
-fastify.post('/chat', async (request, reply) => {
+fastify.post('/run', async (request, reply) => {
+  const abortController = new AbortController();
+  request.raw.once('aborted', () => abortController.abort());
+  reply.raw.once('close', () => abortController.abort());
   const stream = HashbrownOllama.stream.text({
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: request.body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input: request.body as RunAgentInput,
+    signal: abortController.signal,
   });
+  const encoder = new EventEncoder();
 
-  reply.header('Content-Type', 'application/octet-stream');
+  reply.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+  reply.header('Content-Type', encoder.getContentType());
+  reply.header('Connection', 'keep-alive');
 
-  for await (const chunk of stream) {
-    reply.raw.write(chunk); // Pipe each encoded frame as it arrives
+  for await (const event of stream) {
+    reply.raw.write(encoder.encodeSSE(event));
   }
 
-  reply.raw.end();
+  if (!reply.raw.writableEnded) {
+    reply.raw.end();
+  }
 });
 
 fastify.listen({ port: 3000 });
@@ -126,27 +121,43 @@ fastify.listen({ port: 3000 });
 <div backend="nestjs">
 
 ```ts
-import { Controller, Post, Body, Res } from '@nestjs/common';
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Response } from 'express';
+import type { Request, Response } from 'express';
 
 @Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Res() res: Response) {
+export class RunController {
+  @Post('run')
+  async run(
+    @Body() input: RunAgentInput,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
     const stream = HashbrownOllama.stream.text({
-      // Optional: use Ollama Turbo
-      // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-      request: body, // must be Chat.Api.CompletionCreateParams
+      host: process.env.OLLAMA_HOST,
+      model: process.env.OLLAMA_MODEL ?? 'gemma3',
+      input,
+      signal: abortController.signal,
     });
+    const encoder = new EventEncoder();
 
-    res.header('Content-Type', 'application/octet-stream');
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
 
-    for await (const chunk of stream) {
-      res.write(chunk); // Pipe each encoded frame as it arrives
+    for await (const event of stream) {
+      res.write(encoder.encodeSSE(event));
     }
 
-    res.end();
+    if (!res.writableEnded) {
+      res.end();
+    }
   }
 }
 ```
@@ -156,34 +167,39 @@ export class ChatController {
 <div backend="hono">
 
 ```ts
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
 import { HashbrownOllama } from '@hashbrownai/ollama';
 import { Hono } from 'hono';
 
 const app = new Hono();
 
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
+app.post('/run', async (c) => {
+  const input = (await c.req.json()) as RunAgentInput;
   const stream = HashbrownOllama.stream.text({
-    // Optional: use Ollama Turbo
-    // turbo: { apiKey: process.env.OLLAMA_API_KEY! },
-    request: body, // must be Chat.Api.CompletionCreateParams
+    host: process.env.OLLAMA_HOST,
+    model: process.env.OLLAMA_MODEL ?? 'gemma3',
+    input,
+    signal: c.req.raw.signal,
   });
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
 
   return new Response(
     new ReadableStream({
       async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk); // Pipe each encoded frame as it arrives
+        for await (const event of stream) {
+          controller.enqueue(textEncoder.encode(encoder.encodeSSE(event)));
         }
         controller.close();
       },
     }),
     {
       headers: {
-        'Content-Type': 'application/octet-stream',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Content-Type': encoder.getContentType(),
       },
-    }
+    },
   );
 });
 
@@ -194,216 +210,81 @@ export default app;
 
 </hb-backend-code-example>
 
----
+## Structured Output
 
----
+Set `input.hashbrown.responseSchema` to use Ollama native structured output. Hashbrown forwards a cloned JSON Schema as the Ollama `format` request field; it does not emulate or prevalidate provider support.
 
-### Transform Request Options
+```ts
+const input = {
+  ...runInput,
+  hashbrown: {
+    responseSchema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+      },
+      required: ['answer'],
+    },
+  },
+};
+```
 
-The `transformRequestOptions` parameter allows you to intercept and modify the chat request before it's sent to Ollama. Use `host` or `client` for transport settings such as the Ollama server URL.
+Ollama Cloud does not currently support structured outputs. Use a local or self-hosted model that supports `format` when setting `responseSchema`.
 
-<hb-backend-code-example>
+## Ollama Cloud
 
-<div backend="express">
+Configure the official SDK client with the Ollama Cloud host and authorization header, then pass it to Hashbrown:
 
 ```ts
 import { HashbrownOllama } from '@hashbrownai/ollama';
-import express from 'express';
+import { Ollama } from 'ollama';
 
-const app = express();
-app.use(express.json());
+const client = new Ollama({
+  host: 'https://ollama.com',
+  headers: {
+    Authorization: `Bearer ${process.env.OLLAMA_API_KEY!}`,
+  },
+});
 
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOllama.stream.text({
-    request: req.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(req.user.id).creativity,
-      };
-    },
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-
-  res.end();
+const stream = HashbrownOllama.stream.text({
+  client,
+  model: process.env.OLLAMA_MODEL ?? 'gpt-oss:120b',
+  input,
 });
 ```
 
-</div>
+## Thinking
 
-<div backend="fastify">
+Use `transformRequestOptions` to enable thinking on a compatible model. Thinking chunks are emitted as AG-UI reasoning records and are included in provider continuation messages.
 
 ```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import Fastify from 'fastify';
-
-const fastify = Fastify();
-
-fastify.post('/chat', async (request, reply) => {
-  const stream = HashbrownOllama.stream.text({
-    request: request.body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(request.user.id).creativity,
-      };
-    },
-  });
-
-  reply.header('Content-Type', 'application/octet-stream');
-
-  for await (const chunk of stream) {
-    reply.raw.write(chunk);
-  }
-
-  reply.raw.end();
+const stream = HashbrownOllama.stream.text({
+  model: process.env.OLLAMA_MODEL ?? 'deepseek-r1',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    think: true,
+  }),
 });
 ```
 
-</div>
+## Transform Request Options
 
-<div backend="nestjs">
-
-```ts
-import { Controller, Post, Body, Res, Req } from '@nestjs/common';
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Response, Request } from 'express';
-
-@Controller()
-export class ChatController {
-  @Post('chat')
-  async chat(@Body() body: any, @Req() req: Request, @Res() res: Response) {
-    const stream = HashbrownOllama.stream.text({
-      request: body,
-      transformRequestOptions: (options) => {
-        return {
-          ...options,
-          // Add server-side system prompt
-          messages: [
-            { role: 'system', content: 'You are a helpful assistant.' },
-            ...options.messages,
-          ],
-          // Adjust parameters based on user preferences
-          temperature: getUserPreferences(req.user.id).creativity,
-        };
-      },
-    });
-
-    res.header('Content-Type', 'application/octet-stream');
-
-    for await (const chunk of stream) {
-      res.write(chunk);
-    }
-
-    res.end();
-  }
-}
-```
-
-</div>
-
-<div backend="hono">
+`transformRequestOptions` receives the final Ollama SDK request after AG-UI input has been mapped. Use it for server-owned model settings.
 
 ```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-import { Hono } from 'hono';
-
-const app = new Hono();
-
-app.post('/chat', async (c) => {
-  const body = await c.req.json();
-  
-  const stream = HashbrownOllama.stream.text({
-    request: body,
-    transformRequestOptions: (options) => {
-      return {
-        ...options,
-        // Add server-side system prompt
-        messages: [
-          { role: 'system', content: 'You are a helpful assistant.' },
-          ...options.messages,
-        ],
-        // Adjust parameters based on user preferences
-        temperature: getUserPreferences(c.req.user.id).creativity,
-      };
+const stream = HashbrownOllama.stream.text({
+  model: process.env.OLLAMA_MODEL ?? 'gemma3',
+  input,
+  transformRequestOptions: (options) => ({
+    ...options,
+    options: {
+      ...options.options,
+      temperature: 0.2,
+      num_predict: 2048,
     },
-  });
-
-  return new Response(
-    new ReadableStream({
-      async start(controller) {
-        for await (const chunk of stream) {
-          controller.enqueue(chunk);
-        }
-        controller.close();
-      },
-    }),
-    {
-      headers: {
-        'Content-Type': 'application/octet-stream',
-      },
-    }
-  );
+  }),
 });
 ```
-
-</div>
-
-</hb-backend-code-example>
 
 [Learn more about transformRequestOptions](/docs/react/concept/transform-request-options)
-
----
-
-## Advanced: Tools, Function Calling, and Response Schema
-
-- **Tools:** Add tools using function specs (name, description, parameters as JSON Schema). The adapter forwards them to Ollama with `strict` mode enabled.
-- **Function Calling:** Ollama can return `tool_calls` which are streamed as frames; execute your tool and continue the conversation by sending a `tool` message.
-- **Response Format:** Pass a JSON schema in `responseFormat` to request validated structured output from models that support it.
-
----
-
-## Using Extended Thinking with DeepSeek Models
-
-DeepSeek R1 and similar models support an extended thinking mode via the `think` parameter. You can enable this using `transformRequestOptions`:
-
-```ts
-import { HashbrownOllama } from '@hashbrownai/ollama';
-
-app.post('/chat', async (req, res) => {
-  const stream = HashbrownOllama.stream.text({
-    request: req.body,
-    transformRequestOptions: async (options) => ({
-      ...options,
-      think: true, // Enable extended thinking for DeepSeek R1
-    }),
-  });
-
-  res.header('Content-Type', 'application/octet-stream');
-  for await (const chunk of stream) {
-    res.write(chunk);
-  }
-  res.end();
-});
-```
-
-The `think` parameter accepts:
-- `true` - Enable thinking
-- `false` - Disable thinking (default)


### PR DESCRIPTION
## Summary

- replace the Ollama binary-frame transport with canonical AG-UI events
- map AG-UI messages, tools, tool results, reasoning continuations, and structured-output schemas to the official Ollama SDK
- preserve thinking as AG-UI reasoning records and terminal provider details as RAW events
- add isolated cancellation behavior for owned and caller-provided Ollama clients
- upgrade the official Ollama SDK to 0.6.3
- convert deterministic Aimock coverage, the kitchen-sink example, and React/Angular documentation to AG-UI SSE

## Breaking Changes

- `HashbrownOllama.stream.text()` now accepts `model`, `input`, `signal`, `host`, `client`, and `transformRequestOptions`
- the stream now returns `AsyncIterable<AGUIEvent>` instead of encoded binary frames
- `request`, `loadThread`, `saveThread`, and `turbo` have been removed
- `@hashbrownai/core` is no longer a peer dependency
- HTTP integrations must encode returned events as AG-UI SSE
- the package now requires Node.js 20 or newer and Ollama SDK 0.6.3

## Verification

- [x] `npx nx build ollama --skip-nx-cache`
- [x] `npx nx test ollama --skip-nx-cache` - 22 tests
- [x] `npx nx e2e ollama --skip-nx-cache` - 7 Aimock tests
- [x] `npx nx lint ollama --skip-nx-cache`
- [x] `npx nx build-api-report ollama --skip-nx-cache`
- [x] `npx nx build kitchen-sink-server --skip-nx-cache`
- [x] `npx nx test www --skip-nx-cache`
- [x] `npx nx build www --skip-nx-cache`
- [x] local HTTP/SSE smoke test using Ollama 0.33.1 and `qwen2.5:14b`