### PR TITLE
refactor(core): isolate and rename the chat runtime

### DIFF
--- a/packages/angular/src/resources/chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/chat-resource.fn.spec.ts
@@ -1,23 +1,28 @@
-import { signal } from '@angular/core';
+import { inject, InjectionToken, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { chatResource } from './chat-resource.fn';
 
-const fryHashbrownMock = vi.hoisted(() => vi.fn());
+const createChatRuntimeMock = vi.hoisted(() => vi.fn());
+const createHttpTransportMock = vi.hoisted(() => vi.fn());
+const middlewareContextToken = new InjectionToken<string>(
+  'middleware context test',
+);
 
 vi.mock('@hashbrownai/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@hashbrownai/core')>();
 
   return {
     ...actual,
-    fryHashbrown: fryHashbrownMock,
+    createHttpTransport: createHttpTransportMock,
+    createChatRuntime: createChatRuntimeMock,
   };
 });
 
 test('chatResource initializes with the provided message history', () => {
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockImplementation((init) =>
-    createHashbrownStub({ messages: init.messages ?? [] }),
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockImplementation((init) =>
+    createRuntimeStub({ messages: init.messages ?? [] }),
   );
   const messages = [
     {
@@ -40,10 +45,73 @@ test('chatResource initializes with the provided message history', () => {
   expect(chat.value()).toEqual(messages);
 });
 
+test('chatResource lowers provider HTTP options into a lazy transport', () => {
+  const middleware = vi.fn((request: RequestInit) => {
+    expect(inject(middlewareContextToken)).toBe('injection-context');
+    return request;
+  });
+  const transport = { name: 'angular-http', send: vi.fn() };
+  createHttpTransportMock.mockReset();
+  createHttpTransportMock.mockReturnValue(transport);
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(createRuntimeStub({ messages: [] }));
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: middlewareContextToken, useValue: 'injection-context' },
+      provideHashbrown({ baseUrl: '/angular-run', middleware: [middleware] }),
+    ],
+  });
+
+  TestBed.runInInjectionContext(() => chatResource({ system: 'test' }));
+
+  const init = createChatRuntimeMock.mock.calls[0]?.[0];
+  expect(init).not.toHaveProperty('apiUrl');
+  expect(init).not.toHaveProperty('middleware');
+  expect(init.transport).toEqual(expect.any(Function));
+  expect(init.transport()).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenCalledWith({
+    baseUrl: '/angular-run',
+    middleware: [expect.any(Function)],
+  });
+  const wrappedMiddleware = createHttpTransportMock.mock.calls[0]?.[0]
+    .middleware[0] as (request: RequestInit) => RequestInit;
+  const request = { headers: { Authorization: 'Bearer test' } };
+
+  expect(wrappedMiddleware(request)).toBe(request);
+  expect(middleware).toHaveBeenCalledWith(request);
+});
+
+test('chatResource transport overrides provider HTTP configuration', () => {
+  const providerTransport = { name: 'provider-transport', send: vi.fn() };
+  const resourceTransport = { name: 'resource-transport', send: vi.fn() };
+  createHttpTransportMock.mockReset();
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(createRuntimeStub({ messages: [] }));
+
+  TestBed.configureTestingModule({
+    providers: [
+      provideHashbrown({
+        baseUrl: '/angular-run',
+        transport: providerTransport,
+      }),
+    ],
+  });
+
+  TestBed.runInInjectionContext(() =>
+    chatResource({ system: 'test', transport: resourceTransport }),
+  );
+
+  expect(createChatRuntimeMock.mock.calls[0]?.[0].transport).toBe(
+    resourceTransport,
+  );
+  expect(createHttpTransportMock).not.toHaveBeenCalled();
+});
+
 test('chatResource allows replacing message history', () => {
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockImplementation((init) =>
-    createHashbrownStub({ messages: init.messages ?? [] }),
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockImplementation((init) =>
+    createRuntimeStub({ messages: init.messages ?? [] }),
   );
   const initialMessages = [
     {
@@ -75,12 +143,13 @@ test('chatResource allows replacing message history', () => {
 });
 
 test('chatResource updates runtime options when option signals change', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
+  const transport = resetHttpTransportMock();
   const apiUrl = signal('/chat-a');
   const system = signal('System A');
   const threadId = signal<string | undefined>('thread-a');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -94,13 +163,18 @@ test('chatResource updates runtime options when option signals change', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      apiUrl: '/chat-a',
-      system: 'System A',
-      threadId: 'thread-a',
-    }),
-  );
+  const initialOptions = createChatRuntimeMock.mock.calls[0]?.[0];
+  expect(initialOptions).toMatchObject({
+    system: 'System A',
+    threadId: 'thread-a',
+    transport: expect.any(Function),
+  });
+  expect(initialOptions).not.toHaveProperty('apiUrl');
+  expect(resolveTransportOption(initialOptions.transport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '/chat-a',
+    middleware: undefined,
+  });
   expect(resource).not.toHaveProperty('isLoadingThread');
   expect(resource).not.toHaveProperty('isSavingThread');
   expect(resource).not.toHaveProperty('threadLoadError');
@@ -112,18 +186,23 @@ test('chatResource updates runtime options when option signals change', () => {
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      apiUrl: '/chat-b',
-      system: 'System B',
-      threadId: 'thread-b',
-    }),
-  );
+  const updatedOptions = runtime.updateOptions.mock.calls.at(-1)?.[0];
+  expect(updatedOptions).toMatchObject({
+    system: 'System B',
+    threadId: 'thread-b',
+    transport: expect.any(Function),
+  });
+  expect(updatedOptions).not.toHaveProperty('apiUrl');
+  expect(resolveTransportOption(updatedOptions.transport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '/chat-b',
+    middleware: undefined,
+  });
 
   threadId.set(undefined);
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: undefined,
     }),
@@ -132,7 +211,7 @@ test('chatResource updates runtime options when option signals change', () => {
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -140,10 +219,11 @@ test('chatResource updates runtime options when option signals change', () => {
 });
 
 test('chatResource preserves an empty apiUrl option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
+  const transport = resetHttpTransportMock();
   const apiUrl = signal('');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -156,35 +236,41 @@ test('chatResource preserves an empty apiUrl option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      apiUrl: '',
-    }),
-  );
+  const initialTransport = createChatRuntimeMock.mock.calls[0]?.[0].transport;
+  expect(resolveTransportOption(initialTransport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '',
+    middleware: undefined,
+  });
 
   apiUrl.set('/chat-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      apiUrl: '/chat-b',
-    }),
-  );
+  const updatedTransport =
+    runtime.updateOptions.mock.calls.at(-1)?.[0].transport;
+  expect(resolveTransportOption(updatedTransport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '/chat-b',
+    middleware: undefined,
+  });
 
   apiUrl.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      apiUrl: '',
-    }),
-  );
+  const clearedTransport =
+    runtime.updateOptions.mock.calls.at(-1)?.[0].transport;
+  expect(resolveTransportOption(clearedTransport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '',
+    middleware: undefined,
+  });
 });
 
 test('chatResource preserves a literal empty apiUrl option', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const transport = resetHttpTransportMock();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -197,26 +283,29 @@ test('chatResource preserves a literal empty apiUrl option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      apiUrl: '',
-    }),
-  );
+  const initialTransport = createChatRuntimeMock.mock.calls[0]?.[0].transport;
+  expect(resolveTransportOption(initialTransport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '',
+    middleware: undefined,
+  });
 
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      apiUrl: '',
-    }),
-  );
+  const updatedTransport =
+    runtime.updateOptions.mock.calls.at(-1)?.[0].transport;
+  expect(resolveTransportOption(updatedTransport)).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenLastCalledWith({
+    baseUrl: '',
+    middleware: undefined,
+  });
 });
 
 test('chatResource preserves an empty threadId option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const threadId = signal<string | undefined>('');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -229,7 +318,7 @@ test('chatResource preserves an empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -238,7 +327,7 @@ test('chatResource preserves an empty threadId option', () => {
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: 'thread-b',
     }),
@@ -247,7 +336,7 @@ test('chatResource preserves an empty threadId option', () => {
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -255,9 +344,9 @@ test('chatResource preserves an empty threadId option', () => {
 });
 
 test('chatResource preserves a literal empty threadId option', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -270,7 +359,7 @@ test('chatResource preserves a literal empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -278,7 +367,7 @@ test('chatResource preserves a literal empty threadId option', () => {
 
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -286,10 +375,10 @@ test('chatResource preserves a literal empty threadId option', () => {
 });
 
 test('chatResource omits threadId from runtime updates when not provided', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const system = signal('System A');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -303,7 +392,7 @@ test('chatResource omits threadId from runtime updates when not provided', () =>
 
   system.set('System B');
   TestBed.flushEffects();
-  const lastOptions = getLastUpdateOptions(hashbrown);
+  const lastOptions = getLastUpdateOptions(runtime);
 
   expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
     false,
@@ -311,10 +400,10 @@ test('chatResource omits threadId from runtime updates when not provided', () =>
 });
 
 test('chatResource throws from value and snapshots a terminal error', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const failure = new Error('Chat request failed');
-  const hashbrown = createHashbrownStub({ messages: [], error: failure });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [], error: failure });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -331,7 +420,7 @@ test('chatResource throws from value and snapshots a terminal error', () => {
 });
 
 test('chatResource keeps stale messages readable while loading with an error', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const messages = [
     {
       role: 'assistant' as const,
@@ -339,12 +428,12 @@ test('chatResource keeps stale messages readable while loading with an error', (
       toolCalls: [],
     },
   ];
-  const hashbrown = createHashbrownStub({
+  const runtime = createRuntimeStub({
     messages,
     error: new Error('Stale error'),
     isLoading: true,
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -361,7 +450,7 @@ test('chatResource keeps stale messages readable while loading with an error', (
 });
 
 test('chatResource reload removes the last assistant response without mutating history', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const messages = [
     { role: 'user' as const, content: 'Summarize this' },
     {
@@ -371,8 +460,8 @@ test('chatResource reload removes the last assistant response without mutating h
     },
   ];
   const originalMessages = structuredClone(messages);
-  const hashbrown = createHashbrownStub({ messages });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -385,15 +474,15 @@ test('chatResource reload removes the last assistant response without mutating h
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(true);
-  expect(hashbrown.setMessages).toHaveBeenCalledTimes(1);
-  expect(hashbrown.setMessages).toHaveBeenCalledWith([messages[0]]);
+  expect(runtime.setMessages).toHaveBeenCalledTimes(1);
+  expect(runtime.setMessages).toHaveBeenCalledWith([messages[0]]);
   expect(messages).toEqual(originalMessages);
 });
 
 test('chatResource reload returns false when messages are empty', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -406,10 +495,24 @@ test('chatResource reload returns false when messages are empty', () => {
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(false);
-  expect(hashbrown.setMessages).not.toHaveBeenCalled();
+  expect(runtime.setMessages).not.toHaveBeenCalled();
 });
 
-function createHashbrownStub({
+function resetHttpTransportMock() {
+  const transport = { name: 'angular-http', send: vi.fn() };
+  createHttpTransportMock.mockReset();
+  createHttpTransportMock.mockReturnValue(transport);
+
+  return transport;
+}
+
+function resolveTransportOption(value: unknown) {
+  expect(value).toEqual(expect.any(Function));
+
+  return (value as () => unknown)();
+}
+
+function createRuntimeStub({
   messages,
   error,
   isLoading = false,
@@ -436,7 +539,7 @@ function createHashbrownStub({
     isSavingThread: createSignal(false),
     threadLoadError: createSignal(undefined),
     threadSaveError: createSignal(undefined),
-    sizzle: vi.fn(() => vi.fn()),
+    start: vi.fn(() => vi.fn()),
     updateOptions: vi.fn(),
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),
@@ -445,10 +548,10 @@ function createHashbrownStub({
   } as never;
 }
 
-function getLastUpdateOptions(hashbrown: {
+function getLastUpdateOptions(runtime: {
   updateOptions: { mock: { calls: [Record<string, unknown>][] } };
 }) {
-  const calls = hashbrown.updateOptions.mock.calls;
+  const calls = runtime.updateOptions.mock.calls;
 
   return calls[calls.length - 1]?.[0];
 }

--- a/packages/angular/src/resources/chat-resource.fn.ts
+++ b/packages/angular/src/resources/chat-resource.fn.ts
@@ -10,7 +10,11 @@ import {
   runInInjectionContext,
   Signal,
 } from '@angular/core';
-import { Chat, fryHashbrown, type TransportOrFactory } from '@hashbrownai/core';
+import {
+  Chat,
+  createChatRuntime,
+  type TransportOrFactory,
+} from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
 import {
   readReactiveOption,
@@ -19,6 +23,7 @@ import {
 } from '../utils/signals';
 import { ReactiveOption } from '../utils/types';
 import { bindToolToInjector } from '../utils/create-tool.fn';
+import { createTransport } from '../utils/create-transport.fn';
 import {
   createResourceSnapshot,
   createResourceValue,
@@ -173,20 +178,25 @@ export function chatResource<Tools extends Chat.AnyTool>(
   const config = ɵinjectHashbrownConfig();
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
-  const hashbrown = fryHashbrown({
-    apiUrl:
-      options.apiUrl !== undefined
-        ? readReactiveOption(options.apiUrl)
-        : config.baseUrl,
-    middleware: config.middleware?.map((m): Chat.Middleware => {
-      return (requestInit) =>
-        runInInjectionContext(injector, () => m(requestInit));
-    }),
+  const resolveTransport = () =>
+    createTransport({
+      transport: options.transport ?? config.transport,
+      readBaseUrl: () =>
+        options.apiUrl !== undefined
+          ? readReactiveOption(options.apiUrl)
+          : config.baseUrl,
+      createMiddleware: () =>
+        config.middleware?.map((middleware): Chat.Middleware => {
+          return (requestInit) =>
+            runInInjectionContext(injector, () => middleware(requestInit));
+        }),
+    });
+  const runtime = createChatRuntime({
     system: readReactiveOption(options.system),
     messages: options.messages ? [...readSignalLike(options.messages)] : [],
     tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
     debugName: options.debugName,
-    transport: options.transport ?? config.transport,
+    transport: resolveTransport(),
     ui: false,
     threadId:
       options.threadId !== undefined
@@ -195,19 +205,11 @@ export function chatResource<Tools extends Chat.AnyTool>(
   });
 
   const optionsEffect = effect(() => {
-    hashbrown.updateOptions({
-      apiUrl:
-        options.apiUrl !== undefined
-          ? readReactiveOption(options.apiUrl)
-          : config.baseUrl,
-      middleware: config.middleware?.map((m): Chat.Middleware => {
-        return (requestInit) =>
-          runInInjectionContext(injector, () => m(requestInit));
-      }),
+    runtime.updateOptions({
       system: readReactiveOption(options.system),
       tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
       debugName: options.debugName,
-      transport: options.transport ?? config.transport,
+      transport: resolveTransport(),
       ui: false,
       ...(options.threadId !== undefined
         ? { threadId: readReactiveOption(options.threadId) }
@@ -215,7 +217,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
     });
   });
 
-  const teardown = hashbrown.sizzle();
+  const teardown = runtime.start();
 
   destroyRef.onDestroy(() => {
     teardown();
@@ -223,43 +225,43 @@ export function chatResource<Tools extends Chat.AnyTool>(
   });
 
   const rawValue = toNgSignal(
-    hashbrown.messages,
+    runtime.messages,
     options.debugName && `${options.debugName}.rawValue`,
   );
   const isReceiving = toNgSignal(
-    hashbrown.isReceiving,
+    runtime.isReceiving,
     options.debugName && `${options.debugName}.isReceiving`,
   );
   const isSending = toNgSignal(
-    hashbrown.isSending,
+    runtime.isSending,
     options.debugName && `${options.debugName}.isSending`,
   );
   const isGenerating = toNgSignal(
-    hashbrown.isGenerating,
+    runtime.isGenerating,
     options.debugName && `${options.debugName}.isGenerating`,
   );
   const isRunningToolCalls = toNgSignal(
-    hashbrown.isRunningToolCalls,
+    runtime.isRunningToolCalls,
     options.debugName && `${options.debugName}.isRunningToolCalls`,
   );
   const isLoading = toNgSignal(
-    hashbrown.isLoading,
+    runtime.isLoading,
     options.debugName && `${options.debugName}.isLoading`,
   );
   const error = toNgSignal(
-    hashbrown.error,
+    runtime.error,
     options.debugName && `${options.debugName}.error`,
   );
   const sendingError = toNgSignal(
-    hashbrown.sendingError,
+    runtime.sendingError,
     options.debugName && `${options.debugName}.sendingError`,
   );
   const generatingError = toNgSignal(
-    hashbrown.generatingError,
+    runtime.generatingError,
     options.debugName && `${options.debugName}.generatingError`,
   );
   const lastAssistantMessage = toNgSignal(
-    hashbrown.lastAssistantMessage,
+    runtime.lastAssistantMessage,
     options.debugName && `${options.debugName}.lastAssistantMessage`,
   );
   const status = computed(
@@ -302,7 +304,7 @@ export function chatResource<Tools extends Chat.AnyTool>(
     const lastMessage = messages[messages.length - 1];
 
     if (lastMessage?.role === 'assistant') {
-      hashbrown.setMessages(messages.slice(0, -1));
+      runtime.setMessages(messages.slice(0, -1));
 
       return true;
     }
@@ -318,15 +320,15 @@ export function chatResource<Tools extends Chat.AnyTool>(
   }
 
   function sendMessage(message: Chat.UserMessage) {
-    hashbrown.sendMessage(message);
+    runtime.sendMessage(message);
   }
 
   function setMessages(messages: Chat.Message<string, Tools>[]) {
-    hashbrown.setMessages(messages);
+    runtime.setMessages(messages);
   }
 
   function stop(clearStreamingMessage = false) {
-    hashbrown.stop(clearStreamingMessage);
+    runtime.stop(clearStreamingMessage);
   }
 
   return {

--- a/packages/angular/src/resources/completion-resource.fn.spec.ts
+++ b/packages/angular/src/resources/completion-resource.fn.spec.ts
@@ -3,25 +3,25 @@ import { TestBed } from '@angular/core/testing';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { completionResource } from './completion-resource.fn';
 
-const fryHashbrownMock = vi.hoisted(() => vi.fn());
+const createChatRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@hashbrownai/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@hashbrownai/core')>();
 
   return {
     ...actual,
-    fryHashbrown: fryHashbrownMock,
+    createChatRuntime: createChatRuntimeMock,
   };
 });
 
 test('completionResource updates runtime options when option signals change', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const apiUrl = signal('/completion-a');
   const system = signal('System A');
   const threadId = signal<string | undefined>('thread-a');
   const input = signal('Summarize this');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -36,11 +36,11 @@ test('completionResource updates runtime options when option signals change', ()
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      apiUrl: '/completion-a',
       system: 'System A',
       threadId: 'thread-a',
+      transport: expect.any(Function),
     }),
   );
   expect(resource).not.toHaveProperty('isLoadingThread');
@@ -54,18 +54,18 @@ test('completionResource updates runtime options when option signals change', ()
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '/completion-b',
       system: 'System B',
       threadId: 'thread-b',
+      transport: expect.any(Function),
     }),
   );
 
   threadId.set(undefined);
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: undefined,
     }),
@@ -74,7 +74,7 @@ test('completionResource updates runtime options when option signals change', ()
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -82,11 +82,11 @@ test('completionResource updates runtime options when option signals change', ()
 });
 
 test('completionResource preserves an empty apiUrl option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const apiUrl = signal('');
   const input = signal('Summarize this');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -100,37 +100,37 @@ test('completionResource preserves an empty apiUrl option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      apiUrl: '',
+      transport: expect.any(Function),
     }),
   );
 
   apiUrl.set('/completion-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '/completion-b',
+      transport: expect.any(Function),
     }),
   );
 
   apiUrl.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '',
+      transport: expect.any(Function),
     }),
   );
 });
 
 test('completionResource preserves an empty threadId option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const input = signal('Summarize this');
   const threadId = signal<string | undefined>('');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -144,7 +144,7 @@ test('completionResource preserves an empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -153,7 +153,7 @@ test('completionResource preserves an empty threadId option', () => {
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: 'thread-b',
     }),
@@ -162,7 +162,7 @@ test('completionResource preserves an empty threadId option', () => {
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -170,10 +170,10 @@ test('completionResource preserves an empty threadId option', () => {
 });
 
 test('completionResource preserves a literal empty threadId option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const input = signal('Summarize this');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -187,7 +187,7 @@ test('completionResource preserves a literal empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -195,7 +195,7 @@ test('completionResource preserves a literal empty threadId option', () => {
 
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -203,11 +203,11 @@ test('completionResource preserves a literal empty threadId option', () => {
 });
 
 test('completionResource omits threadId from runtime updates when not provided', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const system = signal('System A');
   const input = signal('Summarize this');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -222,7 +222,7 @@ test('completionResource omits threadId from runtime updates when not provided',
 
   system.set('System B');
   TestBed.flushEffects();
-  const lastOptions = getLastUpdateOptions(hashbrown);
+  const lastOptions = getLastUpdateOptions(runtime);
 
   expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
     false,
@@ -230,11 +230,11 @@ test('completionResource omits threadId from runtime updates when not provided',
 });
 
 test('completionResource exposes a resolved snapshot after a successful completion', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({
     messages: [{ role: 'assistant', content: 'Completed response' }],
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -256,11 +256,11 @@ test('completionResource exposes a resolved snapshot after a successful completi
 });
 
 test('completionResource retains a successful empty string', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({
     messages: [{ role: 'assistant', content: '' }],
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -279,14 +279,14 @@ test('completionResource retains a successful empty string', () => {
 });
 
 test('completionResource exposes a non-retryable terminal error', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const failure = new Error('Request cannot be retried');
-  const hashbrown = createHashbrownStub({
+  const runtime = createRuntimeStub({
     messages: [],
     error: failure,
     exhaustedRetries: false,
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -305,14 +305,14 @@ test('completionResource exposes a non-retryable terminal error', () => {
 });
 
 test('completionResource reloads a resolved completion without mutating message history', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const messages = [
     { role: 'user' as const, content: 'Summarize this' },
     { role: 'assistant' as const, content: 'Completed response' },
   ];
   const originalMessages = structuredClone(messages);
-  const hashbrown = createHashbrownStub({ messages });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -322,24 +322,24 @@ test('completionResource reloads a resolved completion without mutating message 
       input: signal('Summarize this'),
     }),
   );
-  hashbrown.setMessages.mockClear();
+  runtime.setMessages.mockClear();
 
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(true);
-  expect(hashbrown.setMessages).toHaveBeenCalledTimes(1);
-  expect(hashbrown.setMessages).toHaveBeenCalledWith([messages[0]]);
-  expect(hashbrown.resendMessages).not.toHaveBeenCalled();
+  expect(runtime.setMessages).toHaveBeenCalledTimes(1);
+  expect(runtime.setMessages).toHaveBeenCalledWith([messages[0]]);
+  expect(runtime.resendMessages).not.toHaveBeenCalled();
   expect(messages).toEqual(originalMessages);
 });
 
 test('completionResource retries a failed completion with user-only history', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({
     messages: [{ role: 'user', content: 'Summarize this' }],
     error: new Error('Request failed'),
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -349,19 +349,19 @@ test('completionResource retries a failed completion with user-only history', ()
       input: signal('Summarize this'),
     }),
   );
-  hashbrown.setMessages.mockClear();
+  runtime.setMessages.mockClear();
 
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(true);
-  expect(hashbrown.resendMessages).toHaveBeenCalledTimes(1);
-  expect(hashbrown.setMessages).not.toHaveBeenCalled();
+  expect(runtime.resendMessages).toHaveBeenCalledTimes(1);
+  expect(runtime.setMessages).not.toHaveBeenCalled();
 });
 
 test('completionResource reload returns false when there is no request', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -371,18 +371,18 @@ test('completionResource reload returns false when there is no request', () => {
       input: signal<string | null>(null),
     }),
   );
-  hashbrown.setMessages.mockClear();
+  runtime.setMessages.mockClear();
 
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(false);
-  expect(hashbrown.setMessages).not.toHaveBeenCalled();
-  expect(hashbrown.resendMessages).not.toHaveBeenCalled();
+  expect(runtime.setMessages).not.toHaveBeenCalled();
+  expect(runtime.resendMessages).not.toHaveBeenCalled();
 });
 
 test('completionResource reload does not resend an already-answered history', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({
     messages: [
       { role: 'user', content: 'Summarize this' },
       { role: 'assistant', content: 'Completed response' },
@@ -390,7 +390,7 @@ test('completionResource reload does not resend an already-answered history', ()
     ],
     error: new Error('Follow-up operation failed'),
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -400,16 +400,16 @@ test('completionResource reload does not resend an already-answered history', ()
       input: signal('Summarize this'),
     }),
   );
-  hashbrown.setMessages.mockClear();
+  runtime.setMessages.mockClear();
 
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(false);
-  expect(hashbrown.setMessages).not.toHaveBeenCalled();
-  expect(hashbrown.resendMessages).not.toHaveBeenCalled();
+  expect(runtime.setMessages).not.toHaveBeenCalled();
+  expect(runtime.resendMessages).not.toHaveBeenCalled();
 });
 
-function createHashbrownStub({
+function createRuntimeStub({
   messages,
   error,
   exhaustedRetries = false,
@@ -436,7 +436,7 @@ function createHashbrownStub({
     isSavingThread: createSignal(false),
     threadLoadError: createSignal(undefined),
     threadSaveError: createSignal(undefined),
-    sizzle: vi.fn(() => vi.fn()),
+    start: vi.fn(() => vi.fn()),
     updateOptions: vi.fn(),
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),
@@ -445,10 +445,10 @@ function createHashbrownStub({
   } as never;
 }
 
-function getLastUpdateOptions(hashbrown: {
+function getLastUpdateOptions(runtime: {
   updateOptions: { mock: { calls: [Record<string, unknown>][] } };
 }) {
-  const calls = hashbrown.updateOptions.mock.calls;
+  const calls = runtime.updateOptions.mock.calls;
 
   return calls[calls.length - 1]?.[0];
 }

--- a/packages/angular/src/resources/completion-resource.fn.ts
+++ b/packages/angular/src/resources/completion-resource.fn.ts
@@ -10,8 +10,13 @@ import {
   runInInjectionContext,
   Signal,
 } from '@angular/core';
-import { Chat, fryHashbrown, type TransportOrFactory } from '@hashbrownai/core';
+import {
+  Chat,
+  createChatRuntime,
+  type TransportOrFactory,
+} from '@hashbrownai/core';
 import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
+import { createTransport } from '../utils/create-transport.fn';
 import { ReactiveOption } from '../utils/types';
 import { readReactiveOption, toNgSignal } from '../utils/signals';
 import {
@@ -105,21 +110,26 @@ export function completionResource<Input>(
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
   const config = ɵinjectHashbrownConfig();
-  const hashbrown = fryHashbrown({
+  const resolveTransport = () =>
+    createTransport({
+      transport: options.transport ?? config.transport,
+      readBaseUrl: () =>
+        options.apiUrl !== undefined
+          ? readReactiveOption(options.apiUrl)
+          : config.baseUrl,
+      createMiddleware: () =>
+        config.middleware?.map((middleware): Chat.Middleware => {
+          return (requestInit) =>
+            runInInjectionContext(injector, () => middleware(requestInit));
+        }),
+    });
+  const runtime = createChatRuntime({
     debugName: options.debugName,
-    apiUrl:
-      options.apiUrl !== undefined
-        ? readReactiveOption(options.apiUrl)
-        : config.baseUrl,
-    middleware: config.middleware?.map((m): Chat.Middleware => {
-      return (requestInit) =>
-        runInInjectionContext(injector, () => m(requestInit));
-    }),
     system: readReactiveOption(system),
     messages: [],
     tools: [],
     retries: 3,
-    transport: options.transport ?? config.transport,
+    transport: resolveTransport(),
     threadId:
       options.threadId !== undefined
         ? readReactiveOption(options.threadId)
@@ -127,41 +137,33 @@ export function completionResource<Input>(
   });
 
   const optionsEffect = effect(() => {
-    hashbrown.updateOptions({
+    runtime.updateOptions({
       debugName: options.debugName,
-      apiUrl:
-        options.apiUrl !== undefined
-          ? readReactiveOption(options.apiUrl)
-          : config.baseUrl,
-      middleware: config.middleware?.map((m): Chat.Middleware => {
-        return (requestInit) =>
-          runInInjectionContext(injector, () => m(requestInit));
-      }),
       system: readReactiveOption(system),
       tools: [],
       retries: 3,
-      transport: options.transport ?? config.transport,
+      transport: resolveTransport(),
       ...(options.threadId !== undefined
         ? { threadId: readReactiveOption(options.threadId) }
         : {}),
     });
   });
 
-  const teardown = hashbrown.sizzle();
+  const teardown = runtime.start();
 
   destroyRef.onDestroy(() => {
     teardown();
     optionsEffect.destroy();
   });
 
-  const messages = toNgSignal(hashbrown.messages);
-  const isReceiving = toNgSignal(hashbrown.isReceiving);
-  const isSending = toNgSignal(hashbrown.isSending);
-  const isGenerating = toNgSignal(hashbrown.isGenerating);
-  const isRunningToolCalls = toNgSignal(hashbrown.isRunningToolCalls);
-  const isLoading = toNgSignal(hashbrown.isLoading);
-  const sendingError = toNgSignal(hashbrown.sendingError);
-  const generatingError = toNgSignal(hashbrown.generatingError);
+  const messages = toNgSignal(runtime.messages);
+  const isReceiving = toNgSignal(runtime.isReceiving);
+  const isSending = toNgSignal(runtime.isSending);
+  const isGenerating = toNgSignal(runtime.isGenerating);
+  const isRunningToolCalls = toNgSignal(runtime.isRunningToolCalls);
+  const isLoading = toNgSignal(runtime.isLoading);
+  const sendingError = toNgSignal(runtime.sendingError);
+  const generatingError = toNgSignal(runtime.generatingError);
   const internalMessages = computed(() => {
     const _input = input();
 
@@ -178,14 +180,14 @@ export function completionResource<Input>(
   });
 
   const error = toNgSignal(
-    hashbrown.error,
+    runtime.error,
     options.debugName && `${options.debugName}.error`,
   );
 
   effect(() => {
     const _messages = internalMessages();
 
-    hashbrown.setMessages(_messages);
+    runtime.setMessages(_messages);
   });
 
   const rawValue = computed(
@@ -252,12 +254,12 @@ export function completionResource<Input>(
     }
 
     if (lastMessage.role === 'assistant') {
-      hashbrown.setMessages(requestMessages);
+      runtime.setMessages(requestMessages);
 
       return true;
     }
 
-    hashbrown.resendMessages();
+    runtime.resendMessages();
 
     return true;
   };
@@ -267,7 +269,7 @@ export function completionResource<Input>(
   }
 
   function stop(clearStreamingMessage = false) {
-    hashbrown.stop(clearStreamingMessage);
+    runtime.stop(clearStreamingMessage);
   }
 
   return {

--- a/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.spec.ts
@@ -4,24 +4,24 @@ import { s } from '@hashbrownai/core';
 import { provideHashbrown } from '../providers/provide-hashbrown.fn';
 import { structuredChatResource } from './structured-chat-resource.fn';
 
-const fryHashbrownMock = vi.hoisted(() => vi.fn());
+const createChatRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@hashbrownai/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@hashbrownai/core')>();
 
   return {
     ...actual,
-    fryHashbrown: fryHashbrownMock,
+    createChatRuntime: createChatRuntimeMock,
   };
 });
 
 test('structuredChatResource updates runtime options when option signals change', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const apiUrl = signal('/structured-a');
   const system = signal('System A');
   const threadId = signal<string | undefined>('thread-a');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -38,11 +38,11 @@ test('structuredChatResource updates runtime options when option signals change'
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      apiUrl: '/structured-a',
       system: 'System A',
       threadId: 'thread-a',
+      transport: expect.any(Function),
     }),
   );
   expect(resource).not.toHaveProperty('isLoadingThread');
@@ -56,18 +56,18 @@ test('structuredChatResource updates runtime options when option signals change'
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '/structured-b',
       system: 'System B',
       threadId: 'thread-b',
+      transport: expect.any(Function),
     }),
   );
 
   threadId.set(undefined);
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: undefined,
     }),
@@ -76,7 +76,7 @@ test('structuredChatResource updates runtime options when option signals change'
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -84,10 +84,10 @@ test('structuredChatResource updates runtime options when option signals change'
 });
 
 test('structuredChatResource preserves an empty apiUrl option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const apiUrl = signal('');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -103,36 +103,36 @@ test('structuredChatResource preserves an empty apiUrl option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      apiUrl: '',
+      transport: expect.any(Function),
     }),
   );
 
   apiUrl.set('/structured-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '/structured-b',
+      transport: expect.any(Function),
     }),
   );
 
   apiUrl.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
-      apiUrl: '',
+      transport: expect.any(Function),
     }),
   );
 });
 
 test('structuredChatResource preserves an empty threadId option', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const threadId = signal<string | undefined>('');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -148,7 +148,7 @@ test('structuredChatResource preserves an empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -157,7 +157,7 @@ test('structuredChatResource preserves an empty threadId option', () => {
   threadId.set('thread-b');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: 'thread-b',
     }),
@@ -166,7 +166,7 @@ test('structuredChatResource preserves an empty threadId option', () => {
   threadId.set('');
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -174,9 +174,9 @@ test('structuredChatResource preserves an empty threadId option', () => {
 });
 
 test('structuredChatResource preserves a literal empty threadId option', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -192,7 +192,7 @@ test('structuredChatResource preserves a literal empty threadId option', () => {
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -200,7 +200,7 @@ test('structuredChatResource preserves a literal empty threadId option', () => {
 
   TestBed.flushEffects();
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({
       threadId: '',
     }),
@@ -208,10 +208,10 @@ test('structuredChatResource preserves a literal empty threadId option', () => {
 });
 
 test('structuredChatResource omits threadId from runtime updates when not provided', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const system = signal('System A');
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
 
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
@@ -228,7 +228,7 @@ test('structuredChatResource omits threadId from runtime updates when not provid
 
   system.set('System B');
   TestBed.flushEffects();
-  const lastOptions = getLastUpdateOptions(hashbrown);
+  const lastOptions = getLastUpdateOptions(runtime);
 
   expect(Object.prototype.hasOwnProperty.call(lastOptions, 'threadId')).toBe(
     false,
@@ -236,14 +236,14 @@ test('structuredChatResource omits threadId from runtime updates when not provid
 });
 
 test('structuredChatResource exposes a terminal error when retries are disabled', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const failure = new Error('Invalid request');
-  const hashbrown = createHashbrownStub({
+  const runtime = createRuntimeStub({
     messages: [],
     error: failure,
     exhaustedRetries: false,
   });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -258,7 +258,7 @@ test('structuredChatResource exposes a terminal error when retries are disabled'
     }),
   );
 
-  expect(fryHashbrownMock).toHaveBeenCalledWith(
+  expect(createChatRuntimeMock).toHaveBeenCalledWith(
     expect.objectContaining({ retries: 0 }),
   );
   expect(resource.error()).toBe(failure);
@@ -268,7 +268,7 @@ test('structuredChatResource exposes a terminal error when retries are disabled'
 });
 
 test('structuredChatResource reload removes the last assistant response without mutating history', () => {
-  fryHashbrownMock.mockReset();
+  createChatRuntimeMock.mockReset();
   const messages = [
     { role: 'user' as const, content: 'Summarize this' },
     {
@@ -278,8 +278,8 @@ test('structuredChatResource reload removes the last assistant response without 
     },
   ];
   const originalMessages = structuredClone(messages);
-  const hashbrown = createHashbrownStub({ messages });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -295,15 +295,15 @@ test('structuredChatResource reload removes the last assistant response without 
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(true);
-  expect(hashbrown.setMessages).toHaveBeenCalledTimes(1);
-  expect(hashbrown.setMessages).toHaveBeenCalledWith([messages[0]]);
+  expect(runtime.setMessages).toHaveBeenCalledTimes(1);
+  expect(runtime.setMessages).toHaveBeenCalledWith([messages[0]]);
   expect(messages).toEqual(originalMessages);
 });
 
 test('structuredChatResource reload returns false when messages are empty', () => {
-  fryHashbrownMock.mockReset();
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  createChatRuntimeMock.mockReset();
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReturnValue(runtime);
   TestBed.configureTestingModule({
     providers: [provideHashbrown({ baseUrl: '/chat' })],
   });
@@ -319,10 +319,10 @@ test('structuredChatResource reload returns false when messages are empty', () =
   const reloaded = resource.reload();
 
   expect(reloaded).toBe(false);
-  expect(hashbrown.setMessages).not.toHaveBeenCalled();
+  expect(runtime.setMessages).not.toHaveBeenCalled();
 });
 
-function createHashbrownStub({
+function createRuntimeStub({
   messages,
   error,
   exhaustedRetries = false,
@@ -349,7 +349,7 @@ function createHashbrownStub({
     isSavingThread: createSignal(false),
     threadLoadError: createSignal(undefined),
     threadSaveError: createSignal(undefined),
-    sizzle: vi.fn(() => vi.fn()),
+    start: vi.fn(() => vi.fn()),
     updateOptions: vi.fn(),
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),
@@ -358,10 +358,10 @@ function createHashbrownStub({
   } as never;
 }
 
-function getLastUpdateOptions(hashbrown: {
+function getLastUpdateOptions(runtime: {
   updateOptions: { mock: { calls: [Record<string, unknown>][] } };
 }) {
-  const calls = hashbrown.updateOptions.mock.calls;
+  const calls = runtime.updateOptions.mock.calls;
 
   return calls[calls.length - 1]?.[0];
 }

--- a/packages/angular/src/resources/structured-chat-resource.fn.ts
+++ b/packages/angular/src/resources/structured-chat-resource.fn.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/core';
 import {
   Chat,
-  fryHashbrown,
+  createChatRuntime,
   s,
   type TransportOrFactory,
 } from '@hashbrownai/core';
@@ -20,6 +20,7 @@ import { ɵinjectHashbrownConfig } from '../providers/provide-hashbrown.fn';
 import { readReactiveOption, toNgSignal } from '../utils/signals';
 import { ReactiveOption } from '../utils/types';
 import { bindToolToInjector } from '../utils/create-tool.fn';
+import { createTransport } from '../utils/create-transport.fn';
 import { toDeepSignal } from '../utils/deep-signal';
 import {
   createResourceSnapshot,
@@ -180,15 +181,20 @@ export function structuredChatResource<
   const config = ɵinjectHashbrownConfig();
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
-  const hashbrown = fryHashbrown<Schema, Tools, Output>({
-    apiUrl:
-      options.apiUrl !== undefined
-        ? readReactiveOption(options.apiUrl)
-        : config.baseUrl,
-    middleware: config.middleware?.map((m): Chat.Middleware => {
-      return (requestInit) =>
-        runInInjectionContext(injector, () => m(requestInit));
-    }),
+  const resolveTransport = () =>
+    createTransport({
+      transport: options.transport ?? config.transport,
+      readBaseUrl: () =>
+        options.apiUrl !== undefined
+          ? readReactiveOption(options.apiUrl)
+          : config.baseUrl,
+      createMiddleware: () =>
+        config.middleware?.map((middleware): Chat.Middleware => {
+          return (requestInit) =>
+            runInInjectionContext(injector, () => middleware(requestInit));
+        }),
+    });
+  const runtime = createChatRuntime<Schema, Tools, Output>({
     system: readReactiveOption(options.system),
     messages: [...(options.messages ?? [])],
     tools: options.tools?.map((tool) => bindToolToInjector(tool, injector)),
@@ -196,7 +202,7 @@ export function structuredChatResource<
     debugName: options.debugName,
     debounce: options.debounce,
     retries: options.retries,
-    transport: options.transport ?? config.transport,
+    transport: resolveTransport(),
     ui: options.ui ?? false,
     threadId:
       options.threadId !== undefined
@@ -205,12 +211,9 @@ export function structuredChatResource<
   });
 
   const optionsEffect = effect(() => {
-    hashbrown.updateOptions({
-      apiUrl:
-        options.apiUrl !== undefined
-          ? readReactiveOption(options.apiUrl)
-          : config.baseUrl,
+    runtime.updateOptions({
       system: readReactiveOption(options.system),
+      transport: resolveTransport(),
       ui: options.ui ?? false,
       ...(options.threadId !== undefined
         ? { threadId: readReactiveOption(options.threadId) }
@@ -218,7 +221,7 @@ export function structuredChatResource<
     });
   });
 
-  const teardown = hashbrown.sizzle();
+  const teardown = runtime.start();
 
   destroyRef.onDestroy(() => {
     teardown();
@@ -226,44 +229,44 @@ export function structuredChatResource<
   });
 
   const rawValueSignal = toNgSignal(
-    hashbrown.messages,
+    runtime.messages,
     options.debugName && `${options.debugName}.rawValue`,
   );
   const rawValue = toDeepSignal(rawValueSignal);
   const isReceiving = toNgSignal(
-    hashbrown.isReceiving,
+    runtime.isReceiving,
     options.debugName && `${options.debugName}.isReceiving`,
   );
   const isSending = toNgSignal(
-    hashbrown.isSending,
+    runtime.isSending,
     options.debugName && `${options.debugName}.isSending`,
   );
   const isGenerating = toNgSignal(
-    hashbrown.isGenerating,
+    runtime.isGenerating,
     options.debugName && `${options.debugName}.isGenerating`,
   );
   const isRunningToolCalls = toNgSignal(
-    hashbrown.isRunningToolCalls,
+    runtime.isRunningToolCalls,
     options.debugName && `${options.debugName}.isRunningToolCalls`,
   );
   const isLoading = toNgSignal(
-    hashbrown.isLoading,
+    runtime.isLoading,
     options.debugName && `${options.debugName}.isLoading`,
   );
   const error = toNgSignal(
-    hashbrown.error,
+    runtime.error,
     options.debugName && `${options.debugName}.error`,
   );
   const sendingError = toNgSignal(
-    hashbrown.sendingError,
+    runtime.sendingError,
     options.debugName && `${options.debugName}.sendingError`,
   );
   const generatingError = toNgSignal(
-    hashbrown.generatingError,
+    runtime.generatingError,
     options.debugName && `${options.debugName}.generatingError`,
   );
   const lastAssistantMessage = toNgSignal(
-    hashbrown.lastAssistantMessage,
+    runtime.lastAssistantMessage,
     options.debugName && `${options.debugName}.lastAssistantMessage`,
   );
   const status = computed(
@@ -306,7 +309,7 @@ export function structuredChatResource<
     const lastMessage = messages[messages.length - 1];
 
     if (lastMessage?.role === 'assistant') {
-      hashbrown.setMessages(messages.slice(0, -1));
+      runtime.setMessages(messages.slice(0, -1));
 
       return true;
     }
@@ -322,19 +325,19 @@ export function structuredChatResource<
   }
 
   function sendMessage(message: Chat.UserMessage) {
-    hashbrown.sendMessage(message);
+    runtime.sendMessage(message);
   }
 
   function resendMessages() {
-    hashbrown.resendMessages();
+    runtime.resendMessages();
   }
 
   function setMessages(messages: Chat.Message<Output, Tools>[]) {
-    hashbrown.setMessages(messages);
+    runtime.setMessages(messages);
   }
 
   function stop(clearStreamingMessage = false) {
-    hashbrown.stop(clearStreamingMessage);
+    runtime.stop(clearStreamingMessage);
   }
 
   return {

--- a/packages/angular/src/utils/create-transport.fn.ts
+++ b/packages/angular/src/utils/create-transport.fn.ts
@@ -1,0 +1,30 @@
+import {
+  Chat,
+  createHttpTransport,
+  type TransportOrFactory,
+} from '@hashbrownai/core';
+
+interface CreateTransportOptions {
+  transport?: TransportOrFactory;
+  readBaseUrl: () => string | undefined;
+  createMiddleware: () => Chat.Middleware[] | undefined;
+}
+
+/**
+ * Resolves an explicit Angular transport or lazily creates the configured
+ * default HTTP transport.
+ */
+export function createTransport({
+  transport,
+  readBaseUrl,
+  createMiddleware,
+}: CreateTransportOptions): TransportOrFactory {
+  if (transport) {
+    return transport;
+  }
+
+  const baseUrl = readBaseUrl();
+  const middleware = createMiddleware();
+
+  return () => createHttpTransport({ baseUrl, middleware });
+}

--- a/packages/core/e2e/package-shape.e2e.spec.ts
+++ b/packages/core/e2e/package-shape.e2e.spec.ts
@@ -90,11 +90,17 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
       join(sandboxPath, 'consumer.ts'),
       `
         import {
+          type ChatRuntime,
           type Chat,
+          createChatRuntime,
           type Transport,
           type TransportRequest,
           type TransportResponse,
         } from '@hashbrownai/core';
+        // @ts-expect-error The legacy runtime factory is no longer public.
+        import { fryHashbrown } from '@hashbrownai/core';
+        // @ts-expect-error The branded runtime type has been replaced by ChatRuntime.
+        import type { Hashbrown } from '@hashbrownai/core';
         // @ts-expect-error Legacy frame encoding is no longer public.
         import { encodeFrame, type Frame } from '@hashbrownai/core';
 
@@ -123,6 +129,11 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
             return response;
           },
         };
+        const runtime: ChatRuntime<string, Chat.AnyTool> = createChatRuntime({
+          system: 'test',
+          transport,
+        });
+        const teardown = runtime.start();
         const frame: Frame = { type: 'generation-start' };
         const encoded = encodeFrame(frame);
 
@@ -143,6 +154,12 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
         response.frames;
         // @ts-expect-error Thread-loading capability is not part of Transport.
         transport.supportsLegacyThreadLoading;
+        // @ts-expect-error The legacy lifecycle method has been replaced by start().
+        runtime.sizzle();
+        // @ts-expect-error Direct core endpoint configuration belongs to HttpTransport.
+        createChatRuntime({ system: 'test', apiUrl: '/alternate-run' });
+        // @ts-expect-error Direct core middleware belongs to HttpTransport.
+        runtime.updateOptions({ middleware: [] });
         // @ts-expect-error Provider structured-output modes are no longer public.
         type RemovedStructuredOutputOptions = Chat.Api.StructuredOutputOptions;
         // @ts-expect-error Provider structured-output mode names are no longer public.
@@ -152,7 +169,9 @@ test('packed Core package includes generated chunks and supports ESM and CJS', (
         // @ts-expect-error Legacy completion parameters are no longer public.
         type RemovedCompletionCreateParams = Chat.Api.CompletionCreateParams;
 
-        void [encoded, missingInput, missingEvents];
+        void [encoded, missingInput, missingEvents, teardown];
+        void fryHashbrown;
+        void (null as unknown as Hashbrown<string, Chat.AnyTool>);
         void (null as unknown as RemovedStructuredOutputOptions);
         void (null as unknown as RemovedStructuredOutputMode);
         void (null as unknown as RemovedResponseFormatMode);

--- a/packages/core/src/actions/dev.actions.ts
+++ b/packages/core/src/actions/dev.actions.ts
@@ -5,13 +5,11 @@ import { createActionGroup, props } from '../utils/micro-ngrx';
 
 export default createActionGroup('dev', {
   init: props<{
-    apiUrl?: string;
     system: string;
     debounce?: number;
     messages?: Chat.AnyMessage[];
     tools?: Chat.AnyTool[];
     responseSchema?: s.SchemaOutput;
-    middleware?: Chat.Middleware[];
     retries?: number;
     transport?: TransportOrFactory;
     ui?: boolean;
@@ -28,11 +26,9 @@ export default createActionGroup('dev', {
   resendMessages: props<void>,
   updateOptions: props<{
     debugName?: string;
-    apiUrl?: string;
     system?: string;
     tools?: Chat.AnyTool[];
     responseSchema?: s.SchemaOutput;
-    middleware?: Chat.Middleware[];
     debounce?: number;
     retries?: number;
     transport?: TransportOrFactory;

--- a/packages/core/src/actions/internal.actions.ts
+++ b/packages/core/src/actions/internal.actions.ts
@@ -2,7 +2,7 @@ import { createActionGroup, emptyProps, props } from '../utils/micro-ngrx';
 import { Chat } from '../models';
 
 export default createActionGroup('internal', {
-  sizzle: emptyProps(),
+  start: emptyProps(),
   generationSilentlyRetired: emptyProps(),
   toolTurnSettled: props<{
     toolCalls: Chat.Internal.ToolCall[];

--- a/packages/core/src/chat-runtime.ts
+++ b/packages/core/src/chat-runtime.ts
@@ -25,16 +25,17 @@ import {
 } from './reducers';
 import { s } from './schema';
 import { createStore, StateSignal } from './utils/micro-ngrx';
-import { TransportOrFactory } from './transport';
+import { createHttpTransport, TransportOrFactory } from './transport';
 
 /**
- * Represents a Hashbrown chat instance, providing methods to send and observe messages, track state, and handle errors.
+ * A stateful client runtime for sending messages, processing AG-UI events,
+ * executing tools, and exposing reactive chat state.
  *
  * @public
  * @typeParam Output - The type of messages received from the LLM, either a string or structured output defined by HashbrownType.
  * @typeParam Tools - The set of tools available to the chat instance.
  */
-export interface Hashbrown<Output, Tools extends Chat.AnyTool> {
+export interface ChatRuntime<Output, Tools extends Chat.AnyTool> {
   messages: StateSignal<Chat.Message<Output, Tools>[]>;
   error: StateSignal<Error | undefined>;
   isReceiving: StateSignal<boolean>;
@@ -63,11 +64,9 @@ export interface Hashbrown<Output, Tools extends Chat.AnyTool> {
   updateOptions: (
     options: Partial<{
       debugName?: string;
-      apiUrl?: string;
       system: string;
       tools: Tools[];
       responseSchema: s.SchemaOutput;
-      middleware: Chat.Middleware[];
       debounce: number;
       retries: number;
       transport: TransportOrFactory;
@@ -80,79 +79,72 @@ export interface Hashbrown<Output, Tools extends Chat.AnyTool> {
   /** Stop the current LLM interaction. */
   stop: (clearStreamingMessage?: boolean) => void;
 
-  /** Start the Hashbrown effect loop. */
-  sizzle: () => () => void;
+  /** Start the runtime effect loop and return a function that disposes it. */
+  start: () => () => void;
 }
 
 /**
- * Initialize a Hashbrown chat instance with the given configuration.
+ * Create a stateful client chat runtime with the given configuration.
  *
  * @public
  * @typeParam Output - The type of messages expected from the LLM.
  * @typeParam Tools - The set of tools to register with the chat instance.
  * @param init - Initialization options containing:
  *   - `debugName`: Optional debug name for devtools tracing
- *   - `apiUrl`: Base URL of the Hashbrown API endpoint
  *   - `system`: System prompt or initial context for the chat
  *   - `messages`: Initial message history
  *   - `tools`: Array of tools to enable in the instance
  *   - `responseSchema`: JSON schema for validating structured output
- *   - `middleware`: Middleware functions to run on messages
  *   - `debounce`: Debounce interval in milliseconds for sending messages
- * @returns A configured Hashbrown instance.
+ * @returns A configured chat runtime. Call `start()` to activate its effects.
  */
-export function fryHashbrown<Tools extends Chat.AnyTool>(init: {
+export function createChatRuntime<Tools extends Chat.AnyTool>(init: {
   debugName?: string;
-  apiUrl?: string;
   system: string;
   messages?: Chat.Message<string, Tools>[];
   tools?: Tools[];
-  middleware?: Chat.Middleware[];
   debounce?: number;
   retries?: number;
   transport?: TransportOrFactory;
   ui?: boolean;
   threadId?: string;
-}): Hashbrown<string, Tools>;
+}): ChatRuntime<string, Tools>;
 /**
  * @public
  */
-export function fryHashbrown<
+export function createChatRuntime<
   Schema extends s.SchemaOutput,
   Tools extends Chat.AnyTool,
   Output extends s.InferSchemaOutput<Schema> = s.InferSchemaOutput<Schema>,
 >(init: {
   debugName?: string;
-  apiUrl?: string;
   system: string;
   messages?: Chat.Message<Output, Tools>[];
   tools?: Tools[];
   responseSchema: Schema;
-  middleware?: Chat.Middleware[];
   debounce?: number;
   retries?: number;
   transport?: TransportOrFactory;
   ui?: boolean;
   threadId?: string;
-}): Hashbrown<Output, Tools>;
+}): ChatRuntime<Output, Tools>;
 /**
  * @public
  */
-export function fryHashbrown(init: {
+export function createChatRuntime(init: {
   debugName?: string;
-  apiUrl?: string;
   system: string;
   messages?: Chat.Message<string, Chat.AnyTool>[];
   tools?: Chat.AnyTool[];
   responseSchema?: s.SchemaOutput;
-  middleware?: Chat.Middleware[];
   debounce?: number;
   retries?: number;
   transport?: TransportOrFactory;
   ui?: boolean;
   threadId?: string;
-}): Hashbrown<any, Chat.AnyTool> {
+}): ChatRuntime<any, Chat.AnyTool> {
   const initialThreadId = init.threadId;
+  const transport = init.transport ?? (() => createHttpTransport({}));
 
   const state = createStore({
     debugName: init.debugName,
@@ -175,15 +167,13 @@ export function fryHashbrown(init: {
 
   state.dispatch(
     devActions.init({
-      apiUrl: init.apiUrl,
       system: init.system,
       messages: init.messages as Chat.AnyMessage[],
       tools: init.tools as Chat.AnyTool[],
       responseSchema: init.responseSchema,
-      middleware: init.middleware,
       debounce: init.debounce,
       retries: init.retries,
-      transport: init.transport,
+      transport,
       ui: init.ui,
       threadId: initialThreadId,
     }),
@@ -214,11 +204,9 @@ export function fryHashbrown(init: {
   function updateOptions(
     options: Partial<{
       debugName?: string;
-      apiUrl: string;
       system: string;
       tools: Chat.AnyTool[];
       responseSchema: s.SchemaOutput;
-      middleware: Chat.Middleware[];
       debounce: number;
       retries: number;
       transport: TransportOrFactory;
@@ -229,7 +217,7 @@ export function fryHashbrown(init: {
     state.dispatch(devActions.updateOptions(options));
   }
 
-  function sizzle() {
+  function start() {
     const abortController = new AbortController();
     let effectCleanupFn: () => void;
 
@@ -240,7 +228,7 @@ export function fryHashbrown(init: {
 
       effectCleanupFn = state.runEffects();
 
-      state.dispatch(internalActions.sizzle());
+      state.dispatch(internalActions.start());
     });
 
     return () => {
@@ -265,7 +253,7 @@ export function fryHashbrown(init: {
     resendMessages,
     updateOptions,
     stop,
-    sizzle,
+    start,
     messages: state.createSignal(selectViewMessages),
     error: state.createSignal(selectUnifiedError),
     isReceiving: state.createSignal(selectIsReceiving),

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1,12 +1,10 @@
 import { type AGUIEvent, EventType } from '@ag-ui/core';
 import { apiActions, devActions, internalActions } from '../actions';
-import { fryHashbrown } from '../hashbrown';
+import { createChatRuntime } from '../chat-runtime';
 import { Chat } from '../models';
 import {
   selectApiMessages,
-  selectApiUrl,
   selectDebounce,
-  selectMiddleware,
   selectPendingToolCalls,
   selectRawStreamingMessage,
   selectRawStreamingToolCalls,
@@ -62,8 +60,6 @@ function createTestStore(selectorOverrides: SelectorMap = new Map()) {
   const actions: ActionLike[] = [];
   const handlers: TestHandler[] = [];
   const defaults: SelectorMap = new Map<SelectorKey, unknown>([
-    [selectApiUrl, 'https://example.test'],
-    [selectMiddleware, undefined],
     [selectResponseSchema, undefined],
     [
       selectApiMessages,
@@ -420,7 +416,7 @@ test('configured thread with no messages sends no request', async () => {
   );
   const teardown = generateMessage(store);
 
-  await store.trigger(internalActions.sizzle());
+  await store.trigger(internalActions.start());
 
   expect(send).not.toHaveBeenCalled();
 
@@ -454,6 +450,38 @@ test('transport factory failure dispatches the initialization error', async () =
   ).toHaveLength(0);
 
   teardown?.();
+});
+
+test('missing transport reports configuration error without issuing HTTP', async () => {
+  jest.clearAllMocks();
+  const fetchSpy = jest
+    .spyOn(globalThis, 'fetch')
+    .mockRejectedValue(new Error('HTTP must not be used by the runtime'));
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectTransport, undefined]]),
+  );
+  const teardown = generateMessage(store);
+
+  try {
+    await store.trigger(
+      devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+    );
+
+    const errors = getActionsOfType(
+      store.actions,
+      apiActions.generateMessageError.type,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.payload).toMatchObject({
+      message: 'No transport configured',
+      code: 'CONFIGURATION_ERROR',
+      retryable: false,
+    });
+  } finally {
+    teardown?.();
+    fetchSpy.mockRestore();
+  }
 });
 
 test('first user message uses the configured thread ID', async () => {
@@ -905,7 +933,7 @@ test('validated start then tool continuation reuses the same thread ID', async (
       continuation: 'continue',
     }),
   );
-  await store.trigger(internalActions.sizzle());
+  await store.trigger(internalActions.start());
 
   expect(send).toHaveBeenCalledTimes(2);
   expect(send.mock.calls[1]?.[0].input?.threadId).toBe(acceptedThreadId);
@@ -1013,7 +1041,7 @@ test('continues client tools with isolated reasoning details in transcript order
       ]),
     };
   });
-  const chat = fryHashbrown({
+  const runtime = createChatRuntime({
     system: 'You are a test bot',
     transport: configuredTransport,
     tools: [
@@ -1027,9 +1055,12 @@ test('continues client tools with isolated reasoning details in transcript order
       },
     ],
   });
-  const teardown = chat.sizzle();
+  const teardown = runtime.start();
 
-  chat.sendMessage({ role: 'user', content: 'What is the weather in Paris?' });
+  runtime.sendMessage({
+    role: 'user',
+    content: 'What is the weather in Paris?',
+  });
   const secondRequest = await secondInputCaptured.promise;
 
   expect(toolHandler).toHaveBeenCalledWith(
@@ -1127,7 +1158,7 @@ test('continues client tools with isolated reasoning details in transcript order
       content: '{"city":"Paris","condition":"sunny"}',
     },
   ]);
-  const committedAssistant = chat
+  const committedAssistant = runtime
     .messages()
     .find(
       (message) =>
@@ -2560,7 +2591,7 @@ test('does not generate after a non-continuing tool settlement', async () => {
   );
 
   expect(send).not.toHaveBeenCalled();
-  expect(store.actions).not.toContainEqual(internalActions.sizzle());
+  expect(store.actions).not.toContainEqual(internalActions.start());
 
   teardown?.();
 });

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -3,9 +3,7 @@ import { apiActions, devActions, internalActions } from '../actions';
 import { Chat } from '../models';
 import {
   selectApiMessages,
-  selectApiUrl,
   selectDebounce,
-  selectMiddleware,
   selectPendingToolCalls,
   selectRawStreamingMessage,
   selectRawStreamingToolCalls,
@@ -22,7 +20,6 @@ import {
 } from '../reducers';
 import { s } from '../schema';
 import {
-  createHttpTransport,
   resolveTransport,
   TransportError,
   type TransportResponse,
@@ -60,7 +57,7 @@ export const generateMessage = createEffect((store) => {
   let activeGeneration: ActiveGeneration | undefined;
 
   store.when(
-    internalActions.sizzle,
+    internalActions.start,
     devActions.setMessages,
     devActions.sendMessage,
     devActions.resendMessages,
@@ -103,8 +100,6 @@ export const generateMessage = createEffect((store) => {
         activeGeneration = generation;
       }
 
-      const apiUrl = store.read(selectApiUrl);
-      const middleware = store.read(selectMiddleware);
       const responseSchema = store.read(selectResponseSchema);
       const messages = store.read(selectApiMessages);
       const debounce = store.read(selectDebounce);
@@ -129,12 +124,13 @@ export const generateMessage = createEffect((store) => {
       const transportProvider = store.read(selectTransport);
       let transport;
       try {
-        transport =
-          resolveTransport(transportProvider) ??
-          createHttpTransport({
-            baseUrl: apiUrl,
-            middleware: middleware ?? undefined,
+        transport = resolveTransport(transportProvider);
+        if (!transport) {
+          throw new TransportError('No transport configured', {
+            retryable: false,
+            code: 'CONFIGURATION_ERROR',
           });
+        }
       } catch (error) {
         if (retiredSignal.aborted || runCancelSignal.aborted) {
           releaseGeneration();
@@ -493,7 +489,7 @@ export const generateMessage = createEffect((store) => {
       return;
     }
 
-    store.dispatch(internalActions.sizzle());
+    store.dispatch(internalActions.start());
   });
 
   store.when(devActions.stopMessageGeneration, () => {

--- a/packages/core/src/public_api.ts
+++ b/packages/core/src/public_api.ts
@@ -1,4 +1,4 @@
-export { fryHashbrown, type Hashbrown } from './hashbrown';
+export { createChatRuntime, type ChatRuntime } from './chat-runtime';
 export * from './models';
 export * from './transport';
 export { prompt } from './prompt/prompt';

--- a/packages/core/src/reducers/config.reducer.ts
+++ b/packages/core/src/reducers/config.reducer.ts
@@ -1,22 +1,18 @@
 import { devActions } from '../actions';
-import { Chat } from '../models';
 import { s } from '../schema';
 import { TransportOrFactory } from '../transport';
 import { createReducer, on } from '../utils/micro-ngrx';
 
 export interface ConfigState {
-  apiUrl?: string;
   system: string;
   debounce: number;
   responseSchema?: s.HashbrownType;
-  middleware?: Chat.Middleware[];
   retries: number;
   transport?: TransportOrFactory;
   ui?: boolean;
 }
 
 const initialState: ConfigState = {
-  apiUrl: '',
   system: '',
   debounce: 150,
   retries: 0,
@@ -31,11 +27,9 @@ export const reducer = createReducer(
       : undefined;
     return {
       ...state,
-      apiUrl: action.payload.apiUrl,
       system: action.payload.system,
       debounce: action.payload.debounce ?? state.debounce,
       responseSchema,
-      middleware: action.payload.middleware,
       retries: action.payload.retries ?? state.retries,
       transport: action.payload.transport ?? state.transport,
       ui: action.payload.ui ?? state.ui,
@@ -47,6 +41,7 @@ export const reducer = createReducer(
       system = state.system,
       debounce = state.debounce,
       retries = state.retries,
+      transport = state.transport,
       ui = state.ui,
       ...configPayload
     } = action.payload;
@@ -61,18 +56,17 @@ export const reducer = createReducer(
       system,
       debounce,
       retries,
+      transport,
       ui,
       responseSchema,
     };
   }),
 );
 
-export const selectApiUrl = (state: ConfigState) => state.apiUrl;
 export const selectSystem = (state: ConfigState) => state.system;
 export const selectDebounce = (state: ConfigState) => state.debounce;
 export const selectResponseSchema = (state: ConfigState) =>
   state.responseSchema;
-export const selectMiddleware = (state: ConfigState) => state.middleware;
 export const selectRetries = (state: ConfigState) => state.retries;
 export const selectTransport = (state: ConfigState) => state.transport;
 export const selectUiRequested = (state: ConfigState) => state.ui ?? false;

--- a/packages/core/src/reducers/index.spec.ts
+++ b/packages/core/src/reducers/index.spec.ts
@@ -1,7 +1,6 @@
 import { EventType } from '@ag-ui/core';
 import { apiActions, devActions } from '../actions';
-import { fryHashbrown } from '../hashbrown';
-import { Chat } from '../models';
+import { createChatRuntime } from '../chat-runtime';
 import { s } from '../schema';
 import {
   reducers,
@@ -40,9 +39,9 @@ function reduceAll(
   };
 }
 
-test('fryHashbrown accepts a developer tool named output', () => {
-  const createHashbrown = () =>
-    fryHashbrown({
+test('createChatRuntime accepts a developer tool named output', () => {
+  const createRuntime = () =>
+    createChatRuntime({
       system: 'test',
       tools: [
         {
@@ -54,7 +53,18 @@ test('fryHashbrown accepts a developer tool named output', () => {
       ],
     });
 
-  expect(createHashbrown).not.toThrow();
+  expect(createRuntime).not.toThrow();
+});
+
+test('direct core HTTP configuration is expressed as a transport', () => {
+  const runtime = createChatRuntime({ system: 'test' });
+
+  // @ts-expect-error Direct core endpoint configuration has moved to HttpTransport.
+  createChatRuntime({ system: 'test', apiUrl: '/alternate-run' });
+  // @ts-expect-error Direct core HTTP middleware has moved to HttpTransport.
+  runtime.updateOptions({ middleware: [(request) => request] });
+
+  expect(runtime).toBeDefined();
 });
 
 test('RUN_STARTED updates the selected thread ID', () => {
@@ -284,8 +294,7 @@ test('undefined non-clearable options preserve current config values', () => {
   });
 });
 
-test('undefined clearable options clear current config values', () => {
-  const middleware: Chat.Middleware = (request) => request;
+test('an undefined transport option preserves the current transport', () => {
   const transport = {
     name: 'test-transport',
     send: async () => {
@@ -295,9 +304,7 @@ test('undefined clearable options clear current config values', () => {
   const state = reduceAll(
     createState(),
     devActions.init({
-      apiUrl: 'https://example.test',
       system: 'test',
-      middleware: [middleware],
       transport,
     }),
   );
@@ -305,26 +312,22 @@ test('undefined clearable options clear current config values', () => {
   const nextState = reduceAll(
     state,
     devActions.updateOptions({
-      apiUrl: undefined,
-      middleware: undefined,
       transport: undefined,
     }),
   );
 
-  expect(nextState.config).toHaveProperty('apiUrl', undefined);
-  expect(nextState.config).toHaveProperty('middleware', undefined);
-  expect(nextState.config).toHaveProperty('transport', undefined);
+  expect(nextState.config).toHaveProperty('transport', transport);
 });
 
 test('public options explicitly clear the current thread identity', () => {
-  const hashbrown = fryHashbrown({
+  const runtime = createChatRuntime({
     system: 'test',
     threadId: 'current-thread',
   });
 
-  hashbrown.updateOptions({ threadId: undefined });
+  runtime.updateOptions({ threadId: undefined });
 
-  expect(hashbrown.threadId()).toBeUndefined();
+  expect(runtime.threadId()).toBeUndefined();
 });
 
 test('devtools state includes only the current thread identity', () => {
@@ -345,7 +348,7 @@ test('devtools state includes only the current thread identity', () => {
   });
 
   try {
-    fryHashbrown({
+    createChatRuntime({
       debugName: 'thread-identity-test',
       system: 'test',
       threadId: 'devtools-thread',

--- a/packages/core/src/reducers/index.ts
+++ b/packages/core/src/reducers/index.ts
@@ -130,11 +130,6 @@ export const selectThreadIdState = select(
  * Config
  */
 export const selectConfigState = (state: State) => state.config;
-export const selectApiUrl = select(selectConfigState, fromConfig.selectApiUrl);
-export const selectMiddleware = select(
-  selectConfigState,
-  fromConfig.selectMiddleware,
-);
 export const selectSystem = select(selectConfigState, fromConfig.selectSystem);
 export const selectDebounce = select(
   selectConfigState,

--- a/packages/react/src/hashbrown-provider.tsx
+++ b/packages/react/src/hashbrown-provider.tsx
@@ -1,5 +1,8 @@
-import { createContext } from 'react';
-import { type TransportOrFactory } from '@hashbrownai/core';
+import { createContext, useMemo } from 'react';
+import {
+  createHttpTransport,
+  type TransportOrFactory,
+} from '@hashbrownai/core';
 
 /**
  * The options for the Hashbrown provider.
@@ -12,7 +15,7 @@ export interface HashbrownProviderOptions {
    */
   url?: string;
   /**
-   * The headers to send with the POST request to the Hashbrown endpoint.
+   * Middleware applied before POST requests to the Hashbrown endpoint.
    */
   middleware?: Array<
     (request: RequestInit) => RequestInit | Promise<RequestInit>
@@ -24,11 +27,7 @@ export interface HashbrownProviderOptions {
 }
 
 interface HashbrownProviderContext {
-  url?: string;
-  middleware?: Array<
-    (request: RequestInit) => RequestInit | Promise<RequestInit>
-  >;
-  transport?: TransportOrFactory;
+  transport: TransportOrFactory;
 }
 
 export const HashbrownContext = createContext<
@@ -36,7 +35,7 @@ export const HashbrownContext = createContext<
 >(undefined);
 
 /**
- * The context for the Hashbrown provider.  This is used to store the URL and middleware for contacting the Hashbrown endpoint.
+ * Configures the transport used by descendant Hashbrown hooks.
  *
  * @public
  * @example
@@ -55,11 +54,23 @@ export const HashbrownProvider = (
   },
 ) => {
   const { url, middleware, transport, children } = props;
+  const configuredTransport = useMemo<TransportOrFactory>(
+    () =>
+      transport ??
+      (() =>
+        createHttpTransport({
+          baseUrl: url,
+          middleware,
+        })),
+    [middleware, transport, url],
+  );
+  const context = useMemo(
+    () => ({ transport: configuredTransport }),
+    [configuredTransport],
+  );
 
   return (
-    <HashbrownContext.Provider
-      value={{ url, middleware, transport }}
-    >
+    <HashbrownContext.Provider value={context}>
       {children}
     </HashbrownContext.Provider>
   );

--- a/packages/react/src/hooks/use-chat.spec.tsx
+++ b/packages/react/src/hooks/use-chat.spec.tsx
@@ -3,14 +3,16 @@ import { type ReactNode } from 'react';
 import { HashbrownProvider } from '../hashbrown-provider';
 import { useChat } from './use-chat';
 
-const fryHashbrownMock = vi.hoisted(() => vi.fn());
+const createChatRuntimeMock = vi.hoisted(() => vi.fn());
+const createHttpTransportMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@hashbrownai/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@hashbrownai/core')>();
 
   return {
     ...actual,
-    fryHashbrown: fryHashbrownMock,
+    createHttpTransport: createHttpTransportMock,
+    createChatRuntime: createChatRuntimeMock,
   };
 });
 
@@ -21,9 +23,9 @@ test('useChat initializes with the provided message history', () => {
       content: 'Summarize the previous order.',
     },
   ];
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockImplementation((init) =>
-    createHashbrownStub({ messages: init.messages ?? [] }),
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockImplementation((init) =>
+    createRuntimeStub({ messages: init.messages ?? [] }),
   );
 
   const { result } = renderHook(
@@ -38,10 +40,53 @@ test('useChat initializes with the provided message history', () => {
   expect(result.current.messages).toEqual(messages);
 });
 
+test('HashbrownProvider lowers URL and middleware into a lazy HTTP transport', () => {
+  const middleware = [vi.fn((request: RequestInit) => request)];
+  const transport = { name: 'provider-http', send: vi.fn() };
+  createHttpTransportMock.mockReset();
+  createHttpTransportMock.mockReturnValue(transport);
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(createRuntimeStub({ messages: [] }));
+
+  renderHook(() => useChat({ system: 'test' }), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <HashbrownProvider url="/provider-run" middleware={middleware}>
+        {children}
+      </HashbrownProvider>
+    ),
+  });
+
+  const init = createChatRuntimeMock.mock.calls[0]?.[0];
+  expect(init).not.toHaveProperty('apiUrl');
+  expect(init).not.toHaveProperty('middleware');
+  expect(init.transport).toEqual(expect.any(Function));
+  expect(init.transport()).toBe(transport);
+  expect(createHttpTransportMock).toHaveBeenCalledWith({
+    baseUrl: '/provider-run',
+    middleware,
+  });
+});
+
+test('useChat transport overrides provider HTTP configuration', () => {
+  const transport = { name: 'hook-transport', send: vi.fn() };
+  createHttpTransportMock.mockReset();
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(createRuntimeStub({ messages: [] }));
+
+  renderHook(() => useChat({ system: 'test', transport }), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <HashbrownProvider url="/provider-run">{children}</HashbrownProvider>
+    ),
+  });
+
+  expect(createChatRuntimeMock.mock.calls[0]?.[0].transport).toBe(transport);
+  expect(createHttpTransportMock).not.toHaveBeenCalled();
+});
+
 test('useChat preserves thread identity property presence on updates', () => {
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(runtime);
   type HookProps = {
     system: string;
     threadId?: string | undefined;
@@ -66,11 +111,11 @@ test('useChat preserves thread identity property presence on updates', () => {
   expect(result.current).not.toHaveProperty('threadLoadError');
   expect(result.current).not.toHaveProperty('threadSaveError');
   expect(result.current).not.toHaveProperty('threadId');
-  hashbrown.updateOptions.mockClear();
+  runtime.updateOptions.mockClear();
 
   rerender({ system: 'You are a concise assistant.' });
 
-  const omittedUpdate = hashbrown.updateOptions.mock.calls.at(-1)?.[0];
+  const omittedUpdate = runtime.updateOptions.mock.calls.at(-1)?.[0];
   expect(omittedUpdate).toBeDefined();
   expect(Object.hasOwn(omittedUpdate, 'threadId')).toBe(false);
 
@@ -79,7 +124,7 @@ test('useChat preserves thread identity property presence on updates', () => {
     threadId: undefined,
   });
 
-  const clearedUpdate = hashbrown.updateOptions.mock.calls.at(-1)?.[0];
+  const clearedUpdate = runtime.updateOptions.mock.calls.at(-1)?.[0];
   expect(Object.hasOwn(clearedUpdate, 'threadId')).toBe(true);
   expect(clearedUpdate).toMatchObject({ threadId: undefined });
 
@@ -88,13 +133,13 @@ test('useChat preserves thread identity property presence on updates', () => {
     threadId: 'thread-changed',
   });
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({ threadId: 'thread-changed' }),
   );
 
   rerender({ system: 'You are a concise assistant.', threadId: '' });
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({ threadId: '' }),
   );
 });
@@ -103,7 +148,7 @@ function ProviderWrapper({ children }: { children: ReactNode }) {
   return <HashbrownProvider url="/chat">{children}</HashbrownProvider>;
 }
 
-function createHashbrownStub({ messages }: { messages: unknown[] }) {
+function createRuntimeStub({ messages }: { messages: unknown[] }) {
   return {
     messages: createSignal(messages),
     isReceiving: createSignal(false),
@@ -120,7 +165,7 @@ function createHashbrownStub({ messages }: { messages: unknown[] }) {
     isSavingThread: createSignal(false),
     threadLoadError: createSignal(undefined),
     threadSaveError: createSignal(undefined),
-    sizzle: vi.fn(() => vi.fn()),
+    start: vi.fn(() => vi.fn()),
     updateOptions: vi.fn(),
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),

--- a/packages/react/src/hooks/use-chat.tsx
+++ b/packages/react/src/hooks/use-chat.tsx
@@ -1,7 +1,7 @@
 import {
   type Chat,
-  fryHashbrown,
-  Hashbrown,
+  createChatRuntime,
+  type ChatRuntime,
   type TransportOrFactory,
 } from '@hashbrownai/core';
 import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
@@ -199,12 +199,10 @@ export function useChat<Tools extends Chat.AnyTool>(
   }
 
   const hasThreadId = Object.hasOwn(options, 'threadId');
-  const hashbrownRef = useRef<Hashbrown<string, Tools> | null>(null);
+  const runtimeRef = useRef<ChatRuntime<string, Tools> | null>(null);
 
-  if (!hashbrownRef.current) {
-    hashbrownRef.current = fryHashbrown<Tools>({
-      apiUrl: config.url,
-      middleware: config.middleware,
+  if (!runtimeRef.current) {
+    runtimeRef.current = createChatRuntime<Tools>({
       debugName: options.debugName,
       system: options.system,
       messages: [...(options.messages ?? [])],
@@ -217,24 +215,22 @@ export function useChat<Tools extends Chat.AnyTool>(
     });
   }
 
-  function getHashbrown() {
-    const instance = hashbrownRef.current;
+  function getRuntime() {
+    const instance = runtimeRef.current;
 
     if (!instance) {
-      throw new Error('Hashbrown not found');
+      throw new Error('Chat runtime not found');
     }
 
     return instance;
   }
 
   useEffect(() => {
-    return getHashbrown().sizzle();
+    return getRuntime().start();
   }, []);
 
   useEffect(() => {
-    getHashbrown().updateOptions({
-      apiUrl: config.url,
-      middleware: config.middleware,
+    getRuntime().updateOptions({
       debugName: options.debugName,
       system: options.system,
       tools,
@@ -245,8 +241,6 @@ export function useChat<Tools extends Chat.AnyTool>(
       ...(hasThreadId ? { threadId: options.threadId } : {}),
     });
   }, [
-    config.url,
-    config.middleware,
     config.transport,
     options.debounceTime,
     options.debugName,
@@ -259,41 +253,41 @@ export function useChat<Tools extends Chat.AnyTool>(
   ]);
 
   const internalMessages = useHashbrownSignal<Chat.Message<string, Tools>[]>(
-    getHashbrown().messages,
+    getRuntime().messages,
   );
-  const isReceiving = useHashbrownSignal<boolean>(getHashbrown().isReceiving);
-  const isSending = useHashbrownSignal<boolean>(getHashbrown().isSending);
-  const isGenerating = useHashbrownSignal<boolean>(getHashbrown().isGenerating);
+  const isReceiving = useHashbrownSignal<boolean>(getRuntime().isReceiving);
+  const isSending = useHashbrownSignal<boolean>(getRuntime().isSending);
+  const isGenerating = useHashbrownSignal<boolean>(getRuntime().isGenerating);
   const isRunningToolCalls = useHashbrownSignal<boolean>(
-    getHashbrown().isRunningToolCalls,
+    getRuntime().isRunningToolCalls,
   );
-  const isLoading = useHashbrownSignal<boolean>(getHashbrown().isLoading);
+  const isLoading = useHashbrownSignal<boolean>(getRuntime().isLoading);
   const exhaustedRetries = useHashbrownSignal<boolean>(
-    getHashbrown().exhaustedRetries,
+    getRuntime().exhaustedRetries,
   );
-  const error = useHashbrownSignal<Error | undefined>(getHashbrown().error);
+  const error = useHashbrownSignal<Error | undefined>(getRuntime().error);
   const sendingError = useHashbrownSignal<Error | undefined>(
-    getHashbrown().sendingError,
+    getRuntime().sendingError,
   );
   const generatingError = useHashbrownSignal<Error | undefined>(
-    getHashbrown().generatingError,
+    getRuntime().generatingError,
   );
   const lastAssistantMessage = useHashbrownSignal<
     Chat.AssistantMessage<string, Tools> | undefined
-  >(getHashbrown().lastAssistantMessage);
+  >(getRuntime().lastAssistantMessage);
   const sendMessage = useCallback((message: Chat.Message<string, Tools>) => {
-    getHashbrown().sendMessage(message);
+    getRuntime().sendMessage(message);
   }, []);
 
   const setMessages = useCallback((messages: Chat.Message<string, Tools>[]) => {
-    getHashbrown().setMessages(messages);
+    getRuntime().setMessages(messages);
   }, []);
 
   const reload = useCallback(() => {
     const lastMessage = internalMessages[internalMessages.length - 1];
 
     if (lastMessage.role === 'assistant') {
-      getHashbrown().setMessages(internalMessages.slice(0, -1));
+      getRuntime().setMessages(internalMessages.slice(0, -1));
 
       return true;
     }
@@ -302,7 +296,7 @@ export function useChat<Tools extends Chat.AnyTool>(
   }, [internalMessages]);
 
   const stop = useCallback((clearStreamingMessage = false) => {
-    getHashbrown().stop(clearStreamingMessage);
+    getRuntime().stop(clearStreamingMessage);
   }, []);
 
   return {

--- a/packages/react/src/hooks/use-structured-chat.spec.tsx
+++ b/packages/react/src/hooks/use-structured-chat.spec.tsx
@@ -4,14 +4,14 @@ import { s } from '@hashbrownai/core';
 import { HashbrownProvider } from '../hashbrown-provider';
 import { useStructuredChat } from './use-structured-chat';
 
-const fryHashbrownMock = vi.hoisted(() => vi.fn());
+const createChatRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@hashbrownai/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@hashbrownai/core')>();
 
   return {
     ...actual,
-    fryHashbrown: fryHashbrownMock,
+    createChatRuntime: createChatRuntimeMock,
   };
 });
 
@@ -22,9 +22,9 @@ test('useStructuredChat initializes with the provided message history', () => {
       content: 'What is the current portfolio risk?',
     },
   ];
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockImplementation((init) =>
-    createHashbrownStub({ messages: init.messages ?? [] }),
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockImplementation((init) =>
+    createRuntimeStub({ messages: init.messages ?? [] }),
   );
 
   const { result } = renderHook(
@@ -43,9 +43,9 @@ test('useStructuredChat initializes with the provided message history', () => {
 });
 
 test('useStructuredChat preserves thread identity property presence on updates', () => {
-  const hashbrown = createHashbrownStub({ messages: [] });
-  fryHashbrownMock.mockReset();
-  fryHashbrownMock.mockReturnValue(hashbrown);
+  const runtime = createRuntimeStub({ messages: [] });
+  createChatRuntimeMock.mockReset();
+  createChatRuntimeMock.mockReturnValue(runtime);
   type HookProps = {
     system: string;
     threadId?: string | undefined;
@@ -73,11 +73,11 @@ test('useStructuredChat preserves thread identity property presence on updates',
   expect(result.current).not.toHaveProperty('threadLoadError');
   expect(result.current).not.toHaveProperty('threadSaveError');
   expect(result.current).not.toHaveProperty('threadId');
-  hashbrown.updateOptions.mockClear();
+  runtime.updateOptions.mockClear();
 
   rerender({ system: 'You are a concise portfolio analyst.' });
 
-  const omittedUpdate = hashbrown.updateOptions.mock.calls.at(-1)?.[0];
+  const omittedUpdate = runtime.updateOptions.mock.calls.at(-1)?.[0];
   expect(omittedUpdate).toBeDefined();
   expect(Object.hasOwn(omittedUpdate, 'threadId')).toBe(false);
 
@@ -86,7 +86,7 @@ test('useStructuredChat preserves thread identity property presence on updates',
     threadId: undefined,
   });
 
-  const clearedUpdate = hashbrown.updateOptions.mock.calls.at(-1)?.[0];
+  const clearedUpdate = runtime.updateOptions.mock.calls.at(-1)?.[0];
   expect(Object.hasOwn(clearedUpdate, 'threadId')).toBe(true);
   expect(clearedUpdate).toMatchObject({ threadId: undefined });
 
@@ -95,13 +95,13 @@ test('useStructuredChat preserves thread identity property presence on updates',
     threadId: 'thread-changed',
   });
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({ threadId: 'thread-changed' }),
   );
 
   rerender({ system: 'You are a concise portfolio analyst.', threadId: '' });
 
-  expect(hashbrown.updateOptions).toHaveBeenLastCalledWith(
+  expect(runtime.updateOptions).toHaveBeenLastCalledWith(
     expect.objectContaining({ threadId: '' }),
   );
 });
@@ -110,7 +110,7 @@ function ProviderWrapper({ children }: { children: ReactNode }) {
   return <HashbrownProvider url="/chat">{children}</HashbrownProvider>;
 }
 
-function createHashbrownStub({ messages }: { messages: unknown[] }) {
+function createRuntimeStub({ messages }: { messages: unknown[] }) {
   return {
     messages: createSignal(messages),
     isReceiving: createSignal(false),
@@ -127,7 +127,7 @@ function createHashbrownStub({ messages }: { messages: unknown[] }) {
     isSavingThread: createSignal(false),
     threadLoadError: createSignal(undefined),
     threadSaveError: createSignal(undefined),
-    sizzle: vi.fn(() => vi.fn()),
+    start: vi.fn(() => vi.fn()),
     updateOptions: vi.fn(),
     sendMessage: vi.fn(),
     resendMessages: vi.fn(),

--- a/packages/react/src/hooks/use-structured-chat.tsx
+++ b/packages/react/src/hooks/use-structured-chat.tsx
@@ -1,7 +1,7 @@
 import {
   Chat,
-  fryHashbrown,
-  Hashbrown,
+  createChatRuntime,
+  type ChatRuntime,
   s,
   type TransportOrFactory,
 } from '@hashbrownai/core';
@@ -222,12 +222,10 @@ export function useStructuredChat<
   );
 
   const [schema] = useState<Schema>(options.schema);
-  const hashbrown = useRef<Hashbrown<Output, Tools> | null>(null);
+  const runtimeRef = useRef<ChatRuntime<Output, Tools> | null>(null);
 
-  if (!hashbrown.current) {
-    hashbrown.current = fryHashbrown<Schema, Tools, Output>({
-      apiUrl: config.url,
-      middleware: config.middleware,
+  if (!runtimeRef.current) {
+    runtimeRef.current = createChatRuntime<Schema, Tools, Output>({
       system: options.system,
       responseSchema: schema,
       messages: [...(options.messages ?? [])],
@@ -241,24 +239,22 @@ export function useStructuredChat<
     });
   }
 
-  function getHashbrown() {
-    const instance = hashbrown.current;
+  function getRuntime() {
+    const instance = runtimeRef.current;
 
     if (!instance) {
-      throw new Error('Hashbrown not found');
+      throw new Error('Chat runtime not found');
     }
 
     return instance;
   }
 
   useEffect(() => {
-    return getHashbrown().sizzle();
+    return getRuntime().start();
   }, []);
 
   useEffect(() => {
-    getHashbrown().updateOptions({
-      apiUrl: config.url,
-      middleware: config.middleware,
+    getRuntime().updateOptions({
       system: options.system,
       responseSchema: schema,
       tools,
@@ -270,8 +266,6 @@ export function useStructuredChat<
       ...(hasThreadId ? { threadId: options.threadId } : {}),
     });
   }, [
-    config.url,
-    config.middleware,
     config.transport,
     options.system,
     options.debugName,
@@ -285,44 +279,46 @@ export function useStructuredChat<
     options.threadId,
   ]);
 
-  const internalMessages = useHashbrownSignal(hashbrown.current.messages);
-  const isReceiving = useHashbrownSignal(hashbrown.current.isReceiving);
-  const isSending = useHashbrownSignal(hashbrown.current.isSending);
-  const isGenerating = useHashbrownSignal(hashbrown.current.isGenerating);
+  const internalMessages = useHashbrownSignal(runtimeRef.current.messages);
+  const isReceiving = useHashbrownSignal(runtimeRef.current.isReceiving);
+  const isSending = useHashbrownSignal(runtimeRef.current.isSending);
+  const isGenerating = useHashbrownSignal(runtimeRef.current.isGenerating);
   const isRunningToolCalls = useHashbrownSignal(
-    hashbrown.current.isRunningToolCalls,
+    runtimeRef.current.isRunningToolCalls,
   );
-  const isLoading = useHashbrownSignal(hashbrown.current.isLoading);
+  const isLoading = useHashbrownSignal(runtimeRef.current.isLoading);
   const exhaustedRetries = useHashbrownSignal(
-    hashbrown.current.exhaustedRetries,
+    runtimeRef.current.exhaustedRetries,
   );
-  const error = useHashbrownSignal(hashbrown.current.error);
-  const sendingError = useHashbrownSignal(hashbrown.current.sendingError);
-  const generatingError = useHashbrownSignal(hashbrown.current.generatingError);
+  const error = useHashbrownSignal(runtimeRef.current.error);
+  const sendingError = useHashbrownSignal(runtimeRef.current.sendingError);
+  const generatingError = useHashbrownSignal(
+    runtimeRef.current.generatingError,
+  );
   const lastAssistantMessage = useHashbrownSignal(
-    hashbrown.current.lastAssistantMessage,
+    runtimeRef.current.lastAssistantMessage,
   );
   const sendMessage = useCallback((message: Chat.Message<Output, Tools>) => {
-    getHashbrown().sendMessage(message);
+    getRuntime().sendMessage(message);
   }, []);
 
   const stop = useCallback((clearStreamingMessage = false) => {
-    getHashbrown().stop(clearStreamingMessage);
+    getRuntime().stop(clearStreamingMessage);
   }, []);
 
   const resendMessages = useCallback(() => {
-    getHashbrown().resendMessages();
+    getRuntime().resendMessages();
   }, []);
 
   const setMessages = useCallback((messages: Chat.Message<Output, Tools>[]) => {
-    getHashbrown().setMessages(messages);
+    getRuntime().setMessages(messages);
   }, []);
 
   const reload = useCallback(() => {
     const lastMessage = internalMessages[internalMessages.length - 1];
 
     if (lastMessage.role === 'assistant') {
-      getHashbrown().setMessages(internalMessages.slice(0, -1));
+      getRuntime().setMessages(internalMessages.slice(0, -1));
 
       return true;
     }

--- a/samples/spotify/angular/src/app/game-loop/song-picker-view.ts
+++ b/samples/spotify/angular/src/app/game-loop/song-picker-view.ts
@@ -16,7 +16,7 @@ import {
   uiChatResource,
 } from '@hashbrownai/angular';
 import { SongComponent } from './song';
-import { fryHashbrown, s } from '@hashbrownai/core';
+import { createChatRuntime, createHttpTransport, s } from '@hashbrownai/core';
 import { createRuntime, createRuntimeFunction } from '@hashbrownai/angular';
 import { McpServerService } from '../services/mcp-server';
 import { FormsModule } from '@angular/forms';
@@ -150,17 +150,19 @@ export class SongPickerViewComponent {
         }),
         result: s.string('The completion'),
         handler: ({ system, input }, abortSignal) => {
-          const hashbrown = fryHashbrown({
-            apiUrl: 'http://localhost:5150/chat',
+          const runtime = createChatRuntime({
             debugName: 'inception completion',
             system,
             messages: [{ role: 'user', content: input }],
+            transport: createHttpTransport({
+              baseUrl: 'http://localhost:5150/chat',
+            }),
           });
 
-          const teardown = hashbrown.sizzle();
+          const teardown = runtime.start();
 
           return new Promise<string>((resolve, reject) => {
-            const unsubscribe = hashbrown.messages.subscribe((messages) => {
+            const unsubscribe = runtime.messages.subscribe((messages) => {
               const assistantMessage = messages.find(
                 (m) => m.role === 'assistant',
               );

--- a/tools/testing/aimock/agui-http-transport.spec.ts
+++ b/tools/testing/aimock/agui-http-transport.spec.ts
@@ -6,9 +6,9 @@ import type {
 } from '@copilotkit/aimock/agui';
 import {
   Chat,
+  type ChatRuntime,
+  createChatRuntime,
   createHttpTransport,
-  fryHashbrown,
-  type Hashbrown,
   HttpTransport,
   s,
   type StateSignal,
@@ -145,13 +145,13 @@ function waitForSignal<State>(
 }
 
 async function waitForIdle(
-  hashbrown: Pick<Hashbrown<unknown, Chat.AnyTool>, 'isLoading'>,
+  runtime: Pick<ChatRuntime<unknown, Chat.AnyTool>, 'isLoading'>,
 ): Promise<void> {
-  await waitForSignal(hashbrown.isLoading, (value) => !value);
+  await waitForSignal(runtime.isLoading, (value) => !value);
   await Promise.resolve();
 }
 
-async function drainHashbrownEffects(): Promise<void> {
+async function drainRuntimeEffects(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
 }
@@ -531,7 +531,59 @@ test('createHttpTransport posts Hashbrown run input and collects text events ove
   }
 });
 
-test('fryHashbrown adopts a generated thread identity and reuses it on the next text run', async () => {
+test('createChatRuntime defaults to AG-UI POST /run', async () => {
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  let testAimock: TestAimock | undefined;
+  let teardown: (() => void) | undefined;
+  let fetchSpy: jest.SpiedFunction<typeof fetch> | undefined;
+
+  try {
+    testAimock = await startTestAimock();
+    registerIdentityFixture(
+      testAimock.handle.aguiMock,
+      [],
+      () => true,
+      (input) =>
+        createTextRunEvents(
+          input,
+          'message-default-run',
+          ['Default route.'],
+          1_700_000_009_000,
+        ),
+    );
+    fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input, init) => {
+        return nativeFetch(
+          testAimock?.handle.aguiRunUrl ?? String(input),
+          init,
+        );
+      });
+    const runtime = createChatRuntime({
+      system: 'Answer briefly.',
+      retries: 0,
+    });
+    teardown = runtime.start();
+
+    runtime.sendMessage({ role: 'user', content: 'Use the default route.' });
+    const assistant = await waitForSignal(
+      runtime.lastAssistantMessage,
+      (message) => message?.content === 'Default route.',
+    );
+
+    expect(assistant?.content).toBe('Default route.');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/run',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  } finally {
+    teardown?.();
+    fetchSpy?.mockRestore();
+    await testAimock?.stop();
+  }
+});
+
+test('createChatRuntime adopts a generated thread identity and reuses it on the next text run', async () => {
   const capturedInputs: HashbrownRunInput[] = [];
   let testAimock: TestAimock | undefined;
   let teardown: (() => void) | undefined;
@@ -550,37 +602,37 @@ test('fryHashbrown adopts a generated thread identity and reuses it on the next 
           1_700_000_010_000 + requestIndex * 100,
         ),
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: createHttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
       }),
       system: 'Answer briefly.',
       retries: 0,
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
 
-    await drainHashbrownEffects();
+    await drainRuntimeEffects();
 
     expect(capturedInputs).toEqual([]);
-    expect(hashbrown.threadId()).toBeUndefined();
+    expect(runtime.threadId()).toBeUndefined();
 
-    hashbrown.sendMessage({ role: 'user', content: 'First turn' });
+    runtime.sendMessage({ role: 'user', content: 'First turn' });
     await waitForSignal(
-      hashbrown.lastAssistantMessage,
+      runtime.lastAssistantMessage,
       (message) => message?.content === 'First response.',
     );
-    await waitForIdle(hashbrown);
+    await waitForIdle(runtime);
 
     const generatedThreadId = capturedInputs[0]?.threadId;
     expect(generatedThreadId).toEqual(expect.any(String));
-    expect(hashbrown.threadId()).toBe(generatedThreadId);
+    expect(runtime.threadId()).toBe(generatedThreadId);
 
-    hashbrown.sendMessage({ role: 'user', content: 'Second turn' });
+    runtime.sendMessage({ role: 'user', content: 'Second turn' });
     const secondResponse = await waitForSignal(
-      hashbrown.lastAssistantMessage,
+      runtime.lastAssistantMessage,
       (message) => message?.content === 'Second response.',
     );
-    await waitForIdle(hashbrown);
+    await waitForIdle(runtime);
 
     expect(secondResponse).toEqual({
       role: 'assistant',
@@ -590,15 +642,15 @@ test('fryHashbrown adopts a generated thread identity and reuses it on the next 
     expect(capturedInputs).toHaveLength(2);
     expect(capturedInputs[1]?.threadId).toBe(generatedThreadId);
     expect(capturedInputs[0]?.runId).not.toBe(capturedInputs[1]?.runId);
-    expect(hashbrown.threadId()).toBe(generatedThreadId);
-    expect(hashbrown.error()).toBeUndefined();
+    expect(runtime.threadId()).toBe(generatedThreadId);
+    expect(runtime.error()).toBeUndefined();
   } finally {
     teardown?.();
     await testAimock?.stop();
   }
 }, 10_000);
 
-test('fryHashbrown resolves chunked structured output and sends the response schema in hashbrown metadata', async () => {
+test('createChatRuntime resolves chunked structured output and sends the response schema in hashbrown metadata', async () => {
   const responseSchema = s.object('answer', {
     answer: s.streaming.string('answer text'),
     count: s.number('result count'),
@@ -659,7 +711,7 @@ test('fryHashbrown resolves chunked structured output and sends the response sch
       ],
       25,
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: createHttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
       }),
@@ -667,21 +719,21 @@ test('fryHashbrown resolves chunked structured output and sends the response sch
       responseSchema,
       retries: 0,
     });
-    unsubscribeContent = hashbrown.lastAssistantMessage.subscribe((message) => {
+    unsubscribeContent = runtime.lastAssistantMessage.subscribe((message) => {
       if (message) {
         observedContent.push(message.content);
       }
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
 
-    hashbrown.sendMessage({ role: 'user', content: 'Count the results' });
+    runtime.sendMessage({ role: 'user', content: 'Count the results' });
     const assistant = await waitForSignal(
-      hashbrown.lastAssistantMessage,
+      runtime.lastAssistantMessage,
       (message) =>
         message?.content?.answer === 'deterministic' &&
         message.content.count === 2,
     );
-    await waitForIdle(hashbrown);
+    await waitForIdle(runtime);
 
     expect(assistant?.content).toEqual({
       answer: 'deterministic',
@@ -695,7 +747,7 @@ test('fryHashbrown resolves chunked structured output and sends the response sch
     expect(capturedInputs[0]).not.toHaveProperty('responseSchema');
     expect(capturedInputs[0]).not.toHaveProperty('params');
     expect(capturedInputs[0]?.forwardedProps).toEqual({});
-    expect(hashbrown.error()).toBeUndefined();
+    expect(runtime.error()).toBeUndefined();
   } finally {
     unsubscribeContent?.();
     teardown?.();
@@ -703,7 +755,7 @@ test('fryHashbrown resolves chunked structured output and sends the response sch
   }
 }, 10_000);
 
-test('fryHashbrown resolves validated generative UI state and marks the request as UI', async () => {
+test('createChatRuntime resolves validated generative UI state and marks the request as UI', async () => {
   function StatusComponent(_props: { title: string; count: number }) {
     void _props;
     return null;
@@ -743,7 +795,7 @@ test('fryHashbrown resolves validated generative UI state and marks the request 
           1_700_000_012_000,
         ),
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: createHttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
       }),
@@ -752,19 +804,19 @@ test('fryHashbrown resolves validated generative UI state and marks the request 
       ui: true,
       retries: 0,
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
 
-    hashbrown.sendMessage({ role: 'user', content: 'Show status' });
+    runtime.sendMessage({ role: 'user', content: 'Show status' });
     const partialAssistant = await waitForSignal(
-      hashbrown.lastAssistantMessage,
+      runtime.lastAssistantMessage,
       (message) => message?.content?.ui?.length === 1,
     );
     expect(
       partialAssistant?.content?.ui[0]?.status?.props?.partialValue,
     ).toEqual({ title: 'Re' });
 
-    await waitForIdle(hashbrown);
-    const assistant = hashbrown.lastAssistantMessage();
+    await waitForIdle(runtime);
+    const assistant = runtime.lastAssistantMessage();
 
     expect(assistant?.content).toEqual({
       ui: [
@@ -785,14 +837,14 @@ test('fryHashbrown resolves validated generative UI state and marks the request 
       responseSchema: s.toJsonSchema(responseSchema),
       ui: true,
     });
-    expect(hashbrown.error()).toBeUndefined();
+    expect(runtime.error()).toBeUndefined();
   } finally {
     teardown?.();
     await testAimock?.stop();
   }
 }, 10_000);
 
-test('fryHashbrown cancels a delayed SSE run after the first content without later mutations or continuation', async () => {
+test('createChatRuntime cancels a delayed SSE run after the first content without later mutations or continuation', async () => {
   const toolHandler = jest.fn(async ({ value }: { value: string }) => value);
   const tool: Chat.Tool<'delayedTool', { value: string }, string> = {
     name: 'delayedTool',
@@ -870,7 +922,7 @@ test('fryHashbrown cancels a delayed SSE run after the first content without lat
       ],
       75,
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: new HttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
         fetchImpl: createObservedFetch(observedResponses),
@@ -879,14 +931,14 @@ test('fryHashbrown cancels a delayed SSE run after the first content without lat
       tools: [tool],
       retries: 2,
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
 
-    hashbrown.sendMessage({
+    runtime.sendMessage({
       role: 'user',
       content: 'Start a delayed response',
     });
     const messagesBeforeCancellation = await waitForSignal(
-      hashbrown.messages,
+      runtime.messages,
       (messages) =>
         messages.some(
           (message) =>
@@ -902,11 +954,11 @@ test('fryHashbrown cancels a delayed SSE run after the first content without lat
         toolCalls: [],
       },
     ]);
-    expect(hashbrown.threadId()).toBe(capturedInputs[0]?.threadId);
+    expect(runtime.threadId()).toBe(capturedInputs[0]?.threadId);
 
-    hashbrown.stop();
-    await waitForIdle(hashbrown);
-    const messagesAfterCancellation = hashbrown.messages();
+    runtime.stop();
+    await waitForIdle(runtime);
+    const messagesAfterCancellation = runtime.messages();
     expect(observedResponses).toHaveLength(1);
     const cancellationResponse = observedResponses[0];
     if (!cancellationResponse) {
@@ -918,7 +970,7 @@ test('fryHashbrown cancels a delayed SSE run after the first content without lat
     expect(messagesAfterCancellation).toEqual([
       { role: 'user', content: 'Start a delayed response' },
     ]);
-    expect(hashbrown.messages()).toEqual(messagesAfterCancellation);
+    expect(runtime.messages()).toEqual(messagesAfterCancellation);
     expect(capturedInputs).toHaveLength(1);
     expect(cancellationResponse.cancelCount).toBe(1);
     expect(cancellationResponse.eventTypes).toEqual([
@@ -930,19 +982,19 @@ test('fryHashbrown cancels a delayed SSE run after the first content without lat
     expect(cancellationResponse.readCount).toBe(cancellation.readCount);
     expect(cancellation.readCount).toBeLessThan(9);
     expect(toolHandler).not.toHaveBeenCalled();
-    expect(hashbrown.error()).toBeUndefined();
-    expect(hashbrown.isLoading()).toBe(false);
-    expect(hashbrown.isReceiving()).toBe(false);
-    expect(hashbrown.isSending()).toBe(false);
-    expect(hashbrown.isGenerating()).toBe(false);
-    expect(hashbrown.isRunningToolCalls()).toBe(false);
+    expect(runtime.error()).toBeUndefined();
+    expect(runtime.isLoading()).toBe(false);
+    expect(runtime.isReceiving()).toBe(false);
+    expect(runtime.isSending()).toBe(false);
+    expect(runtime.isGenerating()).toBe(false);
+    expect(runtime.isRunningToolCalls()).toBe(false);
   } finally {
     teardown?.();
     await testAimock?.stop();
   }
 }, 10_000);
 
-test('fryHashbrown surfaces one server run error and closes the SSE response without retrying', async () => {
+test('createChatRuntime surfaces one server run error and closes the SSE response without retrying', async () => {
   const capturedInputs: HashbrownRunInput[] = [];
   const observedResponses: ObservedResponse[] = [];
   const observedErrors: Error[] = [];
@@ -977,7 +1029,7 @@ test('fryHashbrown surfaces one server run error and closes the SSE response wit
       ],
       75,
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: new HttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
         fetchImpl: createObservedFetch(observedResponses),
@@ -985,19 +1037,19 @@ test('fryHashbrown surfaces one server run error and closes the SSE response wit
       system: 'Answer briefly.',
       retries: 2,
     });
-    unsubscribeError = hashbrown.error.subscribe((error) => {
+    unsubscribeError = runtime.error.subscribe((error) => {
       if (error) {
         observedErrors.push(error);
       }
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
 
-    hashbrown.sendMessage({
+    runtime.sendMessage({
       role: 'user',
       content: 'Trigger the server error',
     });
-    const error = await waitForSignal(hashbrown.error, Boolean);
-    await waitForIdle(hashbrown);
+    const error = await waitForSignal(runtime.error, Boolean);
+    await waitForIdle(runtime);
     expect(observedResponses).toHaveLength(1);
     const errorResponse = observedResponses[0];
     if (!errorResponse) {
@@ -1010,12 +1062,12 @@ test('fryHashbrown surfaces one server run error and closes the SSE response wit
     expect(observedErrors.map((value) => value.message)).toEqual([
       'Deterministic server failure',
     ]);
-    expect(hashbrown.messages()).toEqual([
+    expect(runtime.messages()).toEqual([
       { role: 'user', content: 'Trigger the server error' },
       { role: 'error', content: 'Deterministic server failure' },
     ]);
     expect(
-      hashbrown.messages().filter((message) => message.role === 'error'),
+      runtime.messages().filter((message) => message.role === 'error'),
     ).toHaveLength(1);
     expect(capturedInputs).toHaveLength(1);
     expect(errorResponse.response.bodyUsed).toBe(true);
@@ -1027,11 +1079,11 @@ test('fryHashbrown surfaces one server run error and closes the SSE response wit
     expect(errorResponse.reachedEof).toBe(false);
     expect(errorResponse.readCount).toBe(cancellation.readCount);
     expect(cancellation.readCount).toBeLessThan(7);
-    expect(hashbrown.isLoading()).toBe(false);
-    expect(hashbrown.isReceiving()).toBe(false);
-    expect(hashbrown.isSending()).toBe(false);
-    expect(hashbrown.isGenerating()).toBe(false);
-    expect(hashbrown.isRunningToolCalls()).toBe(false);
+    expect(runtime.isLoading()).toBe(false);
+    expect(runtime.isReceiving()).toBe(false);
+    expect(runtime.isSending()).toBe(false);
+    expect(runtime.isGenerating()).toBe(false);
+    expect(runtime.isRunningToolCalls()).toBe(false);
   } finally {
     unsubscribeError?.();
     teardown?.();
@@ -1039,7 +1091,7 @@ test('fryHashbrown surfaces one server run error and closes the SSE response wit
   }
 }, 10_000);
 
-test('fryHashbrown executes and continues an AG-UI tool call over real SSE', async () => {
+test('createChatRuntime executes and continues an AG-UI tool call over real SSE', async () => {
   const handlerStarted = createDeferred<void>();
   const handlerResult = createDeferred<{
     city: string;
@@ -1154,7 +1206,7 @@ test('fryHashbrown executes and continues an AG-UI tool call over real SSE', asy
       },
       75,
     );
-    const hashbrown = fryHashbrown({
+    const runtime = createChatRuntime({
       transport: new HttpTransport({
         baseUrl: testAimock.handle.aguiRunUrl,
         fetchImpl: createObservedFetch(
@@ -1166,10 +1218,10 @@ test('fryHashbrown executes and continues an AG-UI tool call over real SSE', asy
       tools: [tool],
       threadId: 'thread-tool',
     });
-    teardown = hashbrown.sizzle();
+    teardown = runtime.start();
     await Promise.resolve();
 
-    hashbrown.sendMessage({
+    runtime.sendMessage({
       role: 'user',
       content: 'What is the weather in Paris?',
     });
@@ -1208,14 +1260,14 @@ test('fryHashbrown executes and continues an AG-UI tool call over real SSE', asy
       'second-request',
     ]);
 
-    const messages = await waitForSignal(hashbrown.messages, (value) =>
+    const messages = await waitForSignal(runtime.messages, (value) =>
       value.some(
         (message) =>
           message.role === 'assistant' &&
           message.content === 'It is 21 C and sunny in Paris.',
       ),
     );
-    await waitForIdle(hashbrown);
+    await waitForIdle(runtime);
 
     expect(messages).toEqual([
       { role: 'user', content: 'What is the weather in Paris?' },
@@ -1246,13 +1298,13 @@ test('fryHashbrown executes and continues an AG-UI tool call over real SSE', asy
         toolCalls: [],
       },
     ]);
-    expect(hashbrown.error()).toBeUndefined();
-    expect(hashbrown.isLoading()).toBe(false);
-    expect(hashbrown.isReceiving()).toBe(false);
-    expect(hashbrown.isSending()).toBe(false);
-    expect(hashbrown.isGenerating()).toBe(false);
-    expect(hashbrown.isRunningToolCalls()).toBe(false);
-    expect(hashbrown.lastAssistantMessage()).toEqual(messages[2]);
+    expect(runtime.error()).toBeUndefined();
+    expect(runtime.isLoading()).toBe(false);
+    expect(runtime.isReceiving()).toBe(false);
+    expect(runtime.isSending()).toBe(false);
+    expect(runtime.isGenerating()).toBe(false);
+    expect(runtime.isRunningToolCalls()).toBe(false);
+    expect(runtime.lastAssistantMessage()).toEqual(messages[2]);
     expect(toolHandler).toHaveBeenCalledTimes(1);
     expect(toolHandler).toHaveBeenCalledWith(
       { city: 'Paris' },

--- a/www/analog/src/app/pages/docs/angular/recipes/local-models.md
+++ b/www/analog/src/app/pages/docs/angular/recipes/local-models.md
@@ -146,7 +146,7 @@ export class LocalItinerary {
 
 ## 4. Structured output on-device
 
-Both transports forward Hashbrown's `responseFormat` to each browser's `responseConstraint`:
+Both transports forward Hashbrown's response schema to each browser's `responseConstraint`:
 
 - Keep schemas small; models are SLMs.
 - Schemas support the `streaming` keyword letting you eagerly parse JSON as it is being generated.

--- a/www/analog/src/app/pages/docs/angular/start/migration.md
+++ b/www/analog/src/app/pages/docs/angular/start/migration.md
@@ -66,6 +66,44 @@ Local browser models are now transports. Replace `model: experimental_local(...)
 
 ---
 
+## Core Runtime Naming
+
+The direct core API now uses technical lifecycle names:
+
+```ts
+// Before
+const hashbrown = fryHashbrown(options);
+const teardown = hashbrown.sizzle();
+
+// After
+const runtime = createChatRuntime(options);
+const teardown = runtime.start();
+```
+
+The exported `Hashbrown<Output, Tools>` type is now `ChatRuntime<Output, Tools>`. The old factory, type, and lifecycle method were removed without deprecated aliases.
+
+---
+
+## Direct Core HTTP Configuration
+
+The core runtime now stores only transport configuration. `provideHashbrown(...)` and resource `apiUrl` options remain supported, but direct `createChatRuntime(...)` calls configure non-default HTTP endpoints through `createHttpTransport`:
+
+```ts
+import { createHttpTransport, createChatRuntime } from '@hashbrownai/core';
+
+const runtime = createChatRuntime({
+  system: 'You are a helpful assistant.',
+  transport: createHttpTransport({
+    baseUrl: '/alternate-run',
+    middleware: [addAuthorization],
+  }),
+});
+```
+
+Omit `transport` to use AG-UI over POST `/run`.
+
+---
+
 ## Structured Output Controls
 
 Structured resources now use their `schema` option as the sole client-side structured output control. Hashbrown sends that schema in `RunAgentInput.hashbrown.responseSchema`; the server adapter owns provider-specific schema enforcement or JSON-mode settings.

--- a/www/analog/src/app/pages/docs/react/start/migration.md
+++ b/www/analog/src/app/pages/docs/react/start/migration.md
@@ -66,6 +66,44 @@ Local browser models are now transports. Replace `model: experimental_local(...)
 
 ---
 
+## Core Runtime Naming
+
+The direct core API now uses technical lifecycle names:
+
+```ts
+// Before
+const hashbrown = fryHashbrown(options);
+const teardown = hashbrown.sizzle();
+
+// After
+const runtime = createChatRuntime(options);
+const teardown = runtime.start();
+```
+
+The exported `Hashbrown<Output, Tools>` type is now `ChatRuntime<Output, Tools>`. The old factory, type, and lifecycle method were removed without deprecated aliases.
+
+---
+
+## Direct Core HTTP Configuration
+
+The core runtime now stores only transport configuration. `HashbrownProvider` still accepts `url` and `middleware`, but direct `createChatRuntime(...)` calls configure non-default HTTP endpoints through `createHttpTransport`:
+
+```ts
+import { createHttpTransport, createChatRuntime } from '@hashbrownai/core';
+
+const runtime = createChatRuntime({
+  system: 'You are a helpful assistant.',
+  transport: createHttpTransport({
+    baseUrl: '/alternate-run',
+    middleware: [addAuthorization],
+  }),
+});
+```
+
+Omit `transport` to use AG-UI over POST `/run`.
+
+---
+
 ## Structured Output Controls
 
 Structured resources now use their `schema` option as the sole client-side structured output control. Hashbrown sends that schema in `RunAgentInput.hashbrown.responseSchema`; the server adapter owns provider-specific schema enforcement or JSON-mode settings.

--- a/www/analog/src/content/blog/2025-09-24-spotify-game-with-hashbrown.md
+++ b/www/analog/src/content/blog/2025-09-24-spotify-game-with-hashbrown.md
@@ -544,18 +544,19 @@ export class SongPickerViewComponent {
         }),
         result: s.string('The completion'),
         handler: ({ system, input }, abortSignal) => {
-          const hashbrown = fryHashbrown({
-            apiUrl: 'http://localhost:5150/chat',
-            model: 'gpt-4.1-mini',
+          const runtime = createChatRuntime({
             debugName: 'inception completion',
             system,
             messages: [{ role: 'user', content: input }],
+            transport: createHttpTransport({
+              baseUrl: 'http://localhost:5150/chat',
+            }),
           });
 
-          const teardown = hashbrown.sizzle();
+          const teardown = runtime.start();
 
           return new Promise<string>((resolve, reject) => {
-            const unsubscribe = hashbrown.messages.subscribe((messages) => {
+            const unsubscribe = runtime.messages.subscribe((messages) => {
               const assistantMessage = messages.find(
                 (m) => m.role === 'assistant',
               );


### PR DESCRIPTION
## Summary

- Rename the direct core runtime API: `fryHashbrown()` to `createChatRuntime()`, `Hashbrown` to `ChatRuntime`, and `sizzle()` to `start()`.
- Make transports the core runtime's only connection configuration and default direct core usage to AG-UI over `POST /run`.
- Preserve React and Angular HTTP conveniences by lowering their URL and middleware options into `createHttpTransport()`.
- Update AIMock coverage, package contracts, samples, and migration guidance.

## Breaking Changes

- The old runtime factory, type, and lifecycle method are removed without compatibility aliases.
- Direct core `apiUrl` and `middleware` options are removed. Custom HTTP endpoints use `createHttpTransport()`.
- React `HashbrownProvider` and Angular resource/provider HTTP options remain supported.

## Verification

- Core, React, and Angular builds, tests, lint, and API reports
- Packed Core, React, and Angular clean-consumer tests
- Core: 518 tests
- AIMock: 22 tests
- Runtime unit, typecheck, and lint: 24 tests
- Runtime Playwright smoke suite: 24 tests
- Docs: 5 tests, lint, and production build
- Spotify Angular sample build
- Nx formatting and Git diff integrity checks