### PR TITLE
refactor(core): extract AG-UI run driver

### DIFF
--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1368,6 +1368,94 @@ test('generic send rejection retries with exact attempt progression', async () =
   teardown?.();
 });
 
+test('retry uses a fresh attempt after cleanup completes', async () => {
+  jest.clearAllMocks();
+  const returnStarted = createDeferred<void>();
+  const returnRelease = createDeferred<IteratorResult<AGUIEvent>>();
+  const disposeStarted = createDeferred<void>();
+  const disposeRelease = createDeferred<void>();
+  const requests: TransportRequest[] = [];
+  const iterators: AsyncIterator<AGUIEvent>[] = [];
+  const firstIteratorReturn = jest.fn(async () => {
+    returnStarted.resolve();
+    return returnRelease.promise;
+  });
+  const firstDispose = jest.fn(async () => {
+    disposeStarted.resolve();
+    await disposeRelease.promise;
+  });
+  const { send } = makeSelection(async (request) => {
+    requests.push(request);
+    if (requests.length === 1) {
+      const events = [
+        {
+          type: EventType.CUSTOM,
+          name: 'invalid-before-start',
+          value: null,
+        } as AGUIEvent,
+      ];
+      const values = events[Symbol.iterator]();
+      const eventIterator = {
+        next: async () => values.next(),
+        return: firstIteratorReturn,
+      };
+      iterators.push(eventIterator);
+
+      return {
+        events: {
+          [Symbol.asyncIterator]() {
+            return eventIterator;
+          },
+        },
+        dispose: firstDispose,
+      };
+    }
+
+    const events = successfulEvents(request);
+    const eventIterator = events[Symbol.asyncIterator]();
+    iterators.push(eventIterator);
+
+    return {
+      events: {
+        [Symbol.asyncIterator]() {
+          return eventIterator;
+        },
+      },
+    };
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([
+      [selectRetries, 1],
+      [
+        selectRawStreamingMessage,
+        { role: 'assistant', content: 'Recovered', toolCallIds: [] },
+      ],
+    ]),
+  );
+  const teardown = generateMessage(store);
+
+  const generation = store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Retry' } }),
+  );
+  await returnStarted.promise;
+  expect(send).toHaveBeenCalledTimes(1);
+  returnRelease.resolve({ done: true, value: undefined });
+  await disposeStarted.promise;
+  expect(send).toHaveBeenCalledTimes(1);
+  disposeRelease.resolve();
+  await generation;
+
+  expect(send).toHaveBeenCalledTimes(2);
+  expect(requests[0]).not.toBe(requests[1]);
+  expect(requests[0]?.requestId).not.toBe(requests[1]?.requestId);
+  expect(requests[0]?.input.runId).not.toBe(requests[1]?.input.runId);
+  expect(iterators[0]).not.toBe(iterators[1]);
+  expect(firstIteratorReturn).toHaveBeenCalledTimes(1);
+  expect(firstDispose).toHaveBeenCalledTimes(1);
+
+  teardown?.();
+});
+
 test('exhausted generic send retries dispatches the exhausted action', async () => {
   jest.clearAllMocks();
   const error = new Error('still broken');

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -1,4 +1,4 @@
-import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { EventType } from '@ag-ui/core';
 import { apiActions, devActions, internalActions } from '../actions';
 import { Chat } from '../models';
 import {
@@ -19,36 +19,19 @@ import {
   selectUiRequested,
 } from '../reducers';
 import { s } from '../schema';
+import { resolveTransport, TransportError } from '../transport';
 import {
-  resolveTransport,
-  TransportError,
-  type TransportResponse,
-} from '../transport';
+  type AgUiRunAttemptOutcome,
+  runAgUiAttempt,
+} from '../transport/ag-ui-run-driver';
 import { createHashbrownRunAgentInput } from '../transport/hashbrown-run-agent-input';
 import { sleep, switchAsync } from '../utils/async';
 import { updateAssistantMessage } from '../utils/assistant-message';
 import { createEffect } from '../utils/micro-ngrx';
 
-type ActiveRun = {
-  threadId: string;
-  runId: string;
-  terminal: boolean;
-};
-
 type ActiveGeneration = {
   threadId: string | undefined;
 };
-
-type EventIterationResult =
-  | { kind: 'event'; result: IteratorResult<AGUIEvent> }
-  | { kind: 'cancelled' }
-  | { kind: 'retired' };
-
-type RunOutcome =
-  | { kind: 'finished' }
-  | { kind: 'server-error'; error: Error }
-  | { kind: 'cancelled' }
-  | { kind: 'retired' };
 
 export const generateMessage = createEffect((store) => {
   const effectAbortController = new AbortController();
@@ -206,45 +189,21 @@ export const generateMessage = createEffect((store) => {
             maxAttempts: retries + 1,
             requestId,
           };
-          let transportResponse: TransportResponse | undefined;
-          let eventIterator: AsyncIterator<AGUIEvent> | undefined;
-          let iteratorDone = false;
-          let cleanedUp = false;
-          let activeRun: ActiveRun | undefined;
-
-          const cleanup = async () => {
-            if (cleanedUp) {
-              return;
-            }
-            cleanedUp = true;
-
-            const cleanupTasks: Promise<unknown>[] = [];
-            if (!iteratorDone && eventIterator?.return) {
-              cleanupTasks.push(
-                Promise.resolve().then(() => eventIterator?.return?.()),
-              );
-            }
-            if (transportResponse?.dispose) {
-              cleanupTasks.push(
-                Promise.resolve().then(() => transportResponse?.dispose?.()),
-              );
-            }
-
-            await Promise.allSettled(cleanupTasks);
-          };
+          let runStarted = false;
+          let runTerminal = false;
 
           const synthesizeRunError = (
             message: string,
             allowCancelled = false,
           ) => {
-            if (!activeRun || activeRun.terminal || retiredSignal.aborted) {
+            if (!runStarted || runTerminal || retiredSignal.aborted) {
               return;
             }
             if (runCancelSignal.aborted && !allowCancelled) {
               return;
             }
 
-            activeRun = { ...activeRun, terminal: true };
+            runTerminal = true;
             store.dispatch(
               apiActions.generateMessageEvent({
                 type: EventType.RUN_ERROR,
@@ -253,178 +212,41 @@ export const generateMessage = createEffect((store) => {
             );
           };
 
-          let outcome: RunOutcome | undefined;
+          let outcome: AgUiRunAttemptOutcome | undefined;
           let primaryError: Error | undefined;
           try {
-            transportResponse = await transport.send(eventRequest);
-
-            if (retiredSignal.aborted) {
-              outcome = { kind: 'retired' };
-            } else if (runCancelSignal.aborted) {
-              outcome = { kind: 'cancelled' };
-            } else {
-              const events = transportResponse.events;
-              if (
-                !events ||
-                typeof events[Symbol.asyncIterator] !== 'function'
-              ) {
-                throw new TransportError(
-                  'Transport response did not provide an event stream',
-                  { retryable: true, code: 'PROTOCOL_ERROR' },
+            outcome = await runAgUiAttempt({
+              transport,
+              request: eventRequest,
+              cancelSignal: runCancelSignal,
+              retiredSignal,
+              onStarted: () => {
+                store.dispatch(
+                  apiActions.generateMessageStart({
+                    responseSchema,
+                    toolsByName,
+                  }),
                 );
-              }
-              eventIterator = events[Symbol.asyncIterator]();
-
-              while (!outcome) {
-                const iteration = await _nextEvent(
-                  eventIterator,
-                  retiredSignal,
-                  runCancelSignal,
-                );
-
-                if (iteration.kind === 'retired') {
-                  outcome = { kind: 'retired' };
-                  break;
-                }
-                if (iteration.kind === 'cancelled') {
-                  outcome = { kind: 'cancelled' };
-                  break;
-                }
-
-                const { result } = iteration;
-                if (result.done) {
-                  iteratorDone = true;
-                  if (!activeRun) {
-                    throw new TransportError(
-                      'Generation stream ended before RUN_STARTED',
-                      { retryable: true, code: 'PROTOCOL_ERROR' },
-                    );
-                  }
-                  if (!activeRun.terminal) {
-                    throw new TransportError(
-                      'Generation stream ended before RUN_FINISHED or RUN_ERROR',
-                      { retryable: true, code: 'PROTOCOL_ERROR' },
-                    );
-                  }
-                  break;
-                }
-
-                if (retiredSignal.aborted) {
-                  outcome = { kind: 'retired' };
-                  break;
-                }
-                if (runCancelSignal.aborted) {
-                  outcome = { kind: 'cancelled' };
-                  break;
-                }
-
-                const event = result.value;
-                if (!activeRun) {
-                  if (event.type !== EventType.RUN_STARTED) {
-                    throw new TransportError(
-                      `Received ${event.type} before RUN_STARTED`,
-                      { retryable: true, code: 'PROTOCOL_ERROR' },
-                    );
-                  }
-                  if (
-                    event.threadId !== threadId ||
-                    event.runId !== requestId
-                  ) {
-                    throw new TransportError(
-                      'RUN_STARTED identity does not match the attempted run',
-                      { retryable: true, code: 'PROTOCOL_ERROR' },
-                    );
-                  }
-
-                  if (retiredSignal.aborted || runCancelSignal.aborted) {
-                    outcome = retiredSignal.aborted
-                      ? { kind: 'retired' }
-                      : { kind: 'cancelled' };
-                    break;
-                  }
-                  store.dispatch(
-                    apiActions.generateMessageStart({
-                      responseSchema,
-                      toolsByName,
-                    }),
-                  );
-                  if (retiredSignal.aborted || runCancelSignal.aborted) {
-                    outcome = retiredSignal.aborted
-                      ? { kind: 'retired' }
-                      : { kind: 'cancelled' };
-                    break;
-                  }
-                  activeRun = {
-                    threadId: event.threadId,
-                    runId: event.runId,
-                    terminal: false,
-                  };
-                  store.dispatch(apiActions.generateMessageEvent(event));
-                  continue;
-                }
-
+              },
+              onEvent: (event) => {
                 if (event.type === EventType.RUN_STARTED) {
-                  throw new TransportError('Received duplicate RUN_STARTED', {
-                    retryable: true,
-                    code: 'PROTOCOL_ERROR',
-                  });
+                  runStarted = true;
+                }
+                if (
+                  event.type === EventType.RUN_FINISHED ||
+                  event.type === EventType.RUN_ERROR
+                ) {
+                  runTerminal = true;
                 }
 
-                if (event.type === EventType.RUN_FINISHED) {
-                  if (
-                    event.threadId !== activeRun.threadId ||
-                    event.runId !== activeRun.runId
-                  ) {
-                    throw new TransportError(
-                      'RUN_FINISHED identity does not match the active run',
-                      { retryable: true, code: 'PROTOCOL_ERROR' },
-                    );
-                  }
-
-                  activeRun = { ...activeRun, terminal: true };
-                  if (!retiredSignal.aborted && !runCancelSignal.aborted) {
-                    store.dispatch(apiActions.generateMessageEvent(event));
-                    outcome = { kind: 'finished' };
-                  } else {
-                    outcome = retiredSignal.aborted
-                      ? { kind: 'retired' }
-                      : { kind: 'cancelled' };
-                  }
-                  break;
-                }
-
-                if (event.type === EventType.RUN_ERROR) {
-                  activeRun = { ...activeRun, terminal: true };
-                  if (!retiredSignal.aborted && !runCancelSignal.aborted) {
-                    store.dispatch(apiActions.generateMessageEvent(event));
-                    outcome = {
-                      kind: 'server-error',
-                      error: new Error(event.message),
-                    };
-                  } else {
-                    outcome = retiredSignal.aborted
-                      ? { kind: 'retired' }
-                      : { kind: 'cancelled' };
-                  }
-                  break;
-                }
-
-                if (!retiredSignal.aborted && !runCancelSignal.aborted) {
-                  store.dispatch(apiActions.generateMessageEvent(event));
-                } else {
-                  outcome = retiredSignal.aborted
-                    ? { kind: 'retired' }
-                    : { kind: 'cancelled' };
-                }
-              }
-            }
+                store.dispatch(apiActions.generateMessageEvent(event));
+              },
+            });
           } catch (error) {
             primaryError =
               error instanceof Error
                 ? error
                 : new Error('Unknown transport error');
-          } finally {
-            await cleanup();
           }
 
           if (retiredSignal.aborted || outcome?.kind === 'retired') {
@@ -522,51 +344,6 @@ export const generateMessage = createEffect((store) => {
     threadIdentityAbortController.abort();
   };
 });
-
-function _nextEvent(
-  iterator: AsyncIterator<AGUIEvent>,
-  retiredSignal: AbortSignal,
-  cancelSignal: AbortSignal,
-): Promise<EventIterationResult> {
-  if (retiredSignal.aborted) {
-    return Promise.resolve({ kind: 'retired' });
-  }
-  if (cancelSignal.aborted) {
-    return Promise.resolve({ kind: 'cancelled' });
-  }
-
-  return new Promise<EventIterationResult>((resolve, reject) => {
-    let settled = false;
-    const cleanup = () => {
-      retiredSignal.removeEventListener('abort', handleRetired);
-      cancelSignal.removeEventListener('abort', handleCancelled);
-    };
-    const settle = (result: EventIterationResult) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      resolve(result);
-    };
-    const fail = (error: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      reject(error);
-    };
-    const handleRetired = () => settle({ kind: 'retired' });
-    const handleCancelled = () => settle({ kind: 'cancelled' });
-
-    retiredSignal.addEventListener('abort', handleRetired, { once: true });
-    cancelSignal.addEventListener('abort', handleCancelled, { once: true });
-    Promise.resolve()
-      .then(() => iterator.next())
-      .then((result) => settle({ kind: 'event', result }), fail);
-  });
-}
 
 function _createRequestId() {
   if (

--- a/packages/core/src/transport/ag-ui-run-driver.spec.ts
+++ b/packages/core/src/transport/ag-ui-run-driver.spec.ts
@@ -1,0 +1,615 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type {
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from './transport';
+import { TransportError } from './transport-error';
+import { createHashbrownRunAgentInput } from './hashbrown-run-agent-input';
+import { runAgUiAttempt } from './ag-ui-run-driver';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createRequest(): TransportRequest {
+  const threadId = 'thread-id';
+  const runId = 'run-id';
+
+  return {
+    input: createHashbrownRunAgentInput({
+      threadId,
+      runId,
+      messages: [],
+      tools: [],
+    }),
+    signal: new AbortController().signal,
+    attempt: 1,
+    maxAttempts: 1,
+    requestId: runId,
+  };
+}
+
+function createEvents(events: AGUIEvent[]): AsyncIterable<AGUIEvent> {
+  return (async function* () {
+    yield* events;
+  })();
+}
+
+function createStarted(request: TransportRequest): AGUIEvent {
+  return {
+    type: EventType.RUN_STARTED,
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+}
+
+function createFinished(request: TransportRequest): AGUIEvent {
+  return {
+    type: EventType.RUN_FINISHED,
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+}
+
+function createTransport(
+  send: Transport['send'],
+): Transport & { send: jest.MockedFunction<Transport['send']> } {
+  return {
+    name: 'test-transport',
+    send: jest.fn(send),
+  };
+}
+
+function runAttempt({
+  transport,
+  request = createRequest(),
+  cancelSignal = new AbortController().signal,
+  retiredSignal = new AbortController().signal,
+  onStarted = jest.fn(),
+  onEvent = jest.fn(),
+}: {
+  transport: Transport;
+  request?: TransportRequest;
+  cancelSignal?: AbortSignal;
+  retiredSignal?: AbortSignal;
+  onStarted?: () => void;
+  onEvent?: (event: AGUIEvent) => void;
+}) {
+  return runAgUiAttempt({
+    transport,
+    request,
+    cancelSignal,
+    retiredSignal,
+    onStarted,
+    onEvent,
+  });
+}
+
+test('sends one request and reports a validated finished run', async () => {
+  const request = createRequest();
+  const started = createStarted(request);
+  const middle: AGUIEvent = {
+    type: EventType.CUSTOM,
+    name: 'middle',
+    value: { ok: true },
+  };
+  const finished = createFinished(request);
+  const dispose = jest.fn();
+  const transport = createTransport(async () => ({
+    events: createEvents([started, middle, finished]),
+    dispose,
+  }));
+  const onStarted = jest.fn();
+  const onEvent = jest.fn();
+
+  const outcome = await runAttempt({
+    transport,
+    request,
+    onStarted,
+    onEvent,
+  });
+
+  expect(outcome).toEqual({ kind: 'finished' });
+  expect(transport.send).toHaveBeenCalledWith(request);
+  expect(transport.send).toHaveBeenCalledTimes(1);
+  expect(onStarted).toHaveBeenCalledTimes(1);
+  expect(onEvent.mock.calls.map(([event]) => event)).toEqual([
+    started,
+    middle,
+    finished,
+  ]);
+  expect(dispose).toHaveBeenCalledTimes(1);
+});
+
+test('returns a named server error without converting RUN_ERROR to a protocol failure', async () => {
+  const request = createRequest();
+  const runError: AGUIEvent = {
+    type: EventType.RUN_ERROR,
+    message: 'server rejected the run',
+  };
+  const transport = createTransport(async () => ({
+    events: createEvents([createStarted(request), runError]),
+  }));
+  const onEvent = jest.fn();
+
+  const outcome = await runAttempt({ transport, request, onEvent });
+
+  expect(outcome).toMatchObject({
+    kind: 'server-error',
+    error: { message: 'server rejected the run' },
+  });
+  expect(onEvent).toHaveBeenLastCalledWith(runError);
+});
+
+test.each([
+  {
+    label: 'an event before RUN_STARTED',
+    events: (request: TransportRequest) => [createFinished(request)],
+    message: `Received ${EventType.RUN_FINISHED} before RUN_STARTED`,
+  },
+  {
+    label: 'a duplicate RUN_STARTED',
+    events: (request: TransportRequest) => [
+      createStarted(request),
+      createStarted(request),
+    ],
+    message: 'Received duplicate RUN_STARTED',
+  },
+  {
+    label: 'a mismatched RUN_STARTED',
+    events: (request: TransportRequest) => [
+      {
+        ...createStarted(request),
+        runId: `${request.input.runId}:other`,
+      } as AGUIEvent,
+    ],
+    message: 'RUN_STARTED identity does not match the attempted run',
+  },
+  {
+    label: 'a mismatched RUN_FINISHED',
+    events: (request: TransportRequest) => [
+      createStarted(request),
+      {
+        ...createFinished(request),
+        threadId: `${request.input.threadId}:other`,
+      } as AGUIEvent,
+    ],
+    message: 'RUN_FINISHED identity does not match the active run',
+  },
+])(
+  'rejects $label as a retryable protocol error',
+  async ({ events, message }) => {
+    const request = createRequest();
+    const transport = createTransport(async () => ({
+      events: createEvents(events(request)),
+    }));
+
+    const attempt = runAttempt({ transport, request });
+
+    await expect(attempt).rejects.toMatchObject({
+      name: 'TransportError',
+      message,
+      retryable: true,
+      code: 'PROTOCOL_ERROR',
+    });
+  },
+);
+
+test('validates against request identity captured before transport mutation', async () => {
+  const request = createRequest();
+  const mutatedIdentity = {
+    threadId: `${request.input.threadId}:mutated`,
+    runId: `${request.input.runId}:mutated`,
+  };
+  const transport = createTransport(async () => {
+    Object.assign(request.input, mutatedIdentity);
+
+    return {
+      events: createEvents([
+        { type: EventType.RUN_STARTED, ...mutatedIdentity },
+        { type: EventType.RUN_FINISHED, ...mutatedIdentity },
+      ] as AGUIEvent[]),
+    };
+  });
+
+  const attempt = runAttempt({ transport, request });
+
+  await expect(attempt).rejects.toMatchObject({
+    name: 'TransportError',
+    message: 'RUN_STARTED identity does not match the attempted run',
+    code: 'PROTOCOL_ERROR',
+  });
+});
+
+test.each([
+  {
+    label: 'before RUN_STARTED',
+    events: () => [],
+    message: 'Generation stream ended before RUN_STARTED',
+  },
+  {
+    label: 'before a terminal event',
+    events: (request: TransportRequest) => [createStarted(request)],
+    message: 'Generation stream ended before RUN_FINISHED or RUN_ERROR',
+  },
+])('rejects premature stream close $label', async ({ events, message }) => {
+  const request = createRequest();
+  const transport = createTransport(async () => ({
+    events: createEvents(events(request)),
+  }));
+
+  const attempt = runAttempt({ transport, request });
+
+  await expect(attempt).rejects.toMatchObject({
+    name: 'TransportError',
+    message,
+    retryable: true,
+    code: 'PROTOCOL_ERROR',
+  });
+});
+
+test.each([
+  { label: 'missing', events: undefined },
+  { label: 'not async iterable', events: {} },
+])(
+  'rejects a $label event stream and disposes the response',
+  async ({ events }) => {
+    const dispose = jest.fn();
+    const response = { events, dispose } as unknown as TransportResponse;
+    const transport = createTransport(async () => response);
+
+    const attempt = runAttempt({ transport });
+
+    await expect(attempt).rejects.toEqual(
+      new TransportError('Transport response did not provide an event stream', {
+        retryable: true,
+        code: 'PROTOCOL_ERROR',
+      }),
+    );
+    expect(dispose).toHaveBeenCalledTimes(1);
+  },
+);
+
+test.each([
+  { label: 'cancellation', cancel: true, retire: false, kind: 'cancelled' },
+  { label: 'retirement', cancel: false, retire: true, kind: 'retired' },
+  {
+    label: 'simultaneous cancellation and retirement',
+    cancel: true,
+    retire: true,
+    kind: 'retired',
+  },
+] as const)(
+  'returns $kind without sending when $label happens before send',
+  async ({ cancel, retire, kind }) => {
+    const cancelController = new AbortController();
+    const retiredController = new AbortController();
+    if (cancel) {
+      cancelController.abort();
+    }
+    if (retire) {
+      retiredController.abort();
+    }
+    const transport = createTransport(async () => {
+      throw new Error('send must not run');
+    });
+
+    const outcome = await runAttempt({
+      transport,
+      cancelSignal: cancelController.signal,
+      retiredSignal: retiredController.signal,
+    });
+
+    expect(outcome).toEqual({ kind });
+    expect(transport.send).not.toHaveBeenCalled();
+  },
+);
+
+test.each([
+  { label: 'cancellation', retire: false, kind: 'cancelled' },
+  { label: 'retirement', retire: true, kind: 'retired' },
+] as const)(
+  'interrupts a pending send on $label and disposes a late response',
+  async ({ retire, kind }) => {
+    const delayedSend = createDeferred<TransportResponse>();
+    const disposed = createDeferred<void>();
+    const dispose = jest.fn(() => disposed.resolve());
+    const transport = createTransport(() => delayedSend.promise);
+    const cancelController = new AbortController();
+    const retiredController = new AbortController();
+
+    const attempt = runAttempt({
+      transport,
+      cancelSignal: cancelController.signal,
+      retiredSignal: retiredController.signal,
+    });
+    if (retire) {
+      retiredController.abort();
+    } else {
+      cancelController.abort();
+    }
+    const outcome = await attempt;
+    delayedSend.resolve({ events: createEvents([]), dispose });
+    await disposed.promise;
+
+    expect(outcome).toEqual({ kind });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  },
+);
+
+test('suppresses a late send rejection after cancellation', async () => {
+  const delayedSend = createDeferred<TransportResponse>();
+  const transport = createTransport(() => delayedSend.promise);
+  const cancelController = new AbortController();
+
+  const attempt = runAttempt({
+    transport,
+    cancelSignal: cancelController.signal,
+  });
+  cancelController.abort();
+  const outcome = await attempt;
+  delayedSend.reject(new Error('late send rejection'));
+  await Promise.resolve();
+
+  expect(outcome).toEqual({ kind: 'cancelled' });
+});
+
+test('observes cancellation triggered synchronously by send', async () => {
+  const delayedSend = createDeferred<TransportResponse>();
+  const cancelController = new AbortController();
+  const transport = createTransport(() => {
+    cancelController.abort();
+    return delayedSend.promise;
+  });
+
+  const attempt = runAttempt({
+    transport,
+    cancelSignal: cancelController.signal,
+  });
+  const outcome = await Promise.race([
+    attempt,
+    new Promise<{ kind: 'still-pending' }>((resolve) => {
+      setTimeout(() => resolve({ kind: 'still-pending' }), 0);
+    }),
+  ]);
+  delayedSend.reject(new Error('late rejection'));
+
+  expect(outcome).toEqual({ kind: 'cancelled' });
+});
+
+test('suppresses late iterator progress and callbacks after cancellation', async () => {
+  const request = createRequest();
+  const delayedNext = createDeferred<IteratorResult<AGUIEvent>>();
+  const nextStarted = createDeferred<void>();
+  const iteratorReturn = jest.fn(async () => ({
+    done: true as const,
+    value: undefined,
+  }));
+  const dispose = jest.fn();
+  const transport = createTransport(async () => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => {
+            nextStarted.resolve();
+            return delayedNext.promise;
+          },
+          return: iteratorReturn,
+        };
+      },
+    },
+    dispose,
+  }));
+  const cancelController = new AbortController();
+  const onStarted = jest.fn();
+  const onEvent = jest.fn();
+
+  const attempt = runAttempt({
+    transport,
+    request,
+    cancelSignal: cancelController.signal,
+    onStarted,
+    onEvent,
+  });
+  await nextStarted.promise;
+  cancelController.abort();
+  const outcome = await attempt;
+  delayedNext.resolve({ done: false, value: createStarted(request) });
+  await Promise.resolve();
+
+  expect(outcome).toEqual({ kind: 'cancelled' });
+  expect(onStarted).not.toHaveBeenCalled();
+  expect(onEvent).not.toHaveBeenCalled();
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+});
+
+test('does not dispatch RUN_STARTED when cancellation occurs in onStarted', async () => {
+  const request = createRequest();
+  const cancelController = new AbortController();
+  const onStarted = jest.fn(() => cancelController.abort());
+  const onEvent = jest.fn();
+  const transport = createTransport(async () => ({
+    events: createEvents([createStarted(request), createFinished(request)]),
+  }));
+
+  const outcome = await runAttempt({
+    transport,
+    request,
+    cancelSignal: cancelController.signal,
+    onStarted,
+    onEvent,
+  });
+
+  expect(outcome).toEqual({ kind: 'cancelled' });
+  expect(onStarted).toHaveBeenCalledTimes(1);
+  expect(onEvent).not.toHaveBeenCalled();
+});
+
+test('retirement wins when both signals abort during onStarted', async () => {
+  const request = createRequest();
+  const cancelController = new AbortController();
+  const retiredController = new AbortController();
+  const onStarted = jest.fn(() => {
+    cancelController.abort();
+    retiredController.abort();
+  });
+  const transport = createTransport(async () => ({
+    events: createEvents([createStarted(request), createFinished(request)]),
+  }));
+
+  const outcome = await runAttempt({
+    transport,
+    request,
+    cancelSignal: cancelController.signal,
+    retiredSignal: retiredController.signal,
+    onStarted,
+  });
+
+  expect(outcome).toEqual({ kind: 'retired' });
+});
+
+test('awaits iterator return before disposing and before rejecting', async () => {
+  const request = createRequest();
+  const returnRelease = createDeferred<IteratorResult<AGUIEvent>>();
+  const returnStarted = createDeferred<void>();
+  const order: string[] = [];
+  const events = [createFinished(request)];
+  const iterator = events[Symbol.iterator]();
+  const iteratorReturn = jest.fn(async () => {
+    order.push('return:start');
+    returnStarted.resolve();
+    const result = await returnRelease.promise;
+    order.push('return:end');
+    return result;
+  });
+  const dispose = jest.fn(() => {
+    order.push('dispose');
+  });
+  const transport = createTransport(async () => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return { next: async () => iterator.next(), return: iteratorReturn };
+      },
+    },
+    dispose,
+  }));
+
+  const attempt = runAttempt({ transport, request });
+  await returnStarted.promise;
+  expect(order).toEqual(['return:start']);
+  returnRelease.resolve({ done: true, value: undefined });
+  await expect(attempt).rejects.toMatchObject({
+    message: `Received ${EventType.RUN_FINISHED} before RUN_STARTED`,
+  });
+
+  expect(order).toEqual(['return:start', 'return:end', 'dispose']);
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+});
+
+test.each(['iterator return', 'response disposal'] as const)(
+  'preserves a primary protocol error when $failurePoint cleanup fails',
+  async (failurePoint) => {
+    const request = createRequest();
+    const cleanupError = new Error(`${failurePoint} failed`);
+    const events = [createStarted(request), createStarted(request)];
+    const iterator = events[Symbol.iterator]();
+    const iteratorReturn = jest.fn(async () => {
+      if (failurePoint === 'iterator return') {
+        throw cleanupError;
+      }
+      return { done: true as const, value: undefined };
+    });
+    const dispose = jest.fn(async () => {
+      if (failurePoint === 'response disposal') {
+        throw cleanupError;
+      }
+    });
+    const transport = createTransport(async () => ({
+      events: {
+        [Symbol.asyncIterator]() {
+          return { next: async () => iterator.next(), return: iteratorReturn };
+        },
+      },
+      dispose,
+    }));
+
+    const attempt = runAttempt({ transport, request });
+
+    await expect(attempt).rejects.toMatchObject({
+      name: 'TransportError',
+      message: 'Received duplicate RUN_STARTED',
+      code: 'PROTOCOL_ERROR',
+    });
+    expect(iteratorReturn).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  },
+);
+
+test('cleanup accessor failures do not replace a primary protocol error', async () => {
+  const request = createRequest();
+  const cleanupError = new Error('cleanup accessor failed');
+  const accesses: string[] = [];
+  const events = [createStarted(request), createStarted(request)];
+  const values = events[Symbol.iterator]();
+  const transport = createTransport(async () => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => values.next(),
+          get return(): AsyncIterator<AGUIEvent>['return'] {
+            accesses.push('return');
+            throw cleanupError;
+          },
+        };
+      },
+    },
+    get dispose(): TransportResponse['dispose'] {
+      accesses.push('dispose');
+      throw cleanupError;
+    },
+  }));
+
+  const attempt = runAttempt({ transport, request });
+
+  await expect(attempt).rejects.toMatchObject({
+    name: 'TransportError',
+    message: 'Received duplicate RUN_STARTED',
+    code: 'PROTOCOL_ERROR',
+  });
+  expect(accesses).toEqual(['return', 'dispose']);
+});
+
+test('cleans up a terminal response exactly once', async () => {
+  const request = createRequest();
+  const events = [createStarted(request), createFinished(request)];
+  const iterator = events[Symbol.iterator]();
+  const iteratorReturn = jest.fn(async () => ({
+    done: true as const,
+    value: undefined,
+  }));
+  const dispose = jest.fn();
+  const transport = createTransport(async () => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return { next: async () => iterator.next(), return: iteratorReturn };
+      },
+    },
+    dispose,
+  }));
+
+  const outcome = await runAttempt({ transport, request });
+
+  expect(outcome).toEqual({ kind: 'finished' });
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+});

--- a/packages/core/src/transport/ag-ui-run-driver.spec.ts
+++ b/packages/core/src/transport/ag-ui-run-driver.spec.ts
@@ -477,10 +477,11 @@ test('retirement wins when both signals abort during onStarted', async () => {
   expect(outcome).toEqual({ kind: 'retired' });
 });
 
-test('awaits iterator return before disposing and before rejecting', async () => {
+test('invokes iterator return before dispose and awaits both before rejecting', async () => {
   const request = createRequest();
   const returnRelease = createDeferred<IteratorResult<AGUIEvent>>();
   const returnStarted = createDeferred<void>();
+  const disposeRelease = createDeferred<void>();
   const order: string[] = [];
   const events = [createFinished(request)];
   const iterator = events[Symbol.iterator]();
@@ -491,8 +492,10 @@ test('awaits iterator return before disposing and before rejecting', async () =>
     order.push('return:end');
     return result;
   });
-  const dispose = jest.fn(() => {
-    order.push('dispose');
+  const dispose = jest.fn(async () => {
+    order.push('dispose:start');
+    await disposeRelease.promise;
+    order.push('dispose:end');
   });
   const transport = createTransport(async () => ({
     events: {
@@ -505,13 +508,97 @@ test('awaits iterator return before disposing and before rejecting', async () =>
 
   const attempt = runAttempt({ transport, request });
   await returnStarted.promise;
-  expect(order).toEqual(['return:start']);
+  await Promise.resolve();
+  expect(order).toEqual(['return:start', 'dispose:start']);
   returnRelease.resolve({ done: true, value: undefined });
+  await Promise.resolve();
+  disposeRelease.resolve();
   await expect(attempt).rejects.toMatchObject({
     message: `Received ${EventType.RUN_FINISHED} before RUN_STARTED`,
   });
 
-  expect(order).toEqual(['return:start', 'return:end', 'dispose']);
+  expect(order).toEqual([
+    'return:start',
+    'dispose:start',
+    'return:end',
+    'dispose:end',
+  ]);
+  expect(iteratorReturn).toHaveBeenCalledTimes(1);
+  expect(dispose).toHaveBeenCalledTimes(1);
+});
+
+test('disposal unblocks pending iterator cleanup without ending cleanup early', async () => {
+  const request = createRequest();
+  const nextStarted = createDeferred<void>();
+  const nextRelease = createDeferred<IteratorResult<AGUIEvent>>();
+  const returnInvoked = createDeferred<void>();
+  const returnRelease = createDeferred<void>();
+  const disposeInvoked = createDeferred<void>();
+  const disposeRelease = createDeferred<void>();
+  const order: string[] = [];
+  let nextCount = 0;
+  const iteratorReturn = jest.fn(async () => {
+    order.push('return:invoked');
+    returnInvoked.resolve();
+    await disposeInvoked.promise;
+    await returnRelease.promise;
+    order.push('return:settled');
+    return { done: true as const, value: undefined };
+  });
+  const dispose = jest.fn(async () => {
+    order.push('dispose:invoked');
+    disposeInvoked.resolve();
+    nextRelease.resolve({ done: true, value: undefined });
+    await disposeRelease.promise;
+    order.push('dispose:settled');
+  });
+  const transport = createTransport(async () => ({
+    events: {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            nextCount++;
+            if (nextCount === 1) {
+              return { done: false, value: createStarted(request) };
+            }
+
+            nextStarted.resolve();
+            return nextRelease.promise;
+          },
+          return: iteratorReturn,
+        };
+      },
+    },
+    dispose,
+  }));
+  const cancelController = new AbortController();
+
+  const attempt = runAttempt({
+    transport,
+    request,
+    cancelSignal: cancelController.signal,
+  });
+  await nextStarted.promise;
+  cancelController.abort();
+  await returnInvoked.promise;
+
+  expect(order).toEqual(['return:invoked', 'dispose:invoked']);
+  let completed = false;
+  void attempt.then(() => {
+    completed = true;
+  });
+  returnRelease.resolve();
+  await Promise.resolve();
+  expect(completed).toBe(false);
+  disposeRelease.resolve();
+  await expect(attempt).resolves.toEqual({ kind: 'cancelled' });
+
+  expect(order).toEqual([
+    'return:invoked',
+    'dispose:invoked',
+    'return:settled',
+    'dispose:settled',
+  ]);
   expect(iteratorReturn).toHaveBeenCalledTimes(1);
   expect(dispose).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/src/transport/ag-ui-run-driver.ts
+++ b/packages/core/src/transport/ag-ui-run-driver.ts
@@ -142,18 +142,13 @@ async function consumeResponse({
     }
     cleanedUp = true;
 
+    const cleanupTasks: Promise<void>[] = [];
     if (!iteratorDone && iterator) {
-      try {
-        const returnIterator = iterator.return;
-        if (returnIterator) {
-          await returnIterator.call(iterator);
-        }
-      } catch {
-        // Cleanup must not replace the attempt's primary result or error.
-      }
+      cleanupTasks.push(closeIterator(iterator));
     }
+    cleanupTasks.push(disposeResponse(response));
 
-    await disposeResponse(response);
+    await Promise.allSettled(cleanupTasks);
   };
 
   try {
@@ -336,6 +331,19 @@ async function disposeResponse(response: TransportResponse): Promise<void> {
     const dispose = response.dispose;
     if (dispose) {
       await dispose.call(response);
+    }
+  } catch {
+    // Cleanup must not replace the attempt's primary result or error.
+  }
+}
+
+async function closeIterator(
+  iterator: AsyncIterator<AGUIEvent>,
+): Promise<void> {
+  try {
+    const returnIterator = iterator.return;
+    if (returnIterator) {
+      await returnIterator.call(iterator);
     }
   } catch {
     // Cleanup must not replace the attempt's primary result or error.

--- a/packages/core/src/transport/ag-ui-run-driver.ts
+++ b/packages/core/src/transport/ag-ui-run-driver.ts
@@ -1,0 +1,350 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type {
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from './transport';
+import { TransportError } from './transport-error';
+
+/**
+ * Result of executing one AG-UI transport attempt.
+ *
+ * @internal
+ */
+export type AgUiRunAttemptOutcome =
+  | { kind: 'finished' }
+  | { kind: 'server-error'; error: Error }
+  | { kind: 'cancelled' }
+  | { kind: 'retired' };
+
+/**
+ * Inputs for executing and observing one AG-UI transport attempt.
+ *
+ * @internal
+ */
+export interface RunAgUiAttemptOptions {
+  transport: Transport;
+  request: TransportRequest;
+  cancelSignal: AbortSignal;
+  retiredSignal: AbortSignal;
+  onStarted: () => void;
+  onEvent: (event: AGUIEvent) => void;
+}
+
+type InterruptionOutcome = Extract<
+  AgUiRunAttemptOutcome,
+  { kind: 'cancelled' | 'retired' }
+>;
+
+type SettledSend =
+  | { kind: 'response'; response: TransportResponse }
+  | { kind: 'error'; error: unknown };
+
+type SettledNext =
+  | { kind: 'event'; result: IteratorResult<AGUIEvent> }
+  | { kind: 'error'; error: unknown };
+
+type InterruptionWait = {
+  promise: Promise<{ kind: 'interrupted' }>;
+  dispose: () => void;
+};
+
+type RunIdentity = {
+  readonly threadId: string;
+  readonly runId: string;
+};
+
+/**
+ * Executes exactly one transport request and validates its AG-UI run protocol.
+ *
+ * @internal
+ */
+export async function runAgUiAttempt({
+  transport,
+  request,
+  cancelSignal,
+  retiredSignal,
+  onStarted,
+  onEvent,
+}: RunAgUiAttemptOptions): Promise<AgUiRunAttemptOutcome> {
+  const interruptionBeforeSend = getInterruption(retiredSignal, cancelSignal);
+  if (interruptionBeforeSend) {
+    return interruptionBeforeSend;
+  }
+
+  const expectedIdentity: RunIdentity = {
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+  const sendPromise = transport.send(request);
+  const settledSend = settleSend(sendPromise);
+  const sendInterruption = waitForInterruption(retiredSignal, cancelSignal);
+  const sendResult = await Promise.race([
+    settledSend,
+    sendInterruption.promise,
+  ]);
+  sendInterruption.dispose();
+
+  const interruptionAfterSend = getInterruption(retiredSignal, cancelSignal);
+  if (sendResult.kind === 'interrupted' || interruptionAfterSend) {
+    if (sendResult.kind === 'response') {
+      await disposeResponse(sendResult.response);
+    } else if (sendResult.kind === 'interrupted') {
+      void sendPromise.then(
+        async (lateResponse) => disposeResponse(lateResponse),
+        () => undefined,
+      );
+    }
+
+    return (
+      interruptionAfterSend ??
+      getInterruption(retiredSignal, cancelSignal) ?? {
+        kind: 'cancelled',
+      }
+    );
+  }
+
+  if (sendResult.kind === 'error') {
+    throw sendResult.error;
+  }
+
+  return consumeResponse({
+    response: sendResult.response,
+    expectedIdentity,
+    cancelSignal,
+    retiredSignal,
+    onStarted,
+    onEvent,
+  });
+}
+
+async function consumeResponse({
+  response,
+  expectedIdentity,
+  cancelSignal,
+  retiredSignal,
+  onStarted,
+  onEvent,
+}: Pick<
+  RunAgUiAttemptOptions,
+  'cancelSignal' | 'retiredSignal' | 'onStarted' | 'onEvent'
+> & {
+  response: TransportResponse;
+  expectedIdentity: RunIdentity;
+}): Promise<AgUiRunAttemptOutcome> {
+  let iterator: AsyncIterator<AGUIEvent> | undefined;
+  let iteratorDone = false;
+  let cleanedUp = false;
+
+  const cleanup = async () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+
+    if (!iteratorDone && iterator) {
+      try {
+        const returnIterator = iterator.return;
+        if (returnIterator) {
+          await returnIterator.call(iterator);
+        }
+      } catch {
+        // Cleanup must not replace the attempt's primary result or error.
+      }
+    }
+
+    await disposeResponse(response);
+  };
+
+  try {
+    const events = response.events;
+    if (!events || typeof events[Symbol.asyncIterator] !== 'function') {
+      throw protocolError('Transport response did not provide an event stream');
+    }
+
+    iterator = events[Symbol.asyncIterator]();
+    let started = false;
+
+    while (true) {
+      const interruptionBeforeNext = getInterruption(
+        retiredSignal,
+        cancelSignal,
+      );
+      if (interruptionBeforeNext) {
+        return interruptionBeforeNext;
+      }
+
+      const nextResult = await nextEvent(iterator, retiredSignal, cancelSignal);
+      if (nextResult.kind === 'interrupted') {
+        return (
+          getInterruption(retiredSignal, cancelSignal) ?? {
+            kind: 'cancelled',
+          }
+        );
+      }
+      if (nextResult.kind === 'error') {
+        throw nextResult.error;
+      }
+
+      const { result } = nextResult;
+      if (result.done) {
+        iteratorDone = true;
+        if (!started) {
+          throw protocolError('Generation stream ended before RUN_STARTED');
+        }
+
+        throw protocolError(
+          'Generation stream ended before RUN_FINISHED or RUN_ERROR',
+        );
+      }
+
+      const interruptionBeforeEvent = getInterruption(
+        retiredSignal,
+        cancelSignal,
+      );
+      if (interruptionBeforeEvent) {
+        return interruptionBeforeEvent;
+      }
+
+      const event = result.value;
+      if (!started) {
+        if (event.type !== EventType.RUN_STARTED) {
+          throw protocolError(`Received ${event.type} before RUN_STARTED`);
+        }
+        if (
+          event.threadId !== expectedIdentity.threadId ||
+          event.runId !== expectedIdentity.runId
+        ) {
+          throw protocolError(
+            'RUN_STARTED identity does not match the attempted run',
+          );
+        }
+
+        onStarted();
+        const interruptionAfterStarted = getInterruption(
+          retiredSignal,
+          cancelSignal,
+        );
+        if (interruptionAfterStarted) {
+          return interruptionAfterStarted;
+        }
+
+        started = true;
+        onEvent(event);
+        continue;
+      }
+
+      if (event.type === EventType.RUN_STARTED) {
+        throw protocolError('Received duplicate RUN_STARTED');
+      }
+
+      if (event.type === EventType.RUN_FINISHED) {
+        if (
+          event.threadId !== expectedIdentity.threadId ||
+          event.runId !== expectedIdentity.runId
+        ) {
+          throw protocolError(
+            'RUN_FINISHED identity does not match the active run',
+          );
+        }
+
+        onEvent(event);
+        return { kind: 'finished' };
+      }
+
+      if (event.type === EventType.RUN_ERROR) {
+        onEvent(event);
+        return { kind: 'server-error', error: new Error(event.message) };
+      }
+
+      onEvent(event);
+    }
+  } finally {
+    await cleanup();
+  }
+}
+
+async function nextEvent(
+  iterator: AsyncIterator<AGUIEvent>,
+  retiredSignal: AbortSignal,
+  cancelSignal: AbortSignal,
+): Promise<SettledNext | { kind: 'interrupted' }> {
+  const settledNext: Promise<SettledNext> = Promise.resolve()
+    .then(() => iterator.next())
+    .then(
+      (result) => ({ kind: 'event' as const, result }),
+      (error: unknown) => ({ kind: 'error' as const, error }),
+    );
+  const interruption = waitForInterruption(retiredSignal, cancelSignal);
+
+  const result = await Promise.race([settledNext, interruption.promise]);
+  interruption.dispose();
+
+  return result;
+}
+
+function settleSend(send: Promise<TransportResponse>): Promise<SettledSend> {
+  return send.then(
+    (response) => ({ kind: 'response', response }),
+    (error: unknown) => ({ kind: 'error', error }),
+  );
+}
+
+function waitForInterruption(
+  retiredSignal: AbortSignal,
+  cancelSignal: AbortSignal,
+): InterruptionWait {
+  let resolveInterruption!: (result: { kind: 'interrupted' }) => void;
+  const promise = new Promise<{ kind: 'interrupted' }>((resolve) => {
+    resolveInterruption = resolve;
+  });
+  const handleInterruption = () => {
+    resolveInterruption({ kind: 'interrupted' });
+  };
+
+  retiredSignal.addEventListener('abort', handleInterruption, { once: true });
+  cancelSignal.addEventListener('abort', handleInterruption, { once: true });
+  if (getInterruption(retiredSignal, cancelSignal)) {
+    handleInterruption();
+  }
+
+  return {
+    promise,
+    dispose: () => {
+      retiredSignal.removeEventListener('abort', handleInterruption);
+      cancelSignal.removeEventListener('abort', handleInterruption);
+    },
+  };
+}
+
+function getInterruption(
+  retiredSignal: AbortSignal,
+  cancelSignal: AbortSignal,
+): InterruptionOutcome | undefined {
+  if (retiredSignal.aborted) {
+    return { kind: 'retired' };
+  }
+  if (cancelSignal.aborted) {
+    return { kind: 'cancelled' };
+  }
+
+  return undefined;
+}
+
+async function disposeResponse(response: TransportResponse): Promise<void> {
+  try {
+    const dispose = response.dispose;
+    if (dispose) {
+      await dispose.call(response);
+    }
+  } catch {
+    // Cleanup must not replace the attempt's primary result or error.
+  }
+}
+
+function protocolError(message: string): TransportError {
+  return new TransportError(message, {
+    retryable: true,
+    code: 'PROTOCOL_ERROR',
+  });
+}


### PR DESCRIPTION
## Summary

- extract single-attempt AG-UI transport execution and protocol validation from the generation effect
- preserve retry, store, finalization, and tool-continuation behavior in the existing orchestration layer
- harden cancellation and retirement races, stale callback suppression, and exactly-once cleanup
- invoke iterator and response cleanup in deterministic order while allowing disposal to unblock pending iteration

## Testing

- `npx nx test core` (546 tests)
- `npx nx build core`
- `npx nx lint core`
- `npx nx build-api-report core`
- `npx nx e2e core`

## Notes

- no public API changes
- existing action-driven tool continuation remains unchanged in this slice
