### PR TITLE
test(core): harden multi-round tool continuation

### DIFF
--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -1580,12 +1580,19 @@ test('resets retry attempts for each logical tool continuation run', async () =>
 
 test('stopping during a later tool handler prevents another run', async () => {
   jest.clearAllMocks();
+  const startActionType = internalActions.start.type;
+  const startActions = jest.spyOn(internalActions, 'start');
+  Object.assign(startActions, { type: startActionType });
   const skippedToolCalls = observeSkippedToolCalls();
   const laterHandlerStarted = createDeferred<void>();
   const releaseLaterHandler = createDeferred<void>();
   const handlerFinished = createDeferred<void>();
   const probeRequestStarted = createDeferred<void>();
   const probePrompt = 'Confirm cancellation completion.';
+  const startupStartActionCount = 1;
+  const toolContinuationStartActionCount = 1;
+  const expectedStartActionCount =
+    startupStartActionCount + toolContinuationStartActionCount;
   const scriptedToolRounds: readonly ScriptedToolRound[] = [
     { callId: 'call-before-stop', value: 1 },
     { callId: 'call-at-stop', value: 2 },
@@ -1679,6 +1686,7 @@ test('stopping during a later tool handler prevents another run', async () => {
     await waitForRuntimeIdle(runtime);
 
     expect(toolHandler).toHaveBeenCalledTimes(2);
+    expect(startActions).toHaveBeenCalledTimes(expectedStartActionCount);
     expect(transportCountAtStop).toBe(2);
     expect(send).toHaveBeenCalledTimes(transportCountAtStop + 1);
     expect(requests).toHaveLength(3);
@@ -1690,6 +1698,7 @@ test('stopping during a later tool handler prevents another run', async () => {
   } finally {
     releaseLaterHandler.resolve();
     skippedToolCalls.restore();
+    startActions.mockRestore();
     teardown();
   }
 });

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -193,6 +193,126 @@ async function waitForDispatchedEvent(
   throw new Error(`Timed out waiting for ${eventType}`);
 }
 
+async function waitForRuntimeIdle(runtime: { isLoading: () => boolean }) {
+  for (let attempt = 0; attempt < 1_000; attempt++) {
+    if (!runtime.isLoading()) {
+      return;
+    }
+
+    await Promise.resolve();
+  }
+
+  throw new Error('Timed out waiting for the chat runtime to become idle');
+}
+
+type ScriptedToolRound = {
+  readonly callId: string;
+  readonly value: number;
+};
+
+type ToolTranscriptEntry =
+  | {
+      readonly role: 'assistant';
+      readonly toolCalls: readonly {
+        readonly id: string;
+        readonly name: string;
+        readonly arguments: string;
+      }[];
+    }
+  | {
+      readonly role: 'tool';
+      readonly toolCallId: string;
+      readonly content: string;
+    };
+
+function createToolRoundEvents(
+  request: TransportRequest,
+  round: ScriptedToolRound,
+): AsyncIterable<AGUIEvent> {
+  const messageId = `assistant-${round.callId}`;
+
+  return successfulEvents(request, [
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId,
+      role: 'assistant',
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId,
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: round.callId,
+      toolCallName: 'recordValue',
+      parentMessageId: messageId,
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: round.callId,
+      delta: JSON.stringify({ value: round.value }),
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: round.callId,
+    },
+  ]);
+}
+
+function summarizeToolTranscript(request: TransportRequest) {
+  return request.input.messages.reduce<ToolTranscriptEntry[]>(
+    (entries, message) => {
+      if (message.role === 'assistant' && message.toolCalls?.length) {
+        return [
+          ...entries,
+          {
+            role: message.role,
+            toolCalls: message.toolCalls.map((toolCall) => ({
+              id: toolCall.id,
+              name: toolCall.function.name,
+              arguments: toolCall.function.arguments,
+            })),
+          },
+        ];
+      }
+
+      if (message.role === 'tool') {
+        return [
+          ...entries,
+          {
+            role: message.role,
+            toolCallId: message.toolCallId,
+            content: message.content,
+          },
+        ];
+      }
+
+      return entries;
+    },
+    [],
+  );
+}
+
+function expectedToolTranscript(rounds: readonly ScriptedToolRound[]) {
+  return rounds.flatMap<ToolTranscriptEntry>((round) => [
+    {
+      role: 'assistant',
+      toolCalls: [
+        {
+          id: round.callId,
+          name: 'recordValue',
+          arguments: JSON.stringify({ value: round.value }),
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      toolCallId: round.callId,
+      content: JSON.stringify({ recorded: round.value }),
+    },
+  ]);
+}
+
 test('updateMessagesWithDelta works without an initial message', () => {
   const delta: Chat.Api.CompletionChunk = {
     choices: [
@@ -1258,6 +1378,272 @@ test('continues client tools with isolated reasoning details in transcript order
   expect(committedToolMetadata).toEqual({
     provider: { toolSteps: [{ index: 1 }] },
   });
+
+  teardown();
+});
+
+test('continues three sequential tool rounds before the terminal response', async () => {
+  jest.clearAllMocks();
+  const scriptedToolRounds: readonly ScriptedToolRound[] = [
+    { callId: 'call-round-1', value: 1 },
+    { callId: 'call-round-2', value: 2 },
+    { callId: 'call-round-3', value: 3 },
+  ];
+  const expectedToolRounds: readonly ScriptedToolRound[] = [
+    { callId: 'call-round-1', value: 1 },
+    { callId: 'call-round-2', value: 2 },
+    { callId: 'call-round-3', value: 3 },
+  ];
+  const capturedRequests: TransportRequest[] = [];
+  const terminalRequestStarted = createDeferred<void>();
+  const toolHandler = jest.fn(async ({ value }: { value: number }) => ({
+    recorded: value,
+  }));
+  const { send } = makeSelection(async (request) => {
+    capturedRequests.push(request);
+    const toolRound = scriptedToolRounds[capturedRequests.length - 1];
+    if (toolRound) {
+      return { events: createToolRoundEvents(request, toolRound) };
+    }
+
+    terminalRequestStarted.resolve();
+    return {
+      events: successfulEvents(request, [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'assistant-terminal',
+          role: 'assistant',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: 'assistant-terminal',
+          delta: 'All values recorded.',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: 'assistant-terminal',
+        },
+      ]),
+    };
+  });
+  const runtime = createChatRuntime({
+    system: 'You are a test bot',
+    transport: configuredTransport,
+    tools: [
+      {
+        name: 'recordValue',
+        description: 'Record a numeric value.',
+        schema: s.object('Value to record', {
+          value: s.number('Numeric value'),
+        }),
+        handler: toolHandler,
+      },
+    ],
+  });
+  const teardown = runtime.start();
+
+  runtime.sendMessage({ role: 'user', content: 'Record three values.' });
+  await terminalRequestStarted.promise;
+  await waitForRuntimeIdle(runtime);
+
+  expect(capturedRequests).toHaveLength(4);
+  const identities = capturedRequests.map(getInputIdentity);
+  expect(new Set(identities.map(({ threadId }) => threadId)).size).toBe(1);
+  expect(new Set(identities.map(({ runId }) => runId)).size).toBe(4);
+  expect(capturedRequests.map(summarizeToolTranscript)).toEqual([
+    expectedToolTranscript([]),
+    expectedToolTranscript(expectedToolRounds.slice(0, 1)),
+    expectedToolTranscript(expectedToolRounds.slice(0, 2)),
+    expectedToolTranscript(expectedToolRounds),
+  ]);
+  expect(toolHandler).toHaveBeenCalledTimes(3);
+  expect(toolHandler.mock.calls.map(([input]) => input)).toEqual([
+    { value: 1 },
+    { value: 2 },
+    { value: 3 },
+  ]);
+  expect(send).toHaveBeenCalledTimes(4);
+
+  teardown();
+});
+
+test('resets retry attempts for each logical tool continuation run', async () => {
+  jest.clearAllMocks();
+  const requests: TransportRequest[] = [];
+  const terminalRequestStarted = createDeferred<void>();
+  const toolHandler = jest.fn(async ({ value }: { value: number }) => ({
+    recorded: value,
+  }));
+  let transportAttemptWithinRun = 0;
+  let successfulRuns = 0;
+  makeSelection(async (request) => {
+    requests.push(request);
+    transportAttemptWithinRun++;
+    if (transportAttemptWithinRun === 1) {
+      throw new Error(`Retry logical run ${successfulRuns + 1}`);
+    }
+
+    transportAttemptWithinRun = 0;
+    successfulRuns++;
+    if (successfulRuns === 1) {
+      return {
+        events: createToolRoundEvents(request, {
+          callId: 'call-retry-reset',
+          value: 7,
+        }),
+      };
+    }
+
+    terminalRequestStarted.resolve();
+    return { events: successfulEvents(request) };
+  });
+  const runtime = createChatRuntime({
+    system: 'You are a test bot',
+    retries: 1,
+    transport: configuredTransport,
+    tools: [
+      {
+        name: 'recordValue',
+        description: 'Record a numeric value.',
+        schema: s.object('Value to record', {
+          value: s.number('Numeric value'),
+        }),
+        handler: toolHandler,
+      },
+    ],
+  });
+  const teardown = runtime.start();
+
+  runtime.sendMessage({ role: 'user', content: 'Record a value.' });
+  await terminalRequestStarted.promise;
+  await waitForRuntimeIdle(runtime);
+
+  expect(requests.map(({ attempt }) => attempt)).toEqual([1, 2, 1, 2]);
+  expect(requests.map(({ maxAttempts }) => maxAttempts)).toEqual([2, 2, 2, 2]);
+  expect(toolHandler).toHaveBeenCalledTimes(1);
+
+  teardown();
+});
+
+test('stopping during a later tool handler prevents another run', async () => {
+  jest.clearAllMocks();
+  const laterHandlerStarted = createDeferred<void>();
+  const releaseLaterHandler = createDeferred<void>();
+  const handlerFinished = createDeferred<void>();
+  const scriptedToolRounds: readonly ScriptedToolRound[] = [
+    { callId: 'call-before-stop', value: 1 },
+    { callId: 'call-at-stop', value: 2 },
+  ];
+  let laterHandlerSignal: AbortSignal | undefined;
+  const toolHandler = jest.fn(
+    async ({ value }: { value: number }, signal: AbortSignal) => {
+      if (value === 1) {
+        return { recorded: value };
+      }
+
+      laterHandlerSignal = signal;
+      laterHandlerStarted.resolve();
+      try {
+        await releaseLaterHandler.promise;
+        return { recorded: value };
+      } finally {
+        handlerFinished.resolve();
+      }
+    },
+  );
+  let requestCount = 0;
+  const { send } = makeSelection(async (request) => {
+    const toolRound = scriptedToolRounds[requestCount];
+    requestCount++;
+    if (toolRound) {
+      return { events: createToolRoundEvents(request, toolRound) };
+    }
+
+    return { events: successfulEvents(request) };
+  });
+  const runtime = createChatRuntime({
+    system: 'You are a test bot',
+    transport: configuredTransport,
+    tools: [
+      {
+        name: 'recordValue',
+        description: 'Record a numeric value.',
+        schema: s.object('Value to record', {
+          value: s.number('Numeric value'),
+        }),
+        handler: toolHandler,
+      },
+    ],
+  });
+  const teardown = runtime.start();
+
+  runtime.sendMessage({
+    role: 'user',
+    content: 'Record values until stopped.',
+  });
+  await laterHandlerStarted.promise;
+  runtime.stop(true);
+  const transportCountAtStop = send.mock.calls.length;
+
+  expect(laterHandlerSignal?.aborted).toBe(true);
+
+  releaseLaterHandler.resolve();
+  await handlerFinished.promise;
+  await waitForRuntimeIdle(runtime);
+
+  expect(toolHandler).toHaveBeenCalledTimes(2);
+  expect(transportCountAtStop).toBe(2);
+  expect(send).toHaveBeenCalledTimes(transportCountAtStop);
+
+  teardown();
+});
+
+test('handles 25 sequential tool rounds before a final response', async () => {
+  jest.clearAllMocks();
+  const scriptedToolRounds: readonly ScriptedToolRound[] = Array.from(
+    { length: 25 },
+    (_, index) => ({
+      callId: `call-sentinel-${index + 1}`,
+      value: index + 1,
+    }),
+  );
+  const terminalRequestStarted = createDeferred<void>();
+  const toolHandler = jest.fn(async ({ value }: { value: number }) => ({
+    recorded: value,
+  }));
+  let requestCount = 0;
+  const { send } = makeSelection(async (request) => {
+    const toolRound = scriptedToolRounds[requestCount];
+    requestCount++;
+    if (toolRound) {
+      return { events: createToolRoundEvents(request, toolRound) };
+    }
+
+    terminalRequestStarted.resolve();
+    return { events: successfulEvents(request) };
+  });
+  const runtime = createChatRuntime({
+    system: 'You are a test bot',
+    transport: configuredTransport,
+    tools: [
+      {
+        name: 'recordValue',
+        description: 'Record a numeric value.',
+        schema: s.object('Value to record', {
+          value: s.number('Numeric value'),
+        }),
+        handler: toolHandler,
+      },
+    ],
+  });
+  const teardown = runtime.start();
+
+  runtime.sendMessage({ role: 'user', content: 'Record the sentinel values.' });
+  await terminalRequestStarted.promise;
+  await waitForRuntimeIdle(runtime);
+
+  expect(send).toHaveBeenCalledTimes(26);
+  expect(toolHandler).toHaveBeenCalledTimes(25);
 
   teardown();
 });

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -205,6 +205,34 @@ async function waitForRuntimeIdle(runtime: { isLoading: () => boolean }) {
   throw new Error('Timed out waiting for the chat runtime to become idle');
 }
 
+function observeSkippedToolCalls() {
+  const waiters = new Map<number, ReturnType<typeof createDeferred<void>>>();
+  let invocationCount = 0;
+  const original = internalActions.skippedToolCalls;
+  const spy = jest
+    .spyOn(internalActions, 'skippedToolCalls')
+    .mockImplementation(() => {
+      invocationCount++;
+      waiters.get(invocationCount)?.resolve();
+
+      return original();
+    });
+
+  return {
+    count: () => invocationCount,
+    restore: () => spy.mockRestore(),
+    waitFor: (expectedInvocationCount: number) => {
+      if (invocationCount >= expectedInvocationCount) {
+        return Promise.resolve();
+      }
+
+      const waiter = createDeferred<void>();
+      waiters.set(expectedInvocationCount, waiter);
+      return waiter.promise;
+    },
+  };
+}
+
 type ScriptedToolRound = {
   readonly callId: string;
   readonly value: number;
@@ -1384,6 +1412,7 @@ test('continues client tools with isolated reasoning details in transcript order
 
 test('continues three sequential tool rounds before the terminal response', async () => {
   jest.clearAllMocks();
+  const skippedToolCalls = observeSkippedToolCalls();
   const scriptedToolRounds: readonly ScriptedToolRound[] = [
     { callId: 'call-round-1', value: 1 },
     { callId: 'call-round-2', value: 2 },
@@ -1442,33 +1471,39 @@ test('continues three sequential tool rounds before the terminal response', asyn
   });
   const teardown = runtime.start();
 
-  runtime.sendMessage({ role: 'user', content: 'Record three values.' });
-  await terminalRequestStarted.promise;
-  await waitForRuntimeIdle(runtime);
+  try {
+    runtime.sendMessage({ role: 'user', content: 'Record three values.' });
+    await terminalRequestStarted.promise;
+    await skippedToolCalls.waitFor(1);
+    await waitForRuntimeIdle(runtime);
 
-  expect(capturedRequests).toHaveLength(4);
-  const identities = capturedRequests.map(getInputIdentity);
-  expect(new Set(identities.map(({ threadId }) => threadId)).size).toBe(1);
-  expect(new Set(identities.map(({ runId }) => runId)).size).toBe(4);
-  expect(capturedRequests.map(summarizeToolTranscript)).toEqual([
-    expectedToolTranscript([]),
-    expectedToolTranscript(expectedToolRounds.slice(0, 1)),
-    expectedToolTranscript(expectedToolRounds.slice(0, 2)),
-    expectedToolTranscript(expectedToolRounds),
-  ]);
-  expect(toolHandler).toHaveBeenCalledTimes(3);
-  expect(toolHandler.mock.calls.map(([input]) => input)).toEqual([
-    { value: 1 },
-    { value: 2 },
-    { value: 3 },
-  ]);
-  expect(send).toHaveBeenCalledTimes(4);
-
-  teardown();
+    expect(skippedToolCalls.count()).toBe(1);
+    expect(capturedRequests).toHaveLength(4);
+    const identities = capturedRequests.map(getInputIdentity);
+    expect(new Set(identities.map(({ threadId }) => threadId)).size).toBe(1);
+    expect(new Set(identities.map(({ runId }) => runId)).size).toBe(4);
+    expect(capturedRequests.map(summarizeToolTranscript)).toEqual([
+      expectedToolTranscript([]),
+      expectedToolTranscript(expectedToolRounds.slice(0, 1)),
+      expectedToolTranscript(expectedToolRounds.slice(0, 2)),
+      expectedToolTranscript(expectedToolRounds),
+    ]);
+    expect(toolHandler).toHaveBeenCalledTimes(3);
+    expect(toolHandler.mock.calls.map(([input]) => input)).toEqual([
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+    ]);
+    expect(send).toHaveBeenCalledTimes(4);
+  } finally {
+    skippedToolCalls.restore();
+    teardown();
+  }
 });
 
 test('resets retry attempts for each logical tool continuation run', async () => {
   jest.clearAllMocks();
+  const skippedToolCalls = observeSkippedToolCalls();
   const requests: TransportRequest[] = [];
   const terminalRequestStarted = createDeferred<void>();
   const toolHandler = jest.fn(async ({ value }: { value: number }) => ({
@@ -1495,7 +1530,19 @@ test('resets retry attempts for each logical tool continuation run', async () =>
     }
 
     terminalRequestStarted.resolve();
-    return { events: successfulEvents(request) };
+    return {
+      events: successfulEvents(request, [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'assistant-retry-terminal',
+          role: 'assistant',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: 'assistant-retry-terminal',
+        },
+      ]),
+    };
   });
   const runtime = createChatRuntime({
     system: 'You are a test bot',
@@ -1514,26 +1561,37 @@ test('resets retry attempts for each logical tool continuation run', async () =>
   });
   const teardown = runtime.start();
 
-  runtime.sendMessage({ role: 'user', content: 'Record a value.' });
-  await terminalRequestStarted.promise;
-  await waitForRuntimeIdle(runtime);
+  try {
+    runtime.sendMessage({ role: 'user', content: 'Record a value.' });
+    await terminalRequestStarted.promise;
+    await skippedToolCalls.waitFor(1);
+    await waitForRuntimeIdle(runtime);
 
-  expect(requests.map(({ attempt }) => attempt)).toEqual([1, 2, 1, 2]);
-  expect(requests.map(({ maxAttempts }) => maxAttempts)).toEqual([2, 2, 2, 2]);
-  expect(toolHandler).toHaveBeenCalledTimes(1);
-
-  teardown();
+    expect(requests.map(({ attempt }) => attempt)).toEqual([1, 2, 1, 2]);
+    expect(requests.map(({ maxAttempts }) => maxAttempts)).toEqual([
+      2, 2, 2, 2,
+    ]);
+    expect(toolHandler).toHaveBeenCalledTimes(1);
+  } finally {
+    skippedToolCalls.restore();
+    teardown();
+  }
 });
 
 test('stopping during a later tool handler prevents another run', async () => {
   jest.clearAllMocks();
+  const skippedToolCalls = observeSkippedToolCalls();
   const laterHandlerStarted = createDeferred<void>();
   const releaseLaterHandler = createDeferred<void>();
   const handlerFinished = createDeferred<void>();
+  const probeRequestStarted = createDeferred<void>();
+  const probePrompt = 'Confirm cancellation completion.';
   const scriptedToolRounds: readonly ScriptedToolRound[] = [
     { callId: 'call-before-stop', value: 1 },
     { callId: 'call-at-stop', value: 2 },
   ];
+  const requests: TransportRequest[] = [];
+  let probeSkippedInvocation = 0;
   let laterHandlerSignal: AbortSignal | undefined;
   const toolHandler = jest.fn(
     async ({ value }: { value: number }, signal: AbortSignal) => {
@@ -1551,15 +1609,35 @@ test('stopping during a later tool handler prevents another run', async () => {
       }
     },
   );
-  let requestCount = 0;
   const { send } = makeSelection(async (request) => {
-    const toolRound = scriptedToolRounds[requestCount];
-    requestCount++;
+    requests.push(request);
+    const toolRound = scriptedToolRounds[requests.length - 1];
     if (toolRound) {
       return { events: createToolRoundEvents(request, toolRound) };
     }
 
-    return { events: successfulEvents(request) };
+    if (
+      request.input.messages.some(
+        (message) => message.role === 'user' && message.content === probePrompt,
+      )
+    ) {
+      probeSkippedInvocation = skippedToolCalls.count() + 1;
+      probeRequestStarted.resolve();
+    }
+
+    return {
+      events: successfulEvents(request, [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'assistant-cancellation-probe',
+          role: 'assistant',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: 'assistant-cancellation-probe',
+        },
+      ]),
+    };
   });
   const runtime = createChatRuntime({
     system: 'You are a test bot',
@@ -1577,29 +1655,48 @@ test('stopping during a later tool handler prevents another run', async () => {
   });
   const teardown = runtime.start();
 
-  runtime.sendMessage({
-    role: 'user',
-    content: 'Record values until stopped.',
-  });
-  await laterHandlerStarted.promise;
-  runtime.stop(true);
-  const transportCountAtStop = send.mock.calls.length;
+  try {
+    runtime.sendMessage({
+      role: 'user',
+      content: 'Record values until stopped.',
+    });
+    await laterHandlerStarted.promise;
+    const laterHandlerPromise = toolHandler.mock.results[1]?.value;
+    if (!laterHandlerPromise) {
+      throw new Error('Expected the later tool handler promise.');
+    }
+    runtime.stop(true);
+    const transportCountAtStop = send.mock.calls.length;
 
-  expect(laterHandlerSignal?.aborted).toBe(true);
+    expect(laterHandlerSignal?.aborted).toBe(true);
 
-  releaseLaterHandler.resolve();
-  await handlerFinished.promise;
-  await waitForRuntimeIdle(runtime);
+    releaseLaterHandler.resolve();
+    await handlerFinished.promise;
+    await laterHandlerPromise;
+    runtime.sendMessage({ role: 'user', content: probePrompt });
+    await probeRequestStarted.promise;
+    await skippedToolCalls.waitFor(probeSkippedInvocation);
+    await waitForRuntimeIdle(runtime);
 
-  expect(toolHandler).toHaveBeenCalledTimes(2);
-  expect(transportCountAtStop).toBe(2);
-  expect(send).toHaveBeenCalledTimes(transportCountAtStop);
-
-  teardown();
+    expect(toolHandler).toHaveBeenCalledTimes(2);
+    expect(transportCountAtStop).toBe(2);
+    expect(send).toHaveBeenCalledTimes(transportCountAtStop + 1);
+    expect(requests).toHaveLength(3);
+    expect(
+      requests[2]?.input.messages.some(
+        (message) => message.role === 'user' && message.content === probePrompt,
+      ),
+    ).toBe(true);
+  } finally {
+    releaseLaterHandler.resolve();
+    skippedToolCalls.restore();
+    teardown();
+  }
 });
 
 test('handles 25 sequential tool rounds before a final response', async () => {
   jest.clearAllMocks();
+  const skippedToolCalls = observeSkippedToolCalls();
   const scriptedToolRounds: readonly ScriptedToolRound[] = Array.from(
     { length: 25 },
     (_, index) => ({
@@ -1620,7 +1717,19 @@ test('handles 25 sequential tool rounds before a final response', async () => {
     }
 
     terminalRequestStarted.resolve();
-    return { events: successfulEvents(request) };
+    return {
+      events: successfulEvents(request, [
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'assistant-sentinel-terminal',
+          role: 'assistant',
+        },
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: 'assistant-sentinel-terminal',
+        },
+      ]),
+    };
   });
   const runtime = createChatRuntime({
     system: 'You are a test bot',
@@ -1638,14 +1747,22 @@ test('handles 25 sequential tool rounds before a final response', async () => {
   });
   const teardown = runtime.start();
 
-  runtime.sendMessage({ role: 'user', content: 'Record the sentinel values.' });
-  await terminalRequestStarted.promise;
-  await waitForRuntimeIdle(runtime);
+  try {
+    runtime.sendMessage({
+      role: 'user',
+      content: 'Record the sentinel values.',
+    });
+    await terminalRequestStarted.promise;
+    await skippedToolCalls.waitFor(1);
+    await waitForRuntimeIdle(runtime);
 
-  expect(send).toHaveBeenCalledTimes(26);
-  expect(toolHandler).toHaveBeenCalledTimes(25);
-
-  teardown();
+    expect(skippedToolCalls.count()).toBe(1);
+    expect(send).toHaveBeenCalledTimes(26);
+    expect(toolHandler).toHaveBeenCalledTimes(25);
+  } finally {
+    skippedToolCalls.restore();
+    teardown();
+  }
 });
 
 test('sends one RunAgentInput with tools, structured output, and UI metadata', async () => {

--- a/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
@@ -11,12 +11,33 @@ import { expect, test } from '../harness/test-fixture';
 
 test.use({ trace: 'off' });
 
-const weatherResult = {
-  city: 'Paris',
-  temperatureC: 21,
-  condition: 'sunny',
+type WeatherRound = {
+  readonly assistantOpaqueValue: string;
+  readonly callId: string;
+  readonly city: string;
+  readonly toolOpaqueValue: string;
 };
-const serializedWeatherResult = JSON.stringify(weatherResult);
+
+const weatherRounds: readonly WeatherRound[] = [
+  {
+    assistantOpaqueValue: 'fixture-assistant-opaque-paris',
+    callId: 'call-weather-paris',
+    city: 'Paris',
+    toolOpaqueValue: 'fixture-tool-opaque-paris',
+  },
+  {
+    assistantOpaqueValue: 'fixture-assistant-opaque-london',
+    callId: 'call-weather-london',
+    city: 'London',
+    toolOpaqueValue: 'fixture-tool-opaque-london',
+  },
+  {
+    assistantOpaqueValue: 'fixture-assistant-opaque-tokyo',
+    callId: 'call-weather-tokyo',
+    city: 'Tokyo',
+    toolOpaqueValue: 'fixture-tool-opaque-tokyo',
+  },
+];
 const expectedWeatherTool = {
   name: 'getWeather',
   description: 'Get the current weather for a city.',
@@ -47,60 +68,73 @@ function createInitialMessages(
     {
       id: `${threadId}:message:0`,
       role: 'user',
-      content: 'What is the weather in Paris?',
+      content: 'Get the weather for Paris, London, and Tokyo.',
     },
   ];
 }
 
 function createContinuationMessages(
   threadId: string,
+  completedRoundCount: number,
 ): HashbrownRunInput['messages'] {
+  const continuationMessages = weatherRounds
+    .slice(0, completedRoundCount)
+    .reduce<HashbrownRunInput['messages']>((messages, round, index) => {
+      const assistantStep = index * 2;
+
+      return [
+        ...messages,
+        {
+          id: `${threadId}:message:${index * 2 + 1}`,
+          role: 'assistant',
+          content: '',
+          encryptedValue: round.assistantOpaqueValue,
+          metadata: {
+            provider: { assistantSteps: [{ index: assistantStep }] },
+          },
+          toolCalls: [
+            {
+              id: round.callId,
+              type: 'function',
+              encryptedValue: round.toolOpaqueValue,
+              metadata: {
+                provider: { toolSteps: [{ index: assistantStep + 1 }] },
+              },
+              function: {
+                name: 'getWeather',
+                arguments: JSON.stringify({ city: round.city }),
+              },
+            },
+          ],
+        },
+        {
+          id: round.callId,
+          role: 'tool',
+          toolCallId: round.callId,
+          content: JSON.stringify({
+            city: round.city,
+            temperatureC: 21,
+            condition: 'sunny',
+          }),
+        },
+      ];
+    }, []);
+
   return [
     ...createInitialMessages(threadId),
-    {
-      id: 'reasoning-weather',
-      role: 'reasoning',
-      content: 'I need the weather tool.',
-      encryptedValue: 'fixture-opaque-value',
-      metadata: { provider: { trace: ['weather'] } },
-    },
-    {
-      id: `${threadId}:message:1`,
-      role: 'assistant',
-      content: '',
-      encryptedValue: 'fixture-assistant-opaque-value',
-      metadata: {
-        provider: { assistantSteps: [{ index: 0 }] },
-      },
-      toolCalls: [
-        {
-          id: 'call-weather',
-          type: 'function',
-          encryptedValue: 'fixture-tool-opaque-value',
-          metadata: {
-            provider: { toolSteps: [{ index: 1 }] },
+    ...(completedRoundCount > 0
+      ? [
+          {
+            id: 'reasoning-weather',
+            role: 'reasoning' as const,
+            content: 'I need the weather tools.',
+            encryptedValue: 'fixture-reasoning-opaque-value',
+            metadata: { provider: { trace: ['weather'] } },
           },
-          function: {
-            name: 'getWeather',
-            arguments: '{"city":"Paris"}',
-          },
-        },
-      ],
-    },
-    {
-      id: 'call-weather',
-      role: 'tool',
-      toolCallId: 'call-weather',
-      content: serializedWeatherResult,
-    },
+        ]
+      : []),
+    ...continuationMessages,
   ];
-}
-
-function hasExactWeatherContinuation(input: HashbrownRunInput): boolean {
-  return isDeepStrictEqual(
-    input.messages,
-    createContinuationMessages(input.threadId),
-  );
 }
 
 /** Returns transcript records with opaque values reduced to presence booleans. */
@@ -146,110 +180,120 @@ function createToolContinuationEvents(
   input: HashbrownRunInput,
   requestIndex: number,
 ): AGUIEvent[] {
-  if (requestIndex === 0) {
-    return [
-      {
-        type: EventType.RUN_STARTED,
-        threadId: input.threadId,
-        runId: input.runId,
-        timestamp: 1_700_000_002_000,
-      },
-      {
-        type: EventType.REASONING_MESSAGE_START,
-        messageId: 'reasoning-weather',
-        role: 'reasoning',
-        metadata: { provider: { trace: ['weather'] } },
-        timestamp: 1_700_000_002_001,
-      },
-      {
-        type: EventType.REASONING_MESSAGE_CONTENT,
-        messageId: 'reasoning-weather',
-        delta: 'I need the weather tool.',
-        timestamp: 1_700_000_002_002,
-      },
-      {
-        type: EventType.REASONING_ENCRYPTED_VALUE,
-        subtype: 'message',
-        entityId: 'reasoning-weather',
-        encryptedValue: 'fixture-opaque-value',
-        timestamp: 1_700_000_002_003,
-      },
-      {
-        type: EventType.REASONING_MESSAGE_END,
-        messageId: 'reasoning-weather',
-        timestamp: 1_700_000_002_004,
-      },
-      {
-        type: EventType.TEXT_MESSAGE_START,
-        messageId: `${input.threadId}:message:1`,
-        role: 'assistant',
-        timestamp: 1_700_000_002_005,
-      },
-      {
-        type: EventType.TEXT_MESSAGE_END,
-        messageId: `${input.threadId}:message:1`,
-        metadata: {
-          provider: { assistantSteps: [{ index: 0 }] },
-        },
-        timestamp: 1_700_000_002_006,
-      },
-      {
-        type: EventType.TOOL_CALL_START,
-        toolCallId: 'call-weather',
-        toolCallName: 'getWeather',
-        parentMessageId: `${input.threadId}:message:1`,
-        timestamp: 1_700_000_002_007,
-      },
-      {
-        type: EventType.REASONING_ENCRYPTED_VALUE,
-        subtype: 'message',
-        entityId: `${input.threadId}:message:1`,
-        encryptedValue: 'fixture-assistant-opaque-value',
-        timestamp: 1_700_000_002_008,
-      },
-      {
-        type: EventType.REASONING_ENCRYPTED_VALUE,
-        subtype: 'tool-call',
-        entityId: 'call-weather',
-        encryptedValue: 'fixture-tool-opaque-value',
-        timestamp: 1_700_000_002_009,
-      },
-      {
-        type: EventType.TOOL_CALL_ARGS,
-        toolCallId: 'call-weather',
-        delta: '{"city":"Paris"}',
-        timestamp: 1_700_000_002_010,
-      },
-      {
-        type: EventType.TOOL_CALL_END,
-        toolCallId: 'call-weather',
-        metadata: {
-          provider: { toolSteps: [{ index: 1 }] },
-        },
-        timestamp: 1_700_000_002_011,
-      },
-      {
-        type: EventType.RUN_FINISHED,
-        threadId: input.threadId,
-        runId: input.runId,
-        timestamp: 1_700_000_002_012,
-      },
-    ];
-  }
-
-  if (requestIndex === 1) {
+  if (requestIndex === weatherRounds.length) {
     return createTextRunEvents(
       input,
       'message-weather-final',
-      ['It is 21 C and sunny in Paris.'],
-      1_700_000_003_000,
+      ['All three cities are 21 C and sunny.'],
+      1_700_000_006_000,
     );
   }
 
-  throw new Error(`Unexpected matched request index: ${requestIndex}`);
+  const round = weatherRounds[requestIndex];
+  if (!round) {
+    throw new Error(`Unexpected matched request index: ${requestIndex}`);
+  }
+  const timestamp = 1_700_000_002_000 + requestIndex * 1_000;
+  const assistantMessageId = `${input.threadId}:message:${requestIndex * 2 + 1}`;
+  const assistantStep = requestIndex * 2;
+  const reasoningEvents: AGUIEvent[] =
+    requestIndex === 0
+      ? [
+          {
+            type: EventType.REASONING_MESSAGE_START,
+            messageId: 'reasoning-weather',
+            role: 'reasoning',
+            metadata: { provider: { trace: ['weather'] } },
+            timestamp: timestamp + 1,
+          },
+          {
+            type: EventType.REASONING_MESSAGE_CONTENT,
+            messageId: 'reasoning-weather',
+            delta: 'I need the weather tools.',
+            timestamp: timestamp + 2,
+          },
+          {
+            type: EventType.REASONING_ENCRYPTED_VALUE,
+            subtype: 'message',
+            entityId: 'reasoning-weather',
+            encryptedValue: 'fixture-reasoning-opaque-value',
+            timestamp: timestamp + 3,
+          },
+          {
+            type: EventType.REASONING_MESSAGE_END,
+            messageId: 'reasoning-weather',
+            timestamp: timestamp + 4,
+          },
+        ]
+      : [];
+
+  return [
+    {
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+      timestamp,
+    },
+    ...reasoningEvents,
+    {
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: assistantMessageId,
+      role: 'assistant',
+      timestamp: timestamp + 5,
+    },
+    {
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: assistantMessageId,
+      metadata: {
+        provider: { assistantSteps: [{ index: assistantStep }] },
+      },
+      timestamp: timestamp + 6,
+    },
+    {
+      type: EventType.TOOL_CALL_START,
+      toolCallId: round.callId,
+      toolCallName: 'getWeather',
+      parentMessageId: assistantMessageId,
+      timestamp: timestamp + 7,
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'message',
+      entityId: assistantMessageId,
+      encryptedValue: round.assistantOpaqueValue,
+      timestamp: timestamp + 8,
+    },
+    {
+      type: EventType.REASONING_ENCRYPTED_VALUE,
+      subtype: 'tool-call',
+      entityId: round.callId,
+      encryptedValue: round.toolOpaqueValue,
+      timestamp: timestamp + 9,
+    },
+    {
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: round.callId,
+      delta: JSON.stringify({ city: round.city }),
+      timestamp: timestamp + 10,
+    },
+    {
+      type: EventType.TOOL_CALL_END,
+      toolCallId: round.callId,
+      metadata: {
+        provider: { toolSteps: [{ index: assistantStep + 1 }] },
+      },
+      timestamp: timestamp + 11,
+    },
+    {
+      type: EventType.RUN_FINISHED,
+      threadId: input.threadId,
+      runId: input.runId,
+      timestamp: timestamp + 12,
+    },
+  ];
 }
 
-test('executes a tool once and automatically continues the run', async ({
+test('executes three sequential tools once each before the terminal response', async ({
   page,
   aimock,
 }) => {
@@ -261,11 +305,20 @@ test('executes a tool once and automatically continues the run', async ({
       registerRunFixture(
         aimock.aguiMock,
         captured,
-        (input, requestIndex) =>
-          requestIndex === 0 ||
-          (requestIndex === 1 &&
-            input.threadId === captured[0]?.threadId &&
-            hasExactWeatherContinuation(input)),
+        (input, requestIndex) => {
+          const firstThreadId = captured[0]?.threadId;
+
+          return (
+            requestIndex <= weatherRounds.length &&
+            (requestIndex === 0 || input.threadId === firstThreadId) &&
+            isDeepStrictEqual(
+              input.messages,
+              requestIndex === 0
+                ? createInitialMessages(input.threadId)
+                : createContinuationMessages(input.threadId, requestIndex),
+            )
+          );
+        },
         createToolContinuationEvents,
         75,
         attempted,
@@ -273,85 +326,107 @@ test('executes a tool once and automatically continues the run', async ({
   });
   const driver = createAppDriver(page);
 
-  await driver.send('What is the weather in Paris?');
+  await driver.send('Get the weather for Paris, London, and Tokyo.');
 
   await expect(driver.userMessage()).toHaveText(
-    'What is the weather in Paris?',
+    'Get the weather for Paris, London, and Tokyo.',
   );
   await driver.expectLoading();
-  await expect(driver.reasoning()).toHaveText('I need the weather tool.');
+  await expect(driver.reasoning()).toHaveText('I need the weather tools.');
   await expect(driver.reasoningDetailCount()).toHaveText('1');
   await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
-  await expect(driver.toolCount()).toHaveText('1');
-  await expect.poll(() => attempted.length).toBe(2);
-  await expect.poll(() => captured.length).toBe(2);
+  await expect.poll(() => attempted.length).toBe(4);
+  await expect.poll(() => captured.length).toBe(4);
   await expect(driver.assistant()).toHaveJSProperty(
     'textContent',
-    'It is 21 C and sunny in Paris.',
+    'All three cities are 21 C and sunny.',
   );
   await driver.expectIdle();
-  await expect(driver.reasoning()).toHaveText('I need the weather tool.');
+  await expect(driver.reasoning()).toHaveText('I need the weather tools.');
   await expect(driver.reasoningDetailCount()).toHaveText('1');
   await expect(driver.reasoningHasOpaqueValue()).toHaveText('true');
-  await expect(driver.toolCount()).toHaveText('1');
+  await expect(driver.toolCount()).toHaveText('3');
   await expect(driver.error()).toHaveJSProperty('textContent', '');
   await expect(driver.sendingError()).toHaveJSProperty('textContent', '');
   await expect(driver.generatingError()).toHaveJSProperty('textContent', '');
-  expect(captured.length).toBe(2);
-  const [firstInput, secondInput] = captured;
-  if (!firstInput || !secondInput) {
-    throw new Error('Expected two captured tool continuation run inputs.');
+  expect(captured).toHaveLength(4);
+  const [firstInput, , , fourthInput] = captured;
+  if (!firstInput || !fourthInput) {
+    throw new Error('Expected four captured tool continuation run inputs.');
   }
-  expect(attempted.length).toBe(2);
-  expect(secondInput.threadId).toBe(firstInput.threadId);
-  expect(secondInput.runId).not.toBe(firstInput.runId);
-  expect(secondInput.messages.map(({ role }) => role)).toEqual([
+  expect(attempted).toHaveLength(4);
+  expect(new Set(captured.map(({ threadId }) => threadId)).size).toBe(1);
+  expect(new Set(captured.map(({ runId }) => runId)).size).toBe(4);
+  expect(fourthInput.messages.map(({ role }) => role)).toEqual([
     'system',
     'user',
     'reasoning',
     'assistant',
     'tool',
+    'assistant',
+    'tool',
+    'assistant',
+    'tool',
   ]);
-  const continuationAssistant = secondInput.messages.find(
+  const continuationAssistants = fourthInput.messages.filter(
     (message) => message.role === 'assistant',
   );
-  if (!continuationAssistant || continuationAssistant.role !== 'assistant') {
-    throw new Error('Expected an assistant in the continuation request.');
+  if (continuationAssistants.length !== weatherRounds.length) {
+    throw new Error('Expected every assistant tool call in the final request.');
   }
-  const continuationToolCall = continuationAssistant.toolCalls?.[0];
-  if (!continuationToolCall) {
-    throw new Error('Expected a tool call in the continuation request.');
-  }
-  expect(continuationAssistant.encryptedValue).toBe(
-    'fixture-assistant-opaque-value',
+  const opaqueContinuations = continuationAssistants.map((assistant, index) => {
+    const toolCall = assistant.toolCalls?.[0];
+    if (!toolCall) {
+      throw new Error(`Expected a tool call for assistant ${index + 1}.`);
+    }
+
+    return {
+      assistantOpaqueValue: assistant.encryptedValue,
+      assistantMetadata: assistant.metadata,
+      toolOpaqueValue: toolCall.encryptedValue,
+      toolMetadata: toolCall.metadata,
+    };
+  });
+  expect(opaqueContinuations).toEqual(
+    weatherRounds.map((round, index) => ({
+      assistantOpaqueValue: round.assistantOpaqueValue,
+      assistantMetadata: {
+        provider: { assistantSteps: [{ index: index * 2 }] },
+      },
+      toolOpaqueValue: round.toolOpaqueValue,
+      toolMetadata: {
+        provider: { toolSteps: [{ index: index * 2 + 1 }] },
+      },
+    })),
   );
-  expect(continuationToolCall.encryptedValue).toBe('fixture-tool-opaque-value');
-  expect(continuationAssistant.metadata).toEqual({
-    provider: { assistantSteps: [{ index: 0 }] },
+  const continuationReasoning = fourthInput.messages.find(
+    (message) => message.role === 'reasoning',
+  );
+  if (!continuationReasoning || continuationReasoning.role !== 'reasoning') {
+    throw new Error('Expected preserved reasoning in the final request.');
+  }
+  expect(continuationReasoning.encryptedValue).toBe(
+    'fixture-reasoning-opaque-value',
+  );
+  expect(continuationReasoning.metadata).toEqual({
+    provider: { trace: ['weather'] },
   });
-  expect(continuationToolCall.metadata).toEqual({
-    provider: { toolSteps: [{ index: 1 }] },
-  });
-  expect(firstInput).toEqual({
-    threadId: firstInput.threadId,
-    runId: firstInput.runId,
-    messages: createInitialMessages(firstInput.threadId),
-    tools: [expectedWeatherTool],
-    context: [],
-    state: {},
-    forwardedProps: {},
-  });
-  expect({
-    ...secondInput,
-    messages: safeTranscript(secondInput.messages),
-  }).toEqual({
-    threadId: firstInput.threadId,
-    runId: secondInput.runId,
-    messages: safeTranscript(createContinuationMessages(firstInput.threadId)),
-    tools: [expectedWeatherTool],
-    context: [],
-    state: {},
-    forwardedProps: {},
-  });
+  for (const [requestIndex, input] of captured.entries()) {
+    expect({ ...input, messages: safeTranscript(input.messages) }).toEqual({
+      threadId: firstInput.threadId,
+      runId: input.runId,
+      messages: safeTranscript(
+        requestIndex === 0
+          ? createInitialMessages(firstInput.threadId)
+          : createContinuationMessages(firstInput.threadId, requestIndex),
+      ),
+      tools: [expectedWeatherTool],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    });
+  }
+
   await hygiene.assertClean();
+  expect(attempted).toHaveLength(4);
 });

--- a/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/tool-continuation.spec.ts
@@ -38,6 +38,10 @@ const weatherRounds: readonly WeatherRound[] = [
     toolOpaqueValue: 'fixture-tool-opaque-tokyo',
   },
 ];
+const initialPrompt = 'Get the weather for Paris, London, and Tokyo.';
+const terminalResponse = 'All three cities are 21 C and sunny.';
+const probePrompt = 'Confirm the completed run.';
+const probeResponse = 'Completion confirmed.';
 const expectedWeatherTool = {
   name: 'getWeather',
   description: 'Get the current weather for a city.',
@@ -68,7 +72,24 @@ function createInitialMessages(
     {
       id: `${threadId}:message:0`,
       role: 'user',
-      content: 'Get the weather for Paris, London, and Tokyo.',
+      content: initialPrompt,
+    },
+  ];
+}
+
+function createProbeMessages(threadId: string): HashbrownRunInput['messages'] {
+  return [
+    ...createContinuationMessages(threadId, weatherRounds.length),
+    {
+      id: `${threadId}:message:7`,
+      role: 'assistant',
+      content: terminalResponse,
+      toolCalls: [],
+    },
+    {
+      id: `${threadId}:message:8`,
+      role: 'user',
+      content: probePrompt,
     },
   ];
 }
@@ -184,8 +205,17 @@ function createToolContinuationEvents(
     return createTextRunEvents(
       input,
       'message-weather-final',
-      ['All three cities are 21 C and sunny.'],
+      [terminalResponse],
       1_700_000_006_000,
+    );
+  }
+
+  if (requestIndex === weatherRounds.length + 1) {
+    return createTextRunEvents(
+      input,
+      'message-probe-final',
+      [probeResponse],
+      1_700_000_007_000,
     );
   }
 
@@ -309,13 +339,15 @@ test('executes three sequential tools once each before the terminal response', a
           const firstThreadId = captured[0]?.threadId;
 
           return (
-            requestIndex <= weatherRounds.length &&
+            requestIndex <= weatherRounds.length + 1 &&
             (requestIndex === 0 || input.threadId === firstThreadId) &&
             isDeepStrictEqual(
               input.messages,
               requestIndex === 0
                 ? createInitialMessages(input.threadId)
-                : createContinuationMessages(input.threadId, requestIndex),
+                : requestIndex <= weatherRounds.length
+                  ? createContinuationMessages(input.threadId, requestIndex)
+                  : createProbeMessages(input.threadId),
             )
           );
         },
@@ -326,11 +358,9 @@ test('executes three sequential tools once each before the terminal response', a
   });
   const driver = createAppDriver(page);
 
-  await driver.send('Get the weather for Paris, London, and Tokyo.');
+  await driver.send(initialPrompt);
 
-  await expect(driver.userMessage()).toHaveText(
-    'Get the weather for Paris, London, and Tokyo.',
-  );
+  await expect(driver.userMessage()).toHaveText(initialPrompt);
   await driver.expectLoading();
   await expect(driver.reasoning()).toHaveText('I need the weather tools.');
   await expect(driver.reasoningDetailCount()).toHaveText('1');
@@ -339,7 +369,7 @@ test('executes three sequential tools once each before the terminal response', a
   await expect.poll(() => captured.length).toBe(4);
   await expect(driver.assistant()).toHaveJSProperty(
     'textContent',
-    'All three cities are 21 C and sunny.',
+    terminalResponse,
   );
   await driver.expectIdle();
   await expect(driver.reasoning()).toHaveText('I need the weather tools.');
@@ -349,12 +379,12 @@ test('executes three sequential tools once each before the terminal response', a
   await expect(driver.error()).toHaveJSProperty('textContent', '');
   await expect(driver.sendingError()).toHaveJSProperty('textContent', '');
   await expect(driver.generatingError()).toHaveJSProperty('textContent', '');
+  expect(attempted).toHaveLength(4);
   expect(captured).toHaveLength(4);
   const [firstInput, , , fourthInput] = captured;
   if (!firstInput || !fourthInput) {
     throw new Error('Expected four captured tool continuation run inputs.');
   }
-  expect(attempted).toHaveLength(4);
   expect(new Set(captured.map(({ threadId }) => threadId)).size).toBe(1);
   expect(new Set(captured.map(({ runId }) => runId)).size).toBe(4);
   expect(fourthInput.messages.map(({ role }) => role)).toEqual([
@@ -427,6 +457,39 @@ test('executes three sequential tools once each before the terminal response', a
     });
   }
 
+  await driver.send(probePrompt);
+
+  await expect.poll(() => attempted.length).toBe(5);
+  await expect.poll(() => captured.length).toBe(5);
+  await expect(driver.userMessage()).toHaveText(probePrompt);
+  await expect(driver.assistant()).toHaveJSProperty(
+    'textContent',
+    probeResponse,
+  );
+  await driver.expectIdle();
+  await expect(driver.toolCount()).toHaveText('3');
+  expect(attempted).toHaveLength(5);
+  expect(captured).toHaveLength(5);
+  const fifthInput = captured[4];
+  if (!fifthInput) {
+    throw new Error('Expected a captured post-completion probe run input.');
+  }
+  expect(new Set(captured.map(({ threadId }) => threadId)).size).toBe(1);
+  expect(new Set(captured.map(({ runId }) => runId)).size).toBe(5);
+  expect({
+    ...fifthInput,
+    messages: safeTranscript(fifthInput.messages),
+  }).toEqual({
+    threadId: firstInput.threadId,
+    runId: fifthInput.runId,
+    messages: safeTranscript(createProbeMessages(firstInput.threadId)),
+    tools: [expectedWeatherTool],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  });
+
   await hygiene.assertClean();
-  expect(attempted).toHaveLength(4);
+  expect(attempted).toHaveLength(5);
+  expect(captured).toHaveLength(5);
 });


### PR DESCRIPTION
## Summary

- cover three sequential client-tool continuations followed by a terminal response
- verify retry accounting resets for each logical AG-UI run
- harden later-round cancellation assertions using explicit lifecycle markers
- add a bounded 25-round continuation regression sentinel
- expand the shared Angular and React Aimock scenario with deterministic post-terminal continuation detection

## Testing

- `npx nx test core --parallel=1`
- `npx nx build core --parallel=1`
- `npx nx lint core --parallel=1`
- `npx nx build-api-report core --parallel=1`
- `npx nx test runtime-smoke --parallel=1`
- `npx nx typecheck runtime-smoke --parallel=1`
- `npx nx lint runtime-smoke --parallel=1`
- `npx nx e2e runtime-smoke --parallel=1`

## Notes

- test-only change
- no runtime, public API, dependency, package-version, or release changes
- Angular and React runtime smoke suites pass 24/24