### PR TITLE
refactor(core): extract logical-run retry policy

### DIFF
--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -2004,6 +2004,38 @@ test('exhausted generic send retries dispatches the exhausted action', async () 
   teardown?.();
 });
 
+test('non-retryable transport error stops without exhausting retries', async () => {
+  jest.clearAllMocks();
+  const error = new TransportError('invalid request', { retryable: false });
+  const { send } = makeSelection(async () => {
+    throw error;
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, 2]]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    getActionsOfType(store.actions, apiActions.generateMessageError.type),
+  ).toEqual([apiActions.generateMessageError(error)]);
+  expect(
+    getActionsOfType(
+      store.actions,
+      apiActions.generateMessageExhaustedRetries.type,
+    ),
+  ).toHaveLength(0);
+  expect(
+    getActionsOfType(store.actions, apiActions.assistantTurnFinalized.type),
+  ).toHaveLength(1);
+
+  teardown?.();
+});
+
 test.each([
   {
     label: 'RUN_ERROR',

--- a/packages/core/src/effects/generate-message.effects.spec.ts
+++ b/packages/core/src/effects/generate-message.effects.spec.ts
@@ -2036,6 +2036,43 @@ test('non-retryable transport error stops without exhausting retries', async () 
   teardown?.();
 });
 
+test('positive infinity retries normalize to one attempt without exhaustion', async () => {
+  jest.clearAllMocks();
+  const error = new Error('still broken');
+  const requests: TransportRequest[] = [];
+  const { send } = makeSelection(async (request) => {
+    requests.push(request);
+    throw error;
+  });
+  const store = createTestStore(
+    new Map<SelectorKey, unknown>([[selectRetries, Number.POSITIVE_INFINITY]]),
+  );
+  const teardown = generateMessage(store);
+
+  await store.trigger(
+    devActions.sendMessage({ message: { role: 'user', content: 'Hi' } }),
+  );
+
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(
+    requests.map(({ attempt, maxAttempts }) => ({ attempt, maxAttempts })),
+  ).toEqual([{ attempt: 1, maxAttempts: 1 }]);
+  expect(
+    getActionsOfType(store.actions, apiActions.generateMessageError.type),
+  ).toEqual([apiActions.generateMessageError(error)]);
+  expect(
+    getActionsOfType(
+      store.actions,
+      apiActions.generateMessageExhaustedRetries.type,
+    ),
+  ).toHaveLength(0);
+  expect(
+    getActionsOfType(store.actions, apiActions.assistantTurnFinalized.type),
+  ).toHaveLength(1);
+
+  teardown?.();
+});
+
 test.each([
   {
     label: 'RUN_ERROR',

--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -28,6 +28,11 @@ import { createHashbrownRunAgentInput } from '../transport/hashbrown-run-agent-i
 import { sleep, switchAsync } from '../utils/async';
 import { updateAssistantMessage } from '../utils/assistant-message';
 import { createEffect } from '../utils/micro-ngrx';
+import {
+  createLogicalRunRetryState,
+  decideLogicalRunFailure,
+  startLogicalRunAttempt,
+} from './logical-run-retry-policy';
 
 type ActiveGeneration = {
   threadId: string | undefined;
@@ -162,7 +167,7 @@ export const generateMessage = createEffect((store) => {
         );
       };
 
-      let attempt = 0;
+      let retryState = createLogicalRunRetryState(retries);
       let exhaustedRetries = false;
 
       try {
@@ -171,7 +176,9 @@ export const generateMessage = createEffect((store) => {
             return;
           }
 
-          attempt++;
+          const startedAttempt = startLogicalRunAttempt(retryState);
+          retryState = startedAttempt.state;
+          const { attempt, maxAttempts } = startedAttempt.context;
 
           const requestId = _createRequestId();
           const eventRequest = {
@@ -186,7 +193,7 @@ export const generateMessage = createEffect((store) => {
             }),
             signal: AbortSignal.any([retiredSignal, runCancelSignal]),
             attempt,
-            maxAttempts: retries + 1,
+            maxAttempts,
             requestId,
           };
           let runStarted = false;
@@ -280,11 +287,12 @@ export const generateMessage = createEffect((store) => {
           synthesizeRunError(primaryError.message);
           store.dispatch(apiActions.generateMessageError(primaryError));
 
-          const retryable =
-            !(primaryError instanceof TransportError) ||
-            primaryError.retryable !== false;
-          if (!retryable || attempt >= retries + 1) {
-            exhaustedRetries = retryable && retries > 0;
+          const failureDecision = decideLogicalRunFailure(
+            retryState,
+            primaryError,
+          );
+          if (failureDecision.kind === 'stop') {
+            exhaustedRetries = failureDecision.exhaustedRetries;
             break;
           }
         }

--- a/packages/core/src/effects/logical-run-retry-policy.spec.ts
+++ b/packages/core/src/effects/logical-run-retry-policy.spec.ts
@@ -1,0 +1,183 @@
+import { TransportError } from '../transport';
+import {
+  createLogicalRunRetryState,
+  decideLogicalRunFailure,
+  startLogicalRunAttempt,
+} from './logical-run-retry-policy';
+
+test('creates the initial retry state without changing the retries value', () => {
+  const retries = 3;
+
+  const state = createLogicalRunRetryState(retries);
+
+  expect(state).toEqual({ retries, attempt: 0 });
+});
+
+test('starts the first attempt with the exact attempt context', () => {
+  const state = createLogicalRunRetryState(2);
+
+  const started = startLogicalRunAttempt(state);
+
+  expect(started).toEqual({
+    state: { retries: 2, attempt: 1 },
+    context: { attempt: 1, maxAttempts: 3 },
+  });
+});
+
+test('does not mutate the input state when starting an attempt', () => {
+  const state = Object.freeze({ retries: 2, attempt: 0 });
+
+  const started = startLogicalRunAttempt(state);
+
+  expect(state).toEqual({ retries: 2, attempt: 0 });
+  expect(started.state).not.toBe(state);
+});
+
+test('returns sequential retry states for sequential attempts', () => {
+  const initialState = createLogicalRunRetryState(2);
+
+  const first = startLogicalRunAttempt(initialState);
+  const second = startLogicalRunAttempt(first.state);
+  const third = startLogicalRunAttempt(second.state);
+
+  expect(first.state).toEqual({ retries: 2, attempt: 1 });
+  expect(second.state).toEqual({ retries: 2, attempt: 2 });
+  expect(third.state).toEqual({ retries: 2, attempt: 3 });
+  expect(first.context).toEqual({ attempt: 1, maxAttempts: 3 });
+  expect(second.context).toEqual({ attempt: 2, maxAttempts: 3 });
+  expect(third.context).toEqual({ attempt: 3, maxAttempts: 3 });
+});
+
+test('retries an ordinary error before stopping after the final attempt', () => {
+  const error = new Error('send failed');
+  const initialState = createLogicalRunRetryState(1);
+  const first = startLogicalRunAttempt(initialState);
+  const second = startLogicalRunAttempt(first.state);
+
+  const retryDecision = decideLogicalRunFailure(first.state, error);
+  const stopDecision = decideLogicalRunFailure(second.state, error);
+
+  expect(retryDecision).toEqual({ kind: 'retry' });
+  expect(stopDecision).toEqual({
+    kind: 'stop',
+    exhaustedRetries: true,
+  });
+});
+
+test('stops immediately for a non-retryable transport error', () => {
+  const error = new TransportError('invalid request', { retryable: false });
+  const state = startLogicalRunAttempt(createLogicalRunRetryState(3)).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({
+    kind: 'stop',
+    exhaustedRetries: false,
+  });
+});
+
+test('retries a retryable transport error before the final attempt', () => {
+  const error = new TransportError('temporarily unavailable', {
+    retryable: true,
+  });
+  const state = startLogicalRunAttempt(createLogicalRunRetryState(2)).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({ kind: 'retry' });
+});
+
+test('stops with zero retries without reporting exhaustion', () => {
+  const error = new Error('send failed');
+  const state = startLogicalRunAttempt(createLogicalRunRetryState(0)).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({
+    kind: 'stop',
+    exhaustedRetries: false,
+  });
+});
+
+test('preserves a negative retries value in the attempt context', () => {
+  const state = createLogicalRunRetryState(-1);
+
+  const started = startLogicalRunAttempt(state);
+
+  expect(started).toEqual({
+    state: { retries: -1, attempt: 1 },
+    context: { attempt: 1, maxAttempts: 0 },
+  });
+});
+
+test('uses the raw fractional retries value for retry decisions', () => {
+  const error = new Error('send failed');
+  const initialState = createLogicalRunRetryState(0.5);
+  const first = startLogicalRunAttempt(initialState);
+  const second = startLogicalRunAttempt(first.state);
+
+  const retryDecision = decideLogicalRunFailure(first.state, error);
+  const stopDecision = decideLogicalRunFailure(second.state, error);
+
+  expect(retryDecision).toEqual({ kind: 'retry' });
+  expect(stopDecision).toEqual({
+    kind: 'stop',
+    exhaustedRetries: true,
+  });
+});
+
+test('retries when retries is NaN', () => {
+  const error = new Error('send failed');
+  const state = startLogicalRunAttempt(
+    createLogicalRunRetryState(Number.NaN),
+  ).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({ kind: 'retry' });
+});
+
+test('retries when retries is positive infinity', () => {
+  const error = new Error('send failed');
+  const state = startLogicalRunAttempt(
+    createLogicalRunRetryState(Number.POSITIVE_INFINITY),
+  ).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({ kind: 'retry' });
+});
+
+test('stops when retries is negative infinity without reporting exhaustion', () => {
+  const error = new Error('send failed');
+  const state = startLogicalRunAttempt(
+    createLogicalRunRetryState(Number.NEGATIVE_INFINITY),
+  ).state;
+
+  const decision = decideLogicalRunFailure(state, error);
+
+  expect(decision).toEqual({
+    kind: 'stop',
+    exhaustedRetries: false,
+  });
+});
+
+test('does not mutate the error when deciding a failure', () => {
+  const error = Object.freeze(
+    new TransportError('invalid request', {
+      retryable: false,
+      status: 400,
+      code: 'INVALID_REQUEST',
+    }),
+  );
+  const state = startLogicalRunAttempt(createLogicalRunRetryState(2)).state;
+
+  decideLogicalRunFailure(state, error);
+
+  expect(error).toMatchObject({
+    message: 'invalid request',
+    retryable: false,
+    status: 400,
+    code: 'INVALID_REQUEST',
+  });
+});

--- a/packages/core/src/effects/logical-run-retry-policy.spec.ts
+++ b/packages/core/src/effects/logical-run-retry-policy.spec.ts
@@ -99,63 +99,25 @@ test('stops with zero retries without reporting exhaustion', () => {
   });
 });
 
-test('preserves a negative retries value in the attempt context', () => {
-  const state = createLogicalRunRetryState(-1);
+test.each([
+  { label: 'negative', retries: -1 },
+  { label: 'fractional', retries: 0.5 },
+  { label: 'NaN', retries: Number.NaN },
+  { label: 'positive infinity', retries: Number.POSITIVE_INFINITY },
+  { label: 'negative infinity', retries: Number.NEGATIVE_INFINITY },
+  { label: 'unsafe integer', retries: Number.MAX_SAFE_INTEGER + 1 },
+])('normalizes $label retries to zero', ({ retries }) => {
+  const error = new Error('send failed');
 
+  const state = createLogicalRunRetryState(retries);
   const started = startLogicalRunAttempt(state);
+  const decision = decideLogicalRunFailure(started.state, error);
 
+  expect(state).toEqual({ retries: 0, attempt: 0 });
   expect(started).toEqual({
-    state: { retries: -1, attempt: 1 },
-    context: { attempt: 1, maxAttempts: 0 },
+    state: { retries: 0, attempt: 1 },
+    context: { attempt: 1, maxAttempts: 1 },
   });
-});
-
-test('uses the raw fractional retries value for retry decisions', () => {
-  const error = new Error('send failed');
-  const initialState = createLogicalRunRetryState(0.5);
-  const first = startLogicalRunAttempt(initialState);
-  const second = startLogicalRunAttempt(first.state);
-
-  const retryDecision = decideLogicalRunFailure(first.state, error);
-  const stopDecision = decideLogicalRunFailure(second.state, error);
-
-  expect(retryDecision).toEqual({ kind: 'retry' });
-  expect(stopDecision).toEqual({
-    kind: 'stop',
-    exhaustedRetries: true,
-  });
-});
-
-test('retries when retries is NaN', () => {
-  const error = new Error('send failed');
-  const state = startLogicalRunAttempt(
-    createLogicalRunRetryState(Number.NaN),
-  ).state;
-
-  const decision = decideLogicalRunFailure(state, error);
-
-  expect(decision).toEqual({ kind: 'retry' });
-});
-
-test('retries when retries is positive infinity', () => {
-  const error = new Error('send failed');
-  const state = startLogicalRunAttempt(
-    createLogicalRunRetryState(Number.POSITIVE_INFINITY),
-  ).state;
-
-  const decision = decideLogicalRunFailure(state, error);
-
-  expect(decision).toEqual({ kind: 'retry' });
-});
-
-test('stops when retries is negative infinity without reporting exhaustion', () => {
-  const error = new Error('send failed');
-  const state = startLogicalRunAttempt(
-    createLogicalRunRetryState(Number.NEGATIVE_INFINITY),
-  ).state;
-
-  const decision = decideLogicalRunFailure(state, error);
-
   expect(decision).toEqual({
     kind: 'stop',
     exhaustedRetries: false,

--- a/packages/core/src/effects/logical-run-retry-policy.ts
+++ b/packages/core/src/effects/logical-run-retry-policy.ts
@@ -40,14 +40,18 @@ export type LogicalRunFailureDecision =
   | { readonly kind: 'stop'; readonly exhaustedRetries: boolean };
 
 /**
- * Creates retry state before the first attempt of a logical run.
+ * Creates retry state before the first attempt of a logical run. Invalid retry
+ * counts are normalized to zero.
  *
  * @internal
  */
 export function createLogicalRunRetryState(
   retries: number,
 ): LogicalRunRetryState {
-  return { retries, attempt: 0 };
+  const normalizedRetries =
+    Number.isSafeInteger(retries) && retries >= 0 ? retries : 0;
+
+  return { retries: normalizedRetries, attempt: 0 };
 }
 
 /**

--- a/packages/core/src/effects/logical-run-retry-policy.ts
+++ b/packages/core/src/effects/logical-run-retry-policy.ts
@@ -1,0 +1,89 @@
+import { TransportError } from '../transport';
+
+/**
+ * Synchronous retry state for one logical run.
+ *
+ * @internal
+ */
+export interface LogicalRunRetryState {
+  readonly retries: number;
+  readonly attempt: number;
+}
+
+/**
+ * Attempt metadata supplied to one transport request.
+ *
+ * @internal
+ */
+export interface LogicalRunAttemptContext {
+  readonly attempt: number;
+  readonly maxAttempts: number;
+}
+
+/**
+ * The next immutable retry state and its transport attempt metadata.
+ *
+ * @internal
+ */
+export interface StartedLogicalRunAttempt {
+  readonly state: LogicalRunRetryState;
+  readonly context: LogicalRunAttemptContext;
+}
+
+/**
+ * The synchronous policy decision after a logical-run attempt fails.
+ *
+ * @internal
+ */
+export type LogicalRunFailureDecision =
+  | { readonly kind: 'retry' }
+  | { readonly kind: 'stop'; readonly exhaustedRetries: boolean };
+
+/**
+ * Creates retry state before the first attempt of a logical run.
+ *
+ * @internal
+ */
+export function createLogicalRunRetryState(
+  retries: number,
+): LogicalRunRetryState {
+  return { retries, attempt: 0 };
+}
+
+/**
+ * Advances retry state and returns metadata for the started attempt.
+ *
+ * @internal
+ */
+export function startLogicalRunAttempt(
+  state: LogicalRunRetryState,
+): StartedLogicalRunAttempt {
+  const attempt = state.attempt + 1;
+
+  return {
+    state: { retries: state.retries, attempt },
+    context: { attempt, maxAttempts: state.retries + 1 },
+  };
+}
+
+/**
+ * Decides whether a failed attempt should retry or stop.
+ *
+ * @internal
+ */
+export function decideLogicalRunFailure(
+  state: LogicalRunRetryState,
+  error: Error,
+): LogicalRunFailureDecision {
+  const retryable =
+    !(error instanceof TransportError) || error.retryable !== false;
+
+  if (!retryable || state.attempt >= state.retries + 1) {
+    return {
+      kind: 'stop',
+      exhaustedRetries: retryable && state.retries > 0,
+    };
+  }
+
+  return { kind: 'retry' };
+}


### PR DESCRIPTION
## Summary
- extract logical-run retry state and failure classification into synchronous pure functions
- preserve retry, cancellation, retirement, and finalization timing for valid configurations
- add direct coverage for retry progression and non-retryable transport failures
- normalize invalid retry counts to zero to prevent unbounded attempts and malformed request metadata

## Testing
- `npx nx test core --parallel=1`
- `npx nx build core --parallel=1`
- `npx nx lint core --parallel=1`
- `npx nx build-api-report core --parallel=1`
- `npx nx test runtime-smoke --parallel=1`
- `npx nx typecheck runtime-smoke --parallel=1`
- `npx nx lint runtime-smoke --parallel=1`
- `npx nx e2e runtime-smoke --parallel=1`

## Results
- Core: 34 suites, 579 tests, 17 snapshots
- Runtime smoke: 24 unit tests
- Browser smoke: 24 Playwright tests
- Independent specification and code-quality reviews approved

## Notes
- negative, fractional, non-finite, and unsafe-integer retry counts now disable retries and execute one attempt
- no public API surface, dependency, package-version, or release changes
- no release included in this PR
