### PR TITLE
fix(markdown): adopt parser invariant hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@angular/router": "22.1.1",
         "@cacheplane/json-stream": "0.1.0",
         "@cacheplane/partial-json": "0.3.0",
-        "@cacheplane/partial-markdown": "0.5.10",
+        "@cacheplane/partial-markdown": "0.5.11",
         "@jitl/quickjs-singlefile-browser-debug-asyncify": "0.31.0",
         "@ngrx/effects": "22.0.0-rc.0",
         "@ngrx/entity": "22.0.0-rc.0",
@@ -8163,9 +8163,9 @@
       }
     },
     "node_modules/@cacheplane/partial-markdown": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.10.tgz",
-      "integrity": "sha512-G1o+I9Zfs9eLXLmm8zS7dp3JEBdqtL3BkpKxvNLtHAizE+D38IadISP8w6KSHBmI3qhMDe20wdja9nG+aaP0tw==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.11.tgz",
+      "integrity": "sha512-xvf3RT2d7Cyutds/7CjJ8lb6iKeycE+LWy2TARyiQfo2dR2G+HaKcPORSURJHedStJuM1xdNIg7rpqrnne/erQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@angular/router": "22.1.1",
     "@cacheplane/json-stream": "0.1.0",
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.10",
+    "@cacheplane/partial-markdown": "0.5.11",
     "@jitl/quickjs-singlefile-browser-debug-asyncify": "0.31.0",
     "@ngrx/effects": "22.0.0-rc.0",
     "@ngrx/entity": "22.0.0-rc.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.10"
+    "@cacheplane/partial-markdown": "0.5.11"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/angular/src/utils/inject-magic-text-parser.spec.ts
+++ b/packages/angular/src/utils/inject-magic-text-parser.spec.ts
@@ -41,7 +41,9 @@ test('injectMagicTextParser refreshes derived maps when prefix growth adds nodes
   expect(secondParagraph?.type).toBe('paragraph');
   expect(secondParagraph).toBeDefined();
   expect(nodeIdsBefore.has(secondParagraph?.id ?? -1)).toBe(false);
-  expect(parser.nodeById().get(secondParagraph?.id ?? -1)).toBe(secondParagraph);
+  expect(parser.nodeById().get(secondParagraph?.id ?? -1)).toBe(
+    secondParagraph,
+  );
   expect(parser.openNode()?.id).toBe(secondParagraph?.children[0]?.id);
 });
 
@@ -56,6 +58,18 @@ test('injectMagicTextParser preserves resolved node identity across prefix updat
 
   expect(firstParagraphBefore).toBeDefined();
   expect(firstParagraphAfter).toBe(firstParagraphBefore);
+});
+
+test('injectMagicTextParser preserves sibling citation numbers', () => {
+  const text = signal('alpha [^first] beta [^second]');
+  const parser = injectMagicTextParser(text);
+
+  const citations = findByType(
+    parser.nodeById().values(),
+    'citation-reference',
+  ) as Array<Extract<MarkdownNode, { type: 'citation-reference' }>>;
+
+  expect(citations.map((citation) => citation.index)).toEqual([1, 2]);
 });
 
 test('injectMagicTextParser resets when markdown updates are not prefix-compatible', () => {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.10"
+    "@cacheplane/partial-markdown": "0.5.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/hooks/use-magic-text-parser.spec.tsx
+++ b/packages/react/src/hooks/use-magic-text-parser.spec.tsx
@@ -61,6 +61,28 @@ test('useMagicTextParser preserves resolved node identity across prefix updates'
   expect(firstParagraphAfter).toBe(firstParagraphBefore);
 });
 
+test('useMagicTextParser recognizes autolinks across prefix updates', () => {
+  const { result, rerender } = renderHook(
+    ({ text }) => useMagicTextParser(text),
+    {
+      initialProps: {
+        text: 'https',
+      },
+    },
+  );
+
+  rerender({
+    text: 'https://example.com',
+  });
+
+  const autolink = findByType(result.current.rootNode, 'autolink')[0] as
+    | Extract<MarkdownNode, { type: 'autolink' }>
+    | undefined;
+
+  expect(autolink?.text).toBe('https://example.com');
+  expect(autolink?.url).toBe('https://example.com');
+});
+
 test('useMagicTextParser does not mutate committed nodes during a suspended render', () => {
   const pending = new Promise<never>(() => undefined);
   let committedRoot: MarkdownNode | null = null;


### PR DESCRIPTION
## Summary

- upgrade the streaming Markdown parser dependency to 0.5.11 for React and Angular
- verify chunk-boundary autolinks through the React parser adapter
- verify stable sibling citation numbering through the Angular parser adapter

## Verification

- `npx nx run-many -t test -p react angular --parallel=2`
- `npx nx run-many -t build -p react angular --parallel=2`
- `npx nx run-many -t build-api-report -p react angular --parallel=2`
- `npx nx run-many -t e2e -p react angular --parallel=2`
- `npx nx lint angular`
- changed-file ESLint for both new regression tests
- `npx nx build finance-angular`
- `npx nx build www`
- clean `npm ci` on Node 24.18.0

React package-wide lint retains two unrelated import-order errors already present on `main`; this branch introduces no changed-file lint failures.