### PR TITLE
chore(markdown): adopt partial-markdown 0.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@angular/router": "22.1.1",
         "@cacheplane/json-stream": "0.1.0",
         "@cacheplane/partial-json": "0.3.0",
-        "@cacheplane/partial-markdown": "0.5.11",
+        "@cacheplane/partial-markdown": "0.5.12",
         "@jitl/quickjs-singlefile-browser-debug-asyncify": "0.31.0",
         "@ngrx/effects": "22.0.0-rc.0",
         "@ngrx/entity": "22.0.0-rc.0",
@@ -8163,9 +8163,9 @@
       }
     },
     "node_modules/@cacheplane/partial-markdown": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.11.tgz",
-      "integrity": "sha512-xvf3RT2d7Cyutds/7CjJ8lb6iKeycE+LWy2TARyiQfo2dR2G+HaKcPORSURJHedStJuM1xdNIg7rpqrnne/erQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@cacheplane/partial-markdown/-/partial-markdown-0.5.12.tgz",
+      "integrity": "sha512-sme54U9XJO133T6gwhyCpc1i6tDM1E58GWas2NH2IVoEDpzekAxRuHeQNIc1hV+hPi2qkmV35OlEcjPglIBrHA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@angular/router": "22.1.1",
     "@cacheplane/json-stream": "0.1.0",
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.11",
+    "@cacheplane/partial-markdown": "0.5.12",
     "@jitl/quickjs-singlefile-browser-debug-asyncify": "0.31.0",
     "@ngrx/effects": "22.0.0-rc.0",
     "@ngrx/entity": "22.0.0-rc.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.11"
+    "@cacheplane/partial-markdown": "0.5.12"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@cacheplane/partial-json": "0.3.0",
-    "@cacheplane/partial-markdown": "0.5.11"
+    "@cacheplane/partial-markdown": "0.5.12"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- update the exact `@cacheplane/partial-markdown` dependency to `0.5.12`
- update React and Angular package manifests plus the root lockfile integrity
- retain the existing Hashbrown Markdown integration and regression coverage unchanged

## Verification

- clean Node 24.18.0 `npm ci` installs `@cacheplane/partial-markdown@0.5.12`
- `npx nx test react` (84 tests)
- `npx nx test angular` (154 tests)
- `npx nx build react`
- `npx nx build angular`
- `npx nx lint angular`
- `npx nx build-api-report react`
- `npx nx build-api-report angular`
- `npx nx e2e react`
- `npx nx e2e angular`
- `npx nx build finance-angular`
- `npx nx build www`
