### PR TITLE
refactor(core): extract AG-UI logical run coordinator

### DIFF
--- a/packages/core/src/effects/generate-message.effects.ts
+++ b/packages/core/src/effects/generate-message.effects.ts
@@ -1,4 +1,3 @@
-import { EventType } from '@ag-ui/core';
 import { apiActions, devActions, internalActions } from '../actions';
 import { Chat } from '../models';
 import {
@@ -20,19 +19,11 @@ import {
 } from '../reducers';
 import { s } from '../schema';
 import { resolveTransport, TransportError } from '../transport';
-import {
-  type AgUiRunAttemptOutcome,
-  runAgUiAttempt,
-} from '../transport/ag-ui-run-driver';
 import { createHashbrownRunAgentInput } from '../transport/hashbrown-run-agent-input';
 import { sleep, switchAsync } from '../utils/async';
 import { updateAssistantMessage } from '../utils/assistant-message';
 import { createEffect } from '../utils/micro-ngrx';
-import {
-  createLogicalRunRetryState,
-  decideLogicalRunFailure,
-  startLogicalRunAttempt,
-} from './logical-run-retry-policy';
+import { executeLogicalRun } from './logical-run-coordinator';
 
 type ActiveGeneration = {
   threadId: string | undefined;
@@ -167,134 +158,60 @@ export const generateMessage = createEffect((store) => {
         );
       };
 
-      let retryState = createLogicalRunRetryState(retries);
       let exhaustedRetries = false;
 
       try {
-        while (true) {
-          if (retiredSignal.aborted || runCancelSignal.aborted) {
-            return;
-          }
+        const outcome = await executeLogicalRun({
+          transport,
+          retries,
+          cancelSignal: runCancelSignal,
+          retiredSignal,
+          createRequest: ({ attempt, maxAttempts, signal }) => {
+            const requestId = _createRequestId();
 
-          const startedAttempt = startLogicalRunAttempt(retryState);
-          retryState = startedAttempt.state;
-          const { attempt, maxAttempts } = startedAttempt.context;
-
-          const requestId = _createRequestId();
-          const eventRequest = {
-            input: createHashbrownRunAgentInput({
-              threadId,
-              runId: requestId,
-              system,
-              messages,
-              tools,
-              responseSchema: responseJsonSchema,
-              ui: uiRequested,
-            }),
-            signal: AbortSignal.any([retiredSignal, runCancelSignal]),
-            attempt,
-            maxAttempts,
-            requestId,
-          };
-          let runStarted = false;
-          let runTerminal = false;
-
-          const synthesizeRunError = (
-            message: string,
-            allowCancelled = false,
-          ) => {
-            if (!runStarted || runTerminal || retiredSignal.aborted) {
-              return;
-            }
-            if (runCancelSignal.aborted && !allowCancelled) {
-              return;
-            }
-
-            runTerminal = true;
+            return {
+              input: createHashbrownRunAgentInput({
+                threadId,
+                runId: requestId,
+                system,
+                messages,
+                tools,
+                responseSchema: responseJsonSchema,
+                ui: uiRequested,
+              }),
+              signal,
+              attempt,
+              maxAttempts,
+              requestId,
+            };
+          },
+          onStarted: () => {
             store.dispatch(
-              apiActions.generateMessageEvent({
-                type: EventType.RUN_ERROR,
-                message,
+              apiActions.generateMessageStart({
+                responseSchema,
+                toolsByName,
               }),
             );
-          };
+          },
+          onEvent: (event) => {
+            store.dispatch(apiActions.generateMessageEvent(event));
+          },
+          onAttemptError: (error) => {
+            store.dispatch(apiActions.generateMessageError(error));
+          },
+        });
 
-          let outcome: AgUiRunAttemptOutcome | undefined;
-          let primaryError: Error | undefined;
-          try {
-            outcome = await runAgUiAttempt({
-              transport,
-              request: eventRequest,
-              cancelSignal: runCancelSignal,
-              retiredSignal,
-              onStarted: () => {
-                store.dispatch(
-                  apiActions.generateMessageStart({
-                    responseSchema,
-                    toolsByName,
-                  }),
-                );
-              },
-              onEvent: (event) => {
-                if (event.type === EventType.RUN_STARTED) {
-                  runStarted = true;
-                }
-                if (
-                  event.type === EventType.RUN_FINISHED ||
-                  event.type === EventType.RUN_ERROR
-                ) {
-                  runTerminal = true;
-                }
-
-                store.dispatch(apiActions.generateMessageEvent(event));
-              },
-            });
-          } catch (error) {
-            primaryError =
-              error instanceof Error
-                ? error
-                : new Error('Unknown transport error');
-          }
-
-          if (retiredSignal.aborted || outcome?.kind === 'retired') {
-            return;
-          }
-
-          if (outcome?.kind === 'finished') {
-            releaseGeneration();
-            finalizeGeneration();
-            break;
-          }
-
-          if (outcome?.kind === 'server-error') {
-            releaseGeneration();
-            store.dispatch(apiActions.generateMessageError(outcome.error));
-            break;
-          }
-
-          if (runCancelSignal.aborted || outcome?.kind === 'cancelled') {
-            synthesizeRunError('Generation cancelled', true);
-            return;
-          }
-
-          if (!primaryError) {
-            primaryError = new TransportError(
-              'Generation ended without a terminal outcome',
-              { retryable: true, code: 'PROTOCOL_ERROR' },
-            );
-          }
-
-          synthesizeRunError(primaryError.message);
-          store.dispatch(apiActions.generateMessageError(primaryError));
-
-          const failureDecision = decideLogicalRunFailure(
-            retryState,
-            primaryError,
-          );
-          if (failureDecision.kind === 'stop') {
-            exhaustedRetries = failureDecision.exhaustedRetries;
-            break;
-          }
+        if (outcome.kind === 'retired' || outcome.kind === 'cancelled') {
+          return;
+        }
+        if (outcome.kind === 'finished') {
+          releaseGeneration();
+          finalizeGeneration();
+        } else if (outcome.kind === 'server-error') {
+          releaseGeneration();
+          store.dispatch(apiActions.generateMessageError(outcome.error));
+        } else {
+          exhaustedRetries = outcome.exhaustedRetries;
         }
       } finally {
         releaseGeneration();

--- a/packages/core/src/effects/logical-run-coordinator.spec.ts
+++ b/packages/core/src/effects/logical-run-coordinator.spec.ts
@@ -1,0 +1,290 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type { Transport, TransportRequest } from '../transport';
+import { TransportError } from '../transport';
+import { createHashbrownRunAgentInput } from '../transport/hashbrown-run-agent-input';
+import {
+  executeLogicalRun,
+  type LogicalRunRequestContext,
+} from './logical-run-coordinator';
+
+function createEvents(events: AGUIEvent[]): AsyncIterable<AGUIEvent> {
+  return (async function* () {
+    yield* events;
+  })();
+}
+
+function createRequest({
+  attempt,
+  maxAttempts,
+  signal,
+}: LogicalRunRequestContext): TransportRequest {
+  const runId = `run-${attempt}`;
+
+  return {
+    input: createHashbrownRunAgentInput({
+      threadId: 'thread-id',
+      runId,
+      messages: [],
+      tools: [],
+    }),
+    signal,
+    attempt,
+    maxAttempts,
+    requestId: runId,
+  };
+}
+
+function createStarted(request: TransportRequest): AGUIEvent {
+  return {
+    type: EventType.RUN_STARTED,
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+}
+
+function createFinished(request: TransportRequest): AGUIEvent {
+  return {
+    type: EventType.RUN_FINISHED,
+    threadId: request.input.threadId,
+    runId: request.input.runId,
+  };
+}
+
+function createTransport(
+  send: Transport['send'],
+): Transport & { send: jest.MockedFunction<Transport['send']> } {
+  return {
+    name: 'test-transport',
+    send: jest.fn(send),
+  };
+}
+
+function execute({
+  transport,
+  retries = 0,
+  cancelSignal = new AbortController().signal,
+  retiredSignal = new AbortController().signal,
+  onStarted = jest.fn(),
+  onEvent = jest.fn(),
+  onAttemptError = jest.fn(),
+}: {
+  transport: Transport;
+  retries?: number;
+  cancelSignal?: AbortSignal;
+  retiredSignal?: AbortSignal;
+  onStarted?: () => void;
+  onEvent?: (event: AGUIEvent) => void;
+  onAttemptError?: (error: Error) => void;
+}) {
+  return executeLogicalRun({
+    transport,
+    retries,
+    cancelSignal,
+    retiredSignal,
+    createRequest,
+    onStarted,
+    onEvent,
+    onAttemptError,
+  });
+}
+
+test('retries a failed attempt with fresh metadata and reports eventual success', async () => {
+  const firstError = new Error('temporary failure');
+  const requests: TransportRequest[] = [];
+  const transport = createTransport(async (request) => {
+    requests.push(request);
+    if (requests.length === 1) {
+      throw firstError;
+    }
+
+    return {
+      events: createEvents([createStarted(request), createFinished(request)]),
+    };
+  });
+  const onEvent = jest.fn();
+  const onAttemptError = jest.fn();
+
+  const outcome = await execute({
+    transport,
+    retries: 1,
+    onEvent,
+    onAttemptError,
+  });
+
+  expect(outcome).toEqual({ kind: 'finished' });
+  expect(
+    requests.map(({ attempt, maxAttempts, requestId }) => ({
+      attempt,
+      maxAttempts,
+      requestId,
+    })),
+  ).toEqual([
+    { attempt: 1, maxAttempts: 2, requestId: 'run-1' },
+    { attempt: 2, maxAttempts: 2, requestId: 'run-2' },
+  ]);
+  expect(onAttemptError).toHaveBeenCalledWith(firstError);
+  expect(onAttemptError).toHaveBeenCalledTimes(1);
+  expect(onEvent.mock.calls.map(([event]) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+    EventType.RUN_FINISHED,
+  ]);
+});
+
+test('stops a non-retryable failure without reporting retry exhaustion', async () => {
+  const error = new TransportError('invalid request', { retryable: false });
+  const transport = createTransport(async () => {
+    throw error;
+  });
+  const onAttemptError = jest.fn();
+
+  const outcome = await execute({
+    transport,
+    retries: 3,
+    onAttemptError,
+  });
+
+  expect(outcome).toEqual({
+    kind: 'failed',
+    error,
+    exhaustedRetries: false,
+  });
+  expect(transport.send).toHaveBeenCalledTimes(1);
+  expect(onAttemptError).toHaveBeenCalledWith(error);
+});
+
+test('reports exhaustion after all retryable attempts fail', async () => {
+  const error = new Error('still unavailable');
+  const transport = createTransport(async () => {
+    throw error;
+  });
+  const onAttemptError = jest.fn();
+
+  const outcome = await execute({
+    transport,
+    retries: 1,
+    onAttemptError,
+  });
+
+  expect(outcome).toEqual({
+    kind: 'failed',
+    error,
+    exhaustedRetries: true,
+  });
+  expect(transport.send).toHaveBeenCalledTimes(2);
+  expect(onAttemptError).toHaveBeenCalledTimes(2);
+});
+
+test('does not synthesize RUN_ERROR when an attempt fails before RUN_STARTED', async () => {
+  const error = new Error('send failed');
+  const transport = createTransport(async () => {
+    throw error;
+  });
+  const onEvent = jest.fn();
+
+  await execute({ transport, onEvent });
+
+  expect(onEvent).not.toHaveBeenCalled();
+});
+
+test('synthesizes one RUN_ERROR when an accepted attempt fails before a terminal event', async () => {
+  const error = new Error('stream failed');
+  const transport = createTransport(async (request) => ({
+    events: (async function* () {
+      yield createStarted(request);
+      throw error;
+    })(),
+  }));
+  const onEvent = jest.fn();
+
+  const outcome = await execute({ transport, onEvent });
+
+  expect(outcome).toEqual({
+    kind: 'failed',
+    error,
+    exhaustedRetries: false,
+  });
+  expect(onEvent.mock.calls.map(([event]) => event)).toEqual([
+    expect.objectContaining({ type: EventType.RUN_STARTED }),
+    { type: EventType.RUN_ERROR, message: error.message },
+  ]);
+});
+
+test('returns a server RUN_ERROR without retrying or synthesizing another terminal', async () => {
+  const runError: AGUIEvent = {
+    type: EventType.RUN_ERROR,
+    message: 'server rejected the run',
+  };
+  const transport = createTransport(async (request) => ({
+    events: createEvents([createStarted(request), runError]),
+  }));
+  const onEvent = jest.fn();
+  const onAttemptError = jest.fn();
+
+  const outcome = await execute({
+    transport,
+    retries: 2,
+    onEvent,
+    onAttemptError,
+  });
+
+  expect(outcome).toMatchObject({
+    kind: 'server-error',
+    error: { message: runError.message },
+  });
+  expect(transport.send).toHaveBeenCalledTimes(1);
+  expect(onEvent.mock.calls.map(([event]) => event)).toEqual([
+    expect.objectContaining({ type: EventType.RUN_STARTED }),
+    runError,
+  ]);
+  expect(onAttemptError).not.toHaveBeenCalled();
+});
+
+test('cancellation after RUN_STARTED synthesizes one cancellation terminal', async () => {
+  const cancelController = new AbortController();
+  const transport = createTransport(async (request) => ({
+    events: createEvents([createStarted(request), createFinished(request)]),
+  }));
+  const onEvent = jest.fn((event: AGUIEvent) => {
+    if (event.type === EventType.RUN_STARTED) {
+      cancelController.abort();
+    }
+  });
+
+  const outcome = await execute({
+    transport,
+    cancelSignal: cancelController.signal,
+    onEvent,
+  });
+
+  expect(outcome).toEqual({ kind: 'cancelled' });
+  expect(onEvent.mock.calls.map(([event]) => event)).toEqual([
+    expect.objectContaining({ type: EventType.RUN_STARTED }),
+    { type: EventType.RUN_ERROR, message: 'Generation cancelled' },
+  ]);
+});
+
+test('retirement takes precedence without synthesizing a terminal or reporting an error', async () => {
+  const retiredController = new AbortController();
+  const transport = createTransport(async (request) => ({
+    events: createEvents([createStarted(request), createFinished(request)]),
+  }));
+  const onEvent = jest.fn((event: AGUIEvent) => {
+    if (event.type === EventType.RUN_STARTED) {
+      retiredController.abort();
+    }
+  });
+  const onAttemptError = jest.fn();
+
+  const outcome = await execute({
+    transport,
+    retiredSignal: retiredController.signal,
+    onEvent,
+    onAttemptError,
+  });
+
+  expect(outcome).toEqual({ kind: 'retired' });
+  expect(onEvent.mock.calls.map(([event]) => event.type)).toEqual([
+    EventType.RUN_STARTED,
+  ]);
+  expect(onAttemptError).not.toHaveBeenCalled();
+});

--- a/packages/core/src/effects/logical-run-coordinator.ts
+++ b/packages/core/src/effects/logical-run-coordinator.ts
@@ -1,0 +1,185 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import type { Transport, TransportRequest } from '../transport';
+import { TransportError } from '../transport';
+import { runAgUiAttempt } from '../transport/ag-ui-run-driver';
+import {
+  createLogicalRunRetryState,
+  decideLogicalRunFailure,
+  startLogicalRunAttempt,
+} from './logical-run-retry-policy';
+
+/**
+ * Metadata used to construct one request in a logical run.
+ *
+ * @internal
+ */
+export interface LogicalRunRequestContext {
+  readonly attempt: number;
+  readonly maxAttempts: number;
+  readonly signal: AbortSignal;
+}
+
+/**
+ * Inputs for executing and observing one logical AG-UI run.
+ *
+ * @internal
+ */
+export interface ExecuteLogicalRunOptions {
+  readonly transport: Transport;
+  readonly retries: number;
+  readonly cancelSignal: AbortSignal;
+  readonly retiredSignal: AbortSignal;
+  readonly createRequest: (
+    context: LogicalRunRequestContext,
+  ) => TransportRequest;
+  readonly onStarted: () => void;
+  readonly onEvent: (event: AGUIEvent) => void;
+  readonly onAttemptError: (error: Error) => void;
+}
+
+/**
+ * Terminal result of one logical AG-UI run across all of its attempts.
+ *
+ * @internal
+ */
+export type LogicalRunOutcome =
+  | { readonly kind: 'finished' }
+  | { readonly kind: 'server-error'; readonly error: Error }
+  | { readonly kind: 'cancelled' }
+  | { readonly kind: 'retired' }
+  | {
+      readonly kind: 'failed';
+      readonly error: Error;
+      readonly exhaustedRetries: boolean;
+    };
+
+/**
+ * Executes a logical AG-UI run, including retries and attempt lifecycle repair.
+ *
+ * @internal
+ */
+export async function executeLogicalRun({
+  transport,
+  retries,
+  cancelSignal,
+  retiredSignal,
+  createRequest,
+  onStarted,
+  onEvent,
+  onAttemptError,
+}: ExecuteLogicalRunOptions): Promise<LogicalRunOutcome> {
+  let retryState = createLogicalRunRetryState(retries);
+
+  while (true) {
+    const interruption = getInterruption(retiredSignal, cancelSignal);
+    if (interruption) {
+      return interruption;
+    }
+
+    const startedAttempt = startLogicalRunAttempt(retryState);
+    retryState = startedAttempt.state;
+    const request = createRequest({
+      ...startedAttempt.context,
+      signal: AbortSignal.any([retiredSignal, cancelSignal]),
+    });
+    let runStarted = false;
+    let runTerminal = false;
+
+    const emitRunError = (message: string, allowCancelled = false) => {
+      if (!runStarted || runTerminal || retiredSignal.aborted) {
+        return;
+      }
+      if (cancelSignal.aborted && !allowCancelled) {
+        return;
+      }
+
+      runTerminal = true;
+      onEvent({ type: EventType.RUN_ERROR, message });
+    };
+
+    let primaryError: Error | undefined;
+    try {
+      const outcome = await runAgUiAttempt({
+        transport,
+        request,
+        cancelSignal,
+        retiredSignal,
+        onStarted,
+        onEvent: (event) => {
+          if (event.type === EventType.RUN_STARTED) {
+            runStarted = true;
+          }
+          if (
+            event.type === EventType.RUN_FINISHED ||
+            event.type === EventType.RUN_ERROR
+          ) {
+            runTerminal = true;
+          }
+
+          onEvent(event);
+        },
+      });
+
+      if (retiredSignal.aborted || outcome.kind === 'retired') {
+        return { kind: 'retired' };
+      }
+      if (outcome.kind === 'finished') {
+        return outcome;
+      }
+      if (outcome.kind === 'server-error') {
+        return outcome;
+      }
+      if (cancelSignal.aborted || outcome.kind === 'cancelled') {
+        emitRunError('Generation cancelled', true);
+        return { kind: 'cancelled' };
+      }
+    } catch (error) {
+      primaryError =
+        error instanceof Error ? error : new Error('Unknown transport error');
+    }
+
+    const interruptionAfterFailure = getInterruption(
+      retiredSignal,
+      cancelSignal,
+    );
+    if (interruptionAfterFailure?.kind === 'retired') {
+      return interruptionAfterFailure;
+    }
+    if (interruptionAfterFailure?.kind === 'cancelled') {
+      emitRunError('Generation cancelled', true);
+      return interruptionAfterFailure;
+    }
+
+    const error =
+      primaryError ??
+      new TransportError('Generation ended without a terminal outcome', {
+        retryable: true,
+        code: 'PROTOCOL_ERROR',
+      });
+    emitRunError(error.message);
+    onAttemptError(error);
+
+    const failureDecision = decideLogicalRunFailure(retryState, error);
+    if (failureDecision.kind === 'stop') {
+      return {
+        kind: 'failed',
+        error,
+        exhaustedRetries: failureDecision.exhaustedRetries,
+      };
+    }
+  }
+}
+
+function getInterruption(
+  retiredSignal: AbortSignal,
+  cancelSignal: AbortSignal,
+): Extract<LogicalRunOutcome, { kind: 'retired' | 'cancelled' }> | undefined {
+  if (retiredSignal.aborted) {
+    return { kind: 'retired' };
+  }
+  if (cancelSignal.aborted) {
+    return { kind: 'cancelled' };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- extract logical AG-UI attempt and retry orchestration from the store-bound generation effect
- centralize interruption precedence and synthesized `RUN_ERROR` terminals in a store-free coordinator
- add focused coverage for retry success and exhaustion, protocol failures, server errors, cancellation, and retirement

## Verification

- `npx nx test core --parallel=1`
- `npx nx build core --parallel=1`
- `npx nx lint core --parallel=1`
- `npx nx tsc:typecheck core --parallel=1`
- `npx nx build-api-report core --parallel=1`
- `npx nx e2e core --parallel=1`
- `npx nx test runtime-smoke --parallel=1`
- `npx nx typecheck runtime-smoke --parallel=1`
- `npx nx lint runtime-smoke --parallel=1`
- `npx nx e2e runtime-smoke --parallel=1` (24 browser tests across Angular and React)