### PR TITLE
refactor(core): extract tool turn coordinator

### DIFF
--- a/packages/core/src/effects/tool-turn-coordinator.spec.ts
+++ b/packages/core/src/effects/tool-turn-coordinator.spec.ts
@@ -1,0 +1,233 @@
+import { Chat } from '../models';
+import {
+  createToolTurnCoordinator,
+  type ToolTurnCoordinator,
+  type ToolTurnOutcome,
+} from './tool-turn-coordinator';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createToolCall(
+  overrides: Partial<Chat.Internal.ToolCall> = {},
+): Chat.Internal.ToolCall {
+  return {
+    id: 'tool-call-1',
+    name: 'lookup',
+    arguments: '{}',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+function createTool(
+  name: string,
+  handler: Chat.Internal.Tool['handler'],
+): Chat.Internal.Tool {
+  return {
+    name,
+    description: `${name} tool`,
+    schema: {},
+    handler,
+  };
+}
+
+function flushTaskBoundary(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+test('executes a tool turn concurrently and completes in call order', async () => {
+  const firstStarted = createDeferred<void>();
+  const secondStarted = createDeferred<void>();
+  const firstResult = createDeferred<string>();
+  const secondResult = createDeferred<string>();
+  const signals: AbortSignal[] = [];
+  const toolCalls = [
+    createToolCall({ id: 'first-call', name: 'first' }),
+    createToolCall({ id: 'second-call', name: 'second' }),
+  ];
+  const coordinator = createToolTurnCoordinator({
+    toolCalls,
+    toolsByName: {
+      first: createTool('first', async (_args, signal) => {
+        signals.push(signal);
+        firstStarted.resolve();
+        return firstResult.promise;
+      }),
+      second: createTool('second', async (_args, signal) => {
+        signals.push(signal);
+        secondStarted.resolve();
+        return secondResult.promise;
+      }),
+    },
+  });
+
+  await Promise.all([firstStarted.promise, secondStarted.promise]);
+  secondResult.resolve('second result');
+  firstResult.resolve('first result');
+  const outcome = await coordinator.completion;
+
+  expect(outcome).toEqual({
+    continuation: 'continue',
+    results: [
+      { status: 'fulfilled', value: 'first result' },
+      { status: 'fulfilled', value: 'second result' },
+    ],
+  });
+  expect(signals).toHaveLength(2);
+  expect(signals[0]).not.toBe(signals[1]);
+  expect(signals.every((signal) => !signal.aborted)).toBe(true);
+  expect(coordinator.cancel()).toBeUndefined();
+});
+
+test('cancels every call and settles once when cancellation wins', async () => {
+  const handlersStarted = createDeferred<void>();
+  const signals: AbortSignal[] = [];
+  const handler = (_args: unknown, signal: AbortSignal) => {
+    signals.push(signal);
+    if (signals.length === 2) {
+      handlersStarted.resolve();
+    }
+    return new Promise(() => undefined);
+  };
+  const coordinator = createToolTurnCoordinator({
+    toolCalls: [
+      createToolCall({ id: 'first-call', name: 'first' }),
+      createToolCall({ id: 'second-call', name: 'second' }),
+    ],
+    toolsByName: {
+      first: createTool('first', handler),
+      second: createTool('second', handler),
+    },
+  });
+
+  await handlersStarted.promise;
+  const cancelledOutcome = coordinator.cancel();
+  const completedOutcome = await coordinator.completion;
+
+  expect(cancelledOutcome).toBeDefined();
+  expect(completedOutcome).toBe(cancelledOutcome);
+  expect(completedOutcome.continuation).toBe('stop');
+  expect(completedOutcome.results).toHaveLength(2);
+  expect(
+    completedOutcome.results.every((result) => result.status === 'rejected'),
+  ).toBe(true);
+  completedOutcome.results.forEach((result) => {
+    if (result.status === 'rejected') {
+      expect(result.reason).toMatchObject({
+        name: 'AbortError',
+        message: 'Tool execution cancelled',
+      });
+    }
+  });
+  expect(signals).toHaveLength(2);
+  expect(signals[0]).not.toBe(signals[1]);
+  expect(signals.every((signal) => signal.aborted)).toBe(true);
+  expect(coordinator.cancel()).toBeUndefined();
+});
+
+test('cancellation before execution does not invoke a handler', async () => {
+  const handler = jest.fn(async () => 'result');
+  const coordinator = createToolTurnCoordinator({
+    toolCalls: [createToolCall()],
+    toolsByName: { lookup: createTool('lookup', handler) },
+  });
+
+  const cancelledOutcome = coordinator.cancel();
+  const completedOutcome = await coordinator.completion;
+
+  expect(handler).not.toHaveBeenCalled();
+  expect(completedOutcome).toBe(cancelledOutcome);
+  expect(completedOutcome).toMatchObject({
+    continuation: 'stop',
+    results: [{ status: 'rejected' }],
+  });
+});
+
+test('publishes the stopped outcome before abort callbacks can cancel again', async () => {
+  const handlerStarted = createDeferred<void>();
+  const coordinatorRef: { current?: ToolTurnCoordinator } = {};
+  let nestedOutcome: ToolTurnOutcome | undefined;
+  const handler = (_args: unknown, signal: AbortSignal) => {
+    signal.addEventListener(
+      'abort',
+      () => {
+        nestedOutcome = coordinatorRef.current?.cancel();
+      },
+      { once: true },
+    );
+    handlerStarted.resolve();
+    return new Promise(() => undefined);
+  };
+  const coordinator = createToolTurnCoordinator({
+    toolCalls: [createToolCall()],
+    toolsByName: { lookup: createTool('lookup', handler) },
+  });
+  coordinatorRef.current = coordinator;
+
+  await handlerStarted.promise;
+  const cancelledOutcome = coordinator.cancel();
+  const completedOutcome = await coordinator.completion;
+
+  expect(nestedOutcome).toBeUndefined();
+  expect(completedOutcome).toBe(cancelledOutcome);
+});
+
+test('cancellation replaces partial successes with a consistent stopped result', async () => {
+  const firstFinished = createDeferred<void>();
+  const secondStarted = createDeferred<void>();
+  const coordinator = createToolTurnCoordinator({
+    toolCalls: [
+      createToolCall({ id: 'first-call', name: 'first' }),
+      createToolCall({ id: 'second-call', name: 'second' }),
+    ],
+    toolsByName: {
+      first: createTool('first', async () => {
+        firstFinished.resolve();
+        return 'first result';
+      }),
+      second: createTool('second', async () => {
+        secondStarted.resolve();
+        return new Promise(() => undefined);
+      }),
+    },
+  });
+
+  await Promise.all([firstFinished.promise, secondStarted.promise]);
+  await flushTaskBoundary();
+  coordinator.cancel();
+  const outcome = await coordinator.completion;
+
+  expect(outcome.continuation).toBe('stop');
+  expect(outcome.results).toHaveLength(2);
+  expect(outcome.results.every((result) => result.status === 'rejected')).toBe(
+    true,
+  );
+});
+
+test('copies the tool-call collection without mutating its inputs', async () => {
+  const toolCall = Object.freeze(createToolCall());
+  const toolCalls = Object.freeze([toolCall]);
+  const toolsByName = Object.freeze({
+    lookup: createTool('lookup', async () => 'result'),
+  });
+  const coordinator = createToolTurnCoordinator({
+    toolCalls,
+    toolsByName,
+  });
+
+  const outcome = await coordinator.completion;
+
+  expect(outcome).toEqual({
+    continuation: 'continue',
+    results: [{ status: 'fulfilled', value: 'result' }],
+  });
+  expect(toolCalls).toEqual([toolCall]);
+  expect(toolsByName.lookup.name).toBe('lookup');
+});

--- a/packages/core/src/effects/tool-turn-coordinator.ts
+++ b/packages/core/src/effects/tool-turn-coordinator.ts
@@ -1,0 +1,98 @@
+import { Chat } from '../models';
+import { executeToolTurn } from './tool-turn-executor';
+
+/**
+ * Inputs for one cancellable tool turn.
+ *
+ * @internal
+ */
+export interface CreateToolTurnCoordinatorOptions {
+  readonly toolCalls: readonly Chat.Internal.ToolCall[];
+  readonly toolsByName: Readonly<
+    Record<string, Chat.Internal.Tool | undefined>
+  >;
+}
+
+/**
+ * Settled result of one tool turn.
+ *
+ * @internal
+ */
+export interface ToolTurnOutcome {
+  readonly results: readonly PromiseSettledResult<unknown>[];
+  readonly continuation: 'continue' | 'stop';
+}
+
+/**
+ * Handle for observing or cancelling one active tool turn.
+ *
+ * @internal
+ */
+export interface ToolTurnCoordinator {
+  readonly completion: Promise<ToolTurnOutcome>;
+  readonly cancel: () => ToolTurnOutcome | undefined;
+}
+
+/**
+ * Starts one tool turn and coordinates its cancellation and terminal outcome.
+ *
+ * @internal
+ */
+export function createToolTurnCoordinator({
+  toolCalls,
+  toolsByName,
+}: CreateToolTurnCoordinatorOptions): ToolTurnCoordinator {
+  const calls = [...toolCalls];
+  const executions = calls.map((toolCall) => ({
+    toolCall,
+    tool: toolsByName[toolCall.name],
+    controller: new AbortController(),
+  }));
+  let settledOutcome: ToolTurnOutcome | undefined;
+
+  const completion = executeToolTurn(
+    executions.map(({ toolCall, tool, controller }) => ({
+      toolCall,
+      tool,
+      signal: controller.signal,
+    })),
+  ).then((results) => {
+    if (settledOutcome) {
+      return settledOutcome;
+    }
+
+    settledOutcome = { results, continuation: 'continue' };
+    return settledOutcome;
+  });
+
+  return {
+    completion,
+    cancel: () => {
+      if (settledOutcome) {
+        return undefined;
+      }
+
+      settledOutcome = {
+        results: cancellationResults(calls),
+        continuation: 'stop',
+      };
+      executions.forEach(({ controller }) => controller.abort());
+      return settledOutcome;
+    },
+  };
+}
+
+function cancellationResults(
+  toolCalls: readonly Chat.Internal.ToolCall[],
+): PromiseSettledResult<unknown>[] {
+  return toolCalls.map(() => ({
+    status: 'rejected',
+    reason: createCancellationError(),
+  }));
+}
+
+function createCancellationError(): Error {
+  const error = new Error('Tool execution cancelled');
+  error.name = 'AbortError';
+  return error;
+}

--- a/packages/core/src/effects/tools.effects.ts
+++ b/packages/core/src/effects/tools.effects.ts
@@ -7,33 +7,22 @@ import {
   selectToolEntities,
   selectUnifiedError,
 } from '../reducers';
-import { executeToolTurn, type ToolCallExecution } from './tool-turn-executor';
+import {
+  createToolTurnCoordinator,
+  type ToolTurnCoordinator,
+  type ToolTurnOutcome,
+} from './tool-turn-coordinator';
 
 interface ActiveToolTurn {
   readonly toolCalls: Chat.Internal.ToolCall[];
-  readonly controllers: Map<string, AbortController>;
+  readonly coordinator: ToolTurnCoordinator;
   readonly threadId: string | undefined;
   settled: boolean;
 }
 
-function createCancellationError(): Error {
-  const error = new Error('Tool execution cancelled');
-  error.name = 'AbortError';
-  return error;
-}
-
-function cancellationResults(
-  toolCalls: Chat.Internal.ToolCall[],
-): PromiseSettledResult<unknown>[] {
-  return toolCalls.map(() => ({
-    status: 'rejected',
-    reason: createCancellationError(),
-  }));
-}
-
 function toToolMessages(
   toolCalls: Chat.Internal.ToolCall[],
-  results: PromiseSettledResult<unknown>[],
+  results: readonly PromiseSettledResult<unknown>[],
 ): Chat.Api.ToolMessage[] {
   return toolCalls.map((toolCall, index) => ({
     role: 'tool',
@@ -46,11 +35,7 @@ function toToolMessages(
 export const runTools = createEffect((store) => {
   let activeTurn: ActiveToolTurn | undefined;
 
-  const settleTurn = (
-    turn: ActiveToolTurn,
-    results: PromiseSettledResult<unknown>[],
-    continuation: 'continue' | 'stop',
-  ) => {
+  const settleTurn = (turn: ActiveToolTurn, outcome: ToolTurnOutcome) => {
     if (turn.settled) {
       return;
     }
@@ -62,8 +47,8 @@ export const runTools = createEffect((store) => {
     store.dispatch(
       internalActions.toolTurnSettled({
         toolCalls: turn.toolCalls,
-        toolMessages: toToolMessages(turn.toolCalls, results),
-        continuation,
+        toolMessages: toToolMessages(turn.toolCalls, outcome.results),
+        continuation: outcome.continuation,
       }),
     );
   };
@@ -74,8 +59,10 @@ export const runTools = createEffect((store) => {
       return;
     }
 
-    turn.controllers.forEach((controller) => controller.abort());
-    settleTurn(turn, cancellationResults(turn.toolCalls), 'stop');
+    const outcome = turn.coordinator.cancel();
+    if (outcome) {
+      settleTurn(turn, outcome);
+    }
   };
 
   store.when(apiActions.assistantTurnFinalized, async (action) => {
@@ -99,44 +86,28 @@ export const runTools = createEffect((store) => {
       return;
     }
 
-    if (action.payload.continuation === 'stop') {
-      settleTurn(
-        {
-          toolCalls,
-          controllers: new Map(),
-          threadId: store.read(selectThreadId),
-          settled: false,
-        },
-        cancellationResults(toolCalls),
-        'stop',
-      );
-      return;
-    }
-
-    const executions = toolCalls.map((toolCall) => ({
-      toolCall,
-      controller: new AbortController(),
-    }));
-    const controllers = new Map(
-      executions.map(({ toolCall, controller }) => [toolCall.id, controller]),
-    );
+    const coordinator = createToolTurnCoordinator({
+      toolCalls,
+      toolsByName: toolEntities,
+    });
     const turn: ActiveToolTurn = {
       toolCalls,
-      controllers,
+      coordinator,
       threadId: store.read(selectThreadId),
       settled: false,
     };
     activeTurn = turn;
 
-    const toolCallExecutions: ToolCallExecution[] = executions.map(
-      ({ toolCall, controller }) => ({
-        toolCall,
-        tool: toolEntities[toolCall.name],
-        signal: controller.signal,
-      }),
-    );
-    const results = await executeToolTurn(toolCallExecutions);
-    settleTurn(turn, results, 'continue');
+    if (action.payload.continuation === 'stop') {
+      const outcome = coordinator.cancel();
+      if (outcome) {
+        settleTurn(turn, outcome);
+      }
+      return;
+    }
+
+    const outcome = await coordinator.completion;
+    settleTurn(turn, outcome);
   });
 
   store.when(


### PR DESCRIPTION
## Summary

- extract per-turn tool cancellation and terminal outcome ownership from the store effect
- preserve deterministic all-cancelled results, per-call abort signals, and settle-once behavior
- harden synchronous abort reentrancy and partial-completion cancellation with focused tests

## Verification

- `npx nx test core --parallel=1` (593 tests)
- `npx nx build core --parallel=1`
- `npx nx lint core --parallel=1`
- `npx nx tsc:typecheck core --parallel=1`
- `npx nx build-api-report core --parallel=1`
- `npx nx e2e core --parallel=1`
- `npx nx test runtime-smoke --parallel=1`
- `npx nx typecheck runtime-smoke --parallel=1`
- `npx nx lint runtime-smoke --parallel=1`
- `npx nx e2e runtime-smoke --parallel=1` (24 browser tests across Angular and React)