### PR TITLE
test: verify Smart Home examples over AG-UI

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Validate smart-home React tooling
         run: npx nx run-many -t eslint:lint,build-storybook -p smart-home-react --parallel=2
 
+      - name: Verify affected real examples
+        run: npx nx affected -t example-e2e --parallel=1
+
       - name: Upload runtime smoke diagnostics
         if: failure()
         uses: actions/upload-artifact@v6
@@ -66,6 +69,8 @@ jobs:
           path: |
             test-results/runtime-smoke
             playwright-report/runtime-smoke
+            test-results/examples
+            playwright-report/examples
           retention-days: 7
           if-no-files-found: ignore
 

--- a/samples/smart-home/angular/project.json
+++ b/samples/smart-home/angular/project.json
@@ -25,6 +25,11 @@
         "styles": ["samples/smart-home/angular/src/styles.scss"]
       },
       "configurations": {
+        "example": {
+          "outputPath": "dist/samples/smart-home/angular-example",
+          "optimization": { "scripts": true, "styles": true, "fonts": false },
+          "outputHashing": "all"
+        },
         "production": {
           "budgets": [
             {

--- a/samples/smart-home/react/project.json
+++ b/samples/smart-home/react/project.json
@@ -6,9 +6,10 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "nx:run-commands",
+      "executor": "@nx/vite:build",
       "options": {
-        "command": "echo 'Skipping build for client-react'"
+        "configFile": "samples/smart-home/react/vite.config.ts",
+        "outputPath": "dist/samples/smart-home/client-react"
       }
     }
   }

--- a/samples/smart-home/react/tailwind.config.js
+++ b/samples/smart-home/react/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  content: { relative: true, files: ['./src/**/*.{js,jsx,ts,tsx}'] },
   theme: {
     extend: {
       colors: {

--- a/samples/smart-home/server/src/app.ts
+++ b/samples/smart-home/server/src/app.ts
@@ -1,0 +1,47 @@
+import type { RunAgentInput } from '@ag-ui/core';
+import { EventEncoder } from '@ag-ui/encoder';
+import { HashbrownOpenAI } from '@hashbrownai/openai';
+import cors from 'cors';
+import express from 'express';
+
+/** Backend-owned model configuration for the Smart Home API. */
+export interface SmartHomeApiOptions {
+  apiKey: string;
+  baseURL?: string;
+  model: string;
+}
+
+/** Creates the sample API without opening a port or reading process globals. */
+export function createApi(options: SmartHomeApiOptions) {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  app.post('/api/chat', async (req, res) => {
+    const abortController = new AbortController();
+    req.once('aborted', () => abortController.abort());
+    res.once('close', () => abortController.abort());
+
+    const response = HashbrownOpenAI.stream.text({
+      ...options,
+      input: req.body as RunAgentInput,
+      signal: abortController.signal,
+    });
+    const encoder = new EventEncoder();
+
+    res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+    res.header('Content-Type', encoder.getContentType());
+    res.header('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    for await (const event of response) {
+      res.write(encoder.encodeSSE(event));
+    }
+
+    if (!res.writableEnded) {
+      res.end();
+    }
+  });
+
+  return app;
+}

--- a/samples/smart-home/server/src/main.ts
+++ b/samples/smart-home/server/src/main.ts
@@ -1,8 +1,4 @@
-import type { RunAgentInput } from '@ag-ui/core';
-import { EventEncoder } from '@ag-ui/encoder';
-import express from 'express';
-import cors from 'cors';
-import { HashbrownOpenAI } from '@hashbrownai/openai';
+import { createApi } from './app';
 
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -14,37 +10,10 @@ if (!OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY is not set');
 }
 
-const app = express();
-
-app.use(cors());
-app.use(express.json());
-
-app.post('/api/chat', async (req, res) => {
-  const abortController = new AbortController();
-  req.once('aborted', () => abortController.abort());
-  res.once('close', () => abortController.abort());
-
-  const response = HashbrownOpenAI.stream.text({
-    apiKey: OPENAI_API_KEY,
-    baseURL: OPENAI_BASE_URL,
-    model: OPENAI_MODEL,
-    input: req.body as RunAgentInput,
-    signal: abortController.signal,
-  });
-  const encoder = new EventEncoder();
-
-  res.header('Cache-Control', 'no-cache, no-store, must-revalidate');
-  res.header('Content-Type', encoder.getContentType());
-  res.header('Connection', 'keep-alive');
-  res.flushHeaders();
-
-  for await (const event of response) {
-    res.write(encoder.encodeSSE(event));
-  }
-
-  if (!res.writableEnded) {
-    res.end();
-  }
+const app = createApi({
+  apiKey: OPENAI_API_KEY,
+  baseURL: OPENAI_BASE_URL,
+  model: OPENAI_MODEL,
 });
 
 app.listen(port, host, () => {

--- a/tools/runtime-smoke/e2e/example-specs/smart-home.spec.ts
+++ b/tools/runtime-smoke/e2e/example-specs/smart-home.spec.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @nx/enforce-module-boundaries -- Exercise the actual sample API, not a replacement endpoint. */
+import { expect, test } from '@playwright/test';
+import { LLMock } from '@copilotkit/aimock';
+import { once } from 'node:events';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createApi } from '../../../../samples/smart-home/server/src/app';
+import type { HashbrownRunInput } from '../harness/agui';
+
+for (const toolRound of [false, true]) {
+  test(`${toolRound ? 'applies a light change and continues' : 'renders trusted UI'} through the real Smart Home server and OpenAI adapter`, async ({
+    page,
+  }, testInfo) => {
+    const angular = testInfo.project.name === 'angular';
+    const content = angular
+      ? {
+          ui: [
+            {
+              'app-markdown': {
+                props: { data: 'Example fixture rendered successfully.' },
+              },
+            },
+          ],
+        }
+      : {
+          ui: [
+            {
+              Card: {
+                props: {
+                  title: 'Example fixture',
+                  description: 'Example fixture rendered successfully.',
+                },
+                children: [],
+              },
+            },
+          ],
+        };
+    const mock = new LLMock({ port: 0 });
+    let release = () => undefined as void;
+    const continuation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    if (toolRound) {
+      mock.onToolResult('sample-control', async () => {
+        await continuation;
+        return { content: JSON.stringify(content) };
+      });
+      mock.onMessage('Verify the example transport', {
+        toolCalls: [
+          {
+            id: 'sample-control',
+            name: 'controlLight',
+            arguments: { lightId: angular ? 'light-1' : '1', brightness: 37 },
+          },
+        ],
+      });
+    } else {
+      mock.onMessage('Verify the example transport', { content });
+    }
+    await mock.start();
+    let server: Server | undefined;
+    const requests: HashbrownRunInput[] = [];
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    try {
+      server = createApi({
+        apiKey: 'fixture-only',
+        baseURL: `${mock.url}/v1`,
+        model: 'gpt-4.1-mini',
+      }).listen(0, '127.0.0.1');
+      await once(server, 'listening');
+      const { port } = server.address() as AddressInfo;
+      // Route only the destination; the browser consumes the sample's real SSE response.
+      await page.route('**/api/chat', async (route) => {
+        requests.push(route.request().postDataJSON());
+        await route.continue({ url: `http://127.0.0.1:${port}/api/chat` });
+      });
+      await page.route('https://fonts.googleapis.com/**', (route) =>
+        route.fulfill({ contentType: 'text/css', body: '' }),
+      );
+      await page.route('https://fonts.gstatic.com/**', (route) =>
+        route.fulfill({ body: '' }),
+      );
+      await page.goto(angular ? '/' : '/lights');
+      if (angular)
+        await page
+          .getByRole('button', { name: 'Close welcome dialog' })
+          .click();
+      if (!angular)
+        await expect(page.locator('.grid-cols-7')).toHaveCSS('display', 'grid');
+      await page
+        .getByPlaceholder(angular ? 'Ask' : 'Type your message...')
+        .fill('Verify the example transport');
+      const responsePromise = page.waitForResponse(
+        (response) =>
+          response.url().endsWith('/api/chat') &&
+          response.request().method() === 'POST',
+      );
+
+      await page.getByRole('button', { name: 'Send', exact: true }).click();
+      const response = await responsePromise;
+      if (toolRound) {
+        await expect.poll(() => requests.length).toBe(2);
+        if (angular) {
+          const light = page
+            .locator('app-light-card')
+            .filter({ hasText: 'Living Room - Ambient 1' });
+          await expect(light.locator('input')).toHaveValue('37');
+        } else {
+          await expect(page.getByText('37%', { exact: true })).toBeVisible();
+        }
+        await expect(
+          page.getByText('Example fixture rendered successfully.', {
+            exact: true,
+          }),
+        ).toHaveCount(0);
+        release();
+      }
+      await expect(
+        page.getByText('Example fixture rendered successfully.', {
+          exact: true,
+        }),
+      ).toBeVisible();
+      if (angular) {
+        await expect(
+          page.locator('app-chat-panel mat-progress-bar'),
+        ).toHaveCount(0);
+      } else {
+        await expect(
+          page.getByRole('button', { name: 'Send', exact: true }),
+        ).toBeVisible();
+      }
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type']).toContain('text/event-stream');
+      expect(requests).toHaveLength(toolRound ? 2 : 1);
+      expect(requests[0]).not.toHaveProperty('model');
+      expect(requests[0]['hashbrown']).toMatchObject({
+        ui: true,
+        responseSchema: expect.any(Object),
+      });
+      expect(mock.getRequests()).toHaveLength(toolRound ? 2 : 1);
+      expect(
+        mock.getRequests().every((entry) => entry.response.status === 200),
+      ).toBe(true);
+      expect(mock.getRequests()[0].body).toMatchObject({
+        model: 'gpt-4.1-mini',
+        stream: true,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            strict: true,
+            schema: requests[0].hashbrown?.responseSchema,
+          },
+        },
+      });
+      if (toolRound) {
+        expect(requests[1]['threadId']).toBe(requests[0]['threadId']);
+        expect(requests[1]['messages']).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              role: 'tool',
+              toolCallId: 'sample-control',
+            }),
+          ]),
+        );
+        expect(
+          mock
+            .getRequests()[1]
+            .body?.messages.filter((message) => message.role === 'tool'),
+        ).toHaveLength(1);
+      }
+      expect(errors).toEqual([]);
+      await page.screenshot({ path: testInfo.outputPath('sample.png') });
+    } finally {
+      release();
+      try {
+        if (server?.listening) {
+          server.closeAllConnections();
+          await new Promise<void>((resolve, reject) =>
+            server?.close((error) => (error ? reject(error) : resolve())),
+          );
+        }
+      } finally {
+        await mock.stop();
+      }
+    }
+  });
+}

--- a/tools/runtime-smoke/e2e/examples.playwright.config.ts
+++ b/tools/runtime-smoke/e2e/examples.playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from '@playwright/test';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  testDir: resolve(__dirname, 'example-specs'),
+  workers: 1,
+  fullyParallel: false,
+  retries: 0,
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  outputDir: resolve(__dirname, '../../../test-results/examples'),
+  reporter: [
+    ['list'],
+    [
+      'html',
+      {
+        outputFolder: resolve(__dirname, '../../../playwright-report/examples'),
+        open: 'never',
+      },
+    ],
+  ],
+  use: {
+    browserName: 'chromium',
+    viewport: { width: 1440, height: 1000 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'angular', use: { baseURL: 'http://127.0.0.1:4321' } },
+    { name: 'react', use: { baseURL: 'http://127.0.0.1:4322' } },
+  ],
+  webServer: ['angular', 'react'].map((framework, index) => ({
+    command: `npx nx serve-example-${framework} runtime-smoke --skip-nx-cache`,
+    cwd: resolve(__dirname, '../../..'),
+    url: `http://127.0.0.1:${4321 + index}`,
+    reuseExistingServer: false,
+    timeout: 60_000,
+  })),
+});

--- a/tools/runtime-smoke/e2e/harness/smart-home-route.spec.ts
+++ b/tools/runtime-smoke/e2e/harness/smart-home-route.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @nx/enforce-module-boundaries -- Exercise the real sample route and provider adapter. */
+import { EventSchemas, EventType } from '@ag-ui/core';
+import { startAimock } from '@hashbrownai/testing/aimock';
+import { once } from 'node:events';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { resolve } from 'node:path';
+import { createApi } from '../../../../samples/smart-home/server/src/app';
+
+jest.mock('express', () => ({
+  __esModule: true,
+  default: jest.requireActual('express'),
+}));
+jest.mock('cors', () => ({
+  __esModule: true,
+  default: jest.requireActual('cors'),
+}));
+
+test('Smart Home serves AG-UI through its native provider without process environment mutation', async () => {
+  const aimock = await startAimock({
+    fixturePath: resolve('tools/testing/aimock/fixtures/text.json'),
+  });
+  let server: Server | undefined;
+
+  try {
+    server = createApi({
+      apiKey: 'fixture-only',
+      baseURL: aimock.openAiBaseUrl,
+      model: 'gpt-4.1-mini',
+    }).listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        threadId: 'sample-thread',
+        runId: 'sample-run',
+        messages: [{ id: 'user', role: 'user', content: 'say hi briefly' }],
+        tools: [],
+        context: [],
+        state: {},
+        forwardedProps: {},
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+    const body = await response.text();
+    const events = body
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => EventSchemas.parse(JSON.parse(line.slice(5))));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(events[0]).toEqual({
+      type: EventType.RUN_STARTED,
+      threadId: 'sample-thread',
+      runId: 'sample-run',
+    });
+    expect(events.at(-1)).toEqual({
+      type: EventType.RUN_FINISHED,
+      threadId: 'sample-thread',
+      runId: 'sample-run',
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        delta: 'Hello from aimock.',
+      }),
+    );
+  } finally {
+    try {
+      if (server?.listening) {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) =>
+          server?.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    } finally {
+      await aimock.stop();
+    }
+  }
+});

--- a/tools/runtime-smoke/e2e/project.json
+++ b/tools/runtime-smoke/e2e/project.json
@@ -8,9 +8,56 @@
     "react",
     "testing",
     "runtime-smoke-angular",
-    "runtime-smoke-react"
+    "runtime-smoke-react",
+    "smart-home-angular",
+    "smart-home-react",
+    "smart-home-server",
+    "openai"
   ],
   "targets": {
+    "example-e2e": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": [
+        {
+          "projects": ["smart-home-react"],
+          "target": "build"
+        }
+      ],
+      "options": {
+        "parallel": false,
+        "commands": [
+          {
+            "command": "npx nx build smart-home-angular --configuration=example",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "npx playwright test --config tools/runtime-smoke/e2e/examples.playwright.config.ts",
+            "forwardAllArgs": true
+          }
+        ]
+      }
+    },
+    "serve-example-angular": {
+      "executor": "@nx/web:file-server",
+      "options": {
+        "staticFilePath": "dist/samples/smart-home/angular-example/browser",
+        "watch": false,
+        "host": "127.0.0.1",
+        "port": 4321,
+        "spa": true
+      }
+    },
+    "serve-example-react": {
+      "executor": "@nx/web:file-server",
+      "options": {
+        "staticFilePath": "dist/samples/smart-home/client-react",
+        "watch": false,
+        "host": "127.0.0.1",
+        "port": 4322,
+        "spa": true
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "options": {

--- a/tools/runtime-smoke/e2e/tsconfig.playwright.json
+++ b/tools/runtime-smoke/e2e/tsconfig.playwright.json
@@ -8,6 +8,11 @@
     "types": ["node"],
     "ignoreDeprecations": "6.0"
   },
-  "include": ["playwright.config.ts", "harness/**/*.ts", "specs/**/*.ts"],
+  "include": [
+    "*playwright.config.ts",
+    "harness/**/*.ts",
+    "specs/**/*.ts",
+    "example-specs/**/*.ts"
+  ],
   "exclude": ["harness/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
Establish deterministic end-to-end coverage for the real Smart Home Angular and React applications through the sample Express server, OpenAI adapter, and aimock fixtures.

## Changes
- Verify trusted UI rendering and light-control tool continuation in both frameworks.
- Hold the continuation response until the browser confirms the light changed.
- Verify thread identity, tool-result forwarding, backend-owned model selection, and strict structured-output schema preservation.
- Extract an importable sample API while preserving server startup configuration.
- Replace React's no-op build target and fix Tailwind scanning when built from the repository root.
- Add an Angular test build without remote font inlining.
- Add an affected-project CI target with zero retries and failure diagnostics.

## Local Verification
- Four example scenarios passed three repetitions each: 12 passes.
- Existing browser smoke suite: 24 passes.
- Runtime smoke unit suite: 25 passes.
- Runtime smoke lint and typecheck passed.
- Smart Home application builds and applicable lint/type checks passed.
- React sample unit tests: three passes.
- Built server entry point started successfully using fixture-only configuration.

Existing lint, bundle-size, tooling-deprecation, and React test-environment warnings remain.

## CI Verification
All required checks passed for commit 48125011e9d58bf36b99cd4e612ae0e16cfe70fd: Lint, Test, Build; Cloudflare Preview; PR Gate; and CLA. Production deployment was skipped as expected.

The completed job log confirms the new example-e2e target ran (not a cache hit): four example scenarios passed. The existing browser suite passed 24 scenarios and the runtime harness passed 25 unit tests.

[CI run](https://github.com/liveloveapp/hashbrown/actions/runs/33917220487)

## Scope
This is the initial real-example baseline, not completion of the broader runtime-hardening arc. Progressive rendering, cancellation/recovery, failure paths, independent endpoint interoperability, and remaining framework parity follow separately.

No state/interrupt API changes, new dependencies, or release.
