### PR TITLE
test: verify gated progressive rendering in Angular and React

### DIFF
--- a/tools/runtime-smoke/e2e/harness/event-gate.spec.ts
+++ b/tools/runtime-smoke/e2e/harness/event-gate.spec.ts
@@ -1,0 +1,40 @@
+import { createEventGate } from './event-gate';
+
+test('holds events until their index is explicitly released', async () => {
+  const gate = createEventGate();
+  const signal = new AbortController().signal;
+  let delivered = false;
+  const waiting = gate.wait(2, signal).then(() => {
+    delivered = true;
+  });
+
+  gate.releaseThrough(1);
+  await Promise.resolve();
+
+  expect(delivered).toBe(false);
+  gate.releaseThrough(2);
+  await waiting;
+  expect(delivered).toBe(true);
+  gate.releaseThrough(0);
+  await gate.wait(2, signal);
+});
+
+test('aborting a gate rejects pending and future waits', async () => {
+  const gate = createEventGate();
+  const controller = new AbortController();
+  const waiting = gate.wait(0, controller.signal);
+  const rejected = expect(waiting).rejects.toThrow('aborted');
+
+  controller.abort();
+
+  await rejected;
+  await expect(gate.wait(0, controller.signal)).rejects.toThrow('aborted');
+});
+
+test('unreleased gates time out instead of leaking pending work', async () => {
+  const gate = createEventGate(10);
+
+  const waiting = gate.wait(0, new AbortController().signal);
+
+  await expect(waiting).rejects.toThrow('Timed out waiting for event 0');
+});

--- a/tools/runtime-smoke/e2e/harness/event-gate.ts
+++ b/tools/runtime-smoke/e2e/harness/event-gate.ts
@@ -1,0 +1,43 @@
+/** Creates a bounded, abortable gate for explicit event delivery in HTTP tests. */
+export function createEventGate(timeoutMs = 10_000): {
+  wait: (index: number, signal: AbortSignal) => Promise<void>;
+  releaseThrough: (index: number) => void;
+} {
+  let released = -1;
+  const listeners = new Set<() => void>();
+
+  return {
+    releaseThrough(index) {
+      released = Math.max(released, index);
+      for (const listener of [...listeners]) listener();
+    },
+    wait(index, signal) {
+      if (signal.aborted)
+        return Promise.reject(new Error('Event gate aborted'));
+      if (index <= released) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          clearTimeout(timer);
+          listeners.delete(check);
+          signal.removeEventListener('abort', abort);
+        };
+        const check = () => {
+          if (index <= released) {
+            cleanup();
+            resolve();
+          }
+        };
+        const abort = () => {
+          cleanup();
+          reject(new Error('Event gate aborted'));
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Timed out waiting for event ${index}`));
+        }, timeoutMs);
+        listeners.add(check);
+        signal.addEventListener('abort', abort, { once: true });
+      });
+    },
+  };
+}

--- a/tools/runtime-smoke/e2e/harness/independent-endpoint.spec.ts
+++ b/tools/runtime-smoke/e2e/harness/independent-endpoint.spec.ts
@@ -1,5 +1,6 @@
 import { EventSchemas, EventType } from '@ag-ui/core';
 import { startIndependentEndpoint } from './independent-endpoint';
+import { createEventGate } from './event-gate';
 
 const input = {
   threadId: 'independent-thread',
@@ -35,6 +36,131 @@ for (const terminal of [
     }
   });
 }
+
+test('gated HTTP delivery exposes a partial body before the terminal is released', async () => {
+  const gate = createEventGate();
+  const endpoint = await startIndependentEndpoint({
+    beforeEvent: gate.wait,
+    events: () => [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ],
+  });
+
+  try {
+    gate.releaseThrough(0);
+    const response = await fetch(endpoint.url, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    if (!response.body) throw new Error('Expected an SSE response body');
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let partial = '';
+    while (!partial.includes('\n\n')) {
+      const chunk = await reader.read();
+      if (chunk.done)
+        throw new Error('Stream ended before the first SSE frame');
+      partial += decoder.decode(chunk.value, { stream: true });
+    }
+
+    expect(partial).toContain('RUN_STARTED');
+    expect(partial).not.toContain('RUN_FINISHED');
+    expect(endpoint.consumeTerminalRun(input.runId)).toBe(false);
+    gate.releaseThrough(1);
+    let rest = '';
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      rest += decoder.decode(chunk.value, { stream: true });
+    }
+    rest += decoder.decode();
+    expect(rest).toContain('RUN_FINISHED');
+    expect(endpoint.consumeTerminalRun(input.runId)).toBe(true);
+    expect(endpoint.consumeTerminalRun(input.runId)).toBe(false);
+  } finally {
+    await endpoint.stop();
+  }
+});
+
+test('stopping the endpoint aborts a blocked delivery gate', async () => {
+  const gate = createEventGate();
+  let signal: AbortSignal | undefined;
+  const endpoint = await startIndependentEndpoint({
+    beforeEvent: (index, currentSignal) => {
+      signal = currentSignal;
+      return gate.wait(index, currentSignal);
+    },
+    events: () => [
+      {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ],
+  });
+
+  try {
+    const response = await fetch(endpoint.url, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    const body = response.text();
+    const settled = body.catch(() => 'closed');
+    await endpoint.stop();
+
+    expect(signal?.aborted).toBe(true);
+    await settled;
+  } finally {
+    await endpoint.stop();
+  }
+});
+
+test('client disconnect aborts a blocked gate without recording a terminal', async () => {
+  const gate = createEventGate();
+  const client = new AbortController();
+  let observedAbort: Promise<void> | undefined;
+  const endpoint = await startIndependentEndpoint({
+    beforeEvent: (index, signal) => {
+      observedAbort = new Promise<void>((resolve) =>
+        signal.addEventListener('abort', () => resolve(), { once: true }),
+      );
+      return gate.wait(index, signal);
+    },
+    events: () => [
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: input.threadId,
+        runId: input.runId,
+      },
+    ],
+  });
+
+  try {
+    const response = await fetch(endpoint.url, {
+      method: 'POST',
+      body: JSON.stringify(input),
+      signal: client.signal,
+    });
+    const body = response.text().catch(() => 'closed');
+    client.abort();
+
+    expect(observedAbort).toBeDefined();
+    await observedAbort;
+    await body;
+    expect(endpoint.consumeTerminalRun(input.runId)).toBe(false);
+  } finally {
+    await endpoint.stop();
+  }
+});
 
 test('standard endpoint parses canonical input without depending on vendor fields', async () => {
   const endpoint = await startIndependentEndpoint({

--- a/tools/runtime-smoke/e2e/harness/independent-endpoint.ts
+++ b/tools/runtime-smoke/e2e/harness/independent-endpoint.ts
@@ -27,6 +27,8 @@ export type EndpointInput = RunAgentInput & {
 export async function startIndependentEndpoint(options: {
   extended?: boolean;
   events: (input: EndpointInput) => readonly AGUIEvent[];
+  /** Optional abortable gate invoked before each event is written. */
+  beforeEvent?: (index: number, signal: AbortSignal) => Promise<void>;
 }): Promise<{
   url: string;
   inputs: readonly EndpointInput[];
@@ -37,6 +39,7 @@ export async function startIndependentEndpoint(options: {
   const inputs: EndpointInput[] = [];
   const terminalRuns = new Set<string>();
   const encoder = new EventEncoder();
+  const deliveries = new Set<AbortController>();
   const server = createServer(async (request, response) => {
     response.setHeader('Access-Control-Allow-Origin', '*');
     response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept');
@@ -68,18 +71,18 @@ export async function startIndependentEndpoint(options: {
       return;
     }
 
+    const delivery = new AbortController();
+    const abortDelivery = () => delivery.abort();
+    deliveries.add(delivery);
+    response.once('close', abortDelivery);
     try {
       inputs.push(input);
       const events = options
         .events(input)
         .map((event) => EventSchemas.parse(event));
-      const body = events.map((event) => encoder.encode(event)).join('');
-      response.writeHead(200, {
-        'Content-Type': encoder.getContentType(),
-        'Cache-Control': 'no-cache',
-      });
-      response.end(body);
-      for (const event of events) {
+      const encoded = events.map((event) => encoder.encode(event));
+      const recordTerminal = (index: number) => {
+        const event = events[index];
         if (
           event.type === EventType.RUN_FINISHED &&
           event.runId === input.runId &&
@@ -87,10 +90,34 @@ export async function startIndependentEndpoint(options: {
         ) {
           terminalRuns.add(input.runId);
         }
+      };
+      response.writeHead(200, {
+        'Content-Type': encoder.getContentType(),
+        'Cache-Control': 'no-cache',
+      });
+      if (options.beforeEvent) {
+        response.flushHeaders();
+        for (const [index, event] of encoded.entries()) {
+          await options.beforeEvent(index, delivery.signal);
+          if (delivery.signal.aborted) return;
+          response.write(event);
+          recordTerminal(index);
+        }
+        response.end();
+      } else {
+        response.end(encoded.join(''));
+        events.forEach((_, index) => recordTerminal(index));
       }
     } catch {
+      if (response.headersSent) {
+        response.destroy();
+        return;
+      }
       response.writeHead(500, { 'Content-Type': 'application/json' });
       response.end(JSON.stringify({ error: 'Invalid fixture events' }));
+    } finally {
+      deliveries.delete(delivery);
+      response.removeListener('close', abortDelivery);
     }
   });
   server.listen(0, '127.0.0.1');
@@ -104,6 +131,7 @@ export async function startIndependentEndpoint(options: {
     consumeTerminalRun: (runId) => terminalRuns.delete(runId),
     stop: () =>
       (stopping ??= new Promise<void>((resolve, reject) => {
+        for (const delivery of deliveries) delivery.abort();
         server.close((error) => (error ? reject(error) : resolve()));
         server.closeAllConnections();
       })),

--- a/tools/runtime-smoke/e2e/playwright.config.ts
+++ b/tools/runtime-smoke/e2e/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from '@playwright/test';
 import { resolve } from 'node:path';
 
 const repoRoot = resolve(__dirname, '../../..');
+const angularPort = Number(process.env['RUNTIME_SMOKE_ANGULAR_PORT'] ?? 4311);
+const reactPort = Number(process.env['RUNTIME_SMOKE_REACT_PORT'] ?? 4312);
 
 export default defineConfig({
   testDir: resolve(__dirname, 'specs'),
@@ -33,25 +35,25 @@ export default defineConfig({
   projects: [
     {
       name: 'angular',
-      use: { baseURL: 'http://127.0.0.1:4311' },
+      use: { baseURL: `http://127.0.0.1:${angularPort}` },
     },
     {
       name: 'react',
-      use: { baseURL: 'http://127.0.0.1:4312' },
+      use: { baseURL: `http://127.0.0.1:${reactPort}` },
     },
   ],
   webServer: [
     {
-      command: 'npx nx run runtime-smoke-angular:serve-built --skip-nx-cache',
+      command: `npx nx serve-built runtime-smoke-angular --skip-nx-cache --port=${angularPort}`,
       cwd: repoRoot,
-      url: 'http://127.0.0.1:4311',
+      url: `http://127.0.0.1:${angularPort}`,
       timeout: 30_000,
       reuseExistingServer: false,
     },
     {
-      command: 'npx nx run runtime-smoke-react:serve-built --skip-nx-cache',
+      command: `npx nx serve-built runtime-smoke-react --skip-nx-cache --port=${reactPort}`,
       cwd: repoRoot,
-      url: 'http://127.0.0.1:4312',
+      url: `http://127.0.0.1:${reactPort}`,
       timeout: 30_000,
       reuseExistingServer: false,
     },

--- a/tools/runtime-smoke/e2e/specs/gated-progressive.spec.ts
+++ b/tools/runtime-smoke/e2e/specs/gated-progressive.spec.ts
@@ -1,0 +1,111 @@
+import { type AGUIEvent, EventType } from '@ag-ui/core';
+import { expect, test } from '@playwright/test';
+import { createAppDriver } from '../harness/app-driver';
+import { installBrowserHygiene } from '../harness/browser';
+import { createEventGate } from '../harness/event-gate';
+import { startIndependentEndpoint } from '../harness/independent-endpoint';
+
+for (const scenario of ['plain', 'structured', 'ui'] as const) {
+  test(`gated ${scenario} renders before completion`, async ({ page }) => {
+    const gate = createEventGate();
+    const chunks =
+      scenario === 'plain'
+        ? ['Re', 'ad', 'y']
+        : scenario === 'structured'
+          ? ['{"count":2,"answer":"Re', 'ad', 'y"}']
+          : [
+              '{"ui":[{"status":{"props":{"title":"Re',
+              'ad',
+              'y","count":2}}}]}',
+            ];
+    const endpoint = await startIndependentEndpoint({
+      extended: scenario !== 'plain',
+      beforeEvent: gate.wait,
+      events: (input): AGUIEvent[] => [
+        {
+          type: EventType.RUN_STARTED,
+          threadId: input.threadId,
+          runId: input.runId,
+        },
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: 'progressive',
+          role: 'assistant',
+        },
+        ...chunks.map((delta) => ({
+          type: EventType.TEXT_MESSAGE_CONTENT as const,
+          messageId: 'progressive',
+          delta,
+        })),
+        { type: EventType.TEXT_MESSAGE_END, messageId: 'progressive' },
+        {
+          type: EventType.RUN_FINISHED,
+          threadId: input.threadId,
+          runId: input.runId,
+        },
+      ],
+    });
+    const hygiene = installBrowserHygiene(page, {}, (request) => {
+      if (
+        request.method() !== 'POST' ||
+        request.url() !== endpoint.url ||
+        request.failure()?.errorText !== 'net::ERR_ABORTED'
+      )
+        return false;
+      const input = request.postDataJSON() as { runId?: unknown };
+      return (
+        typeof input.runId === 'string' &&
+        endpoint.consumeTerminalRun(input.runId)
+      );
+    });
+    const driver = createAppDriver(page);
+    const output =
+      scenario === 'plain'
+        ? driver.assistant()
+        : scenario === 'structured'
+          ? driver.structuredAnswer()
+          : driver.statusCard();
+
+    try {
+      await page.goto(
+        `/?${new URLSearchParams({ scenario, runUrl: endpoint.url, retries: '0' })}`,
+      );
+      await expect(page.getByTestId('fixture-ready')).toBeVisible();
+      gate.releaseThrough(2);
+
+      await driver.send('Show status');
+
+      await expect(output).toHaveText('Re');
+      await driver.expectLoading();
+      const partialNode =
+        scenario === 'ui' ? await output.elementHandle() : null;
+      gate.releaseThrough(3);
+      await expect(output).toHaveText('Read');
+      await driver.expectLoading();
+      if (partialNode) {
+        expect(
+          await output.evaluate(
+            (node, original) => node === original,
+            partialNode,
+          ),
+        ).toBe(true);
+        await partialNode.dispose();
+      }
+      gate.releaseThrough(4);
+      await expect(output).toHaveText(scenario === 'ui' ? 'Ready: 2' : 'Ready');
+      await driver.expectLoading();
+      if (scenario === 'structured')
+        await expect(driver.structuredCount()).toHaveText('2');
+      gate.releaseThrough(6);
+      await driver.expectIdle();
+      await expect(output).toHaveText(scenario === 'ui' ? 'Ready: 2' : 'Ready');
+      await expect(driver.error()).toBeEmpty();
+      await expect(driver.sendingError()).toBeEmpty();
+      await expect(driver.generatingError()).toBeEmpty();
+      expect(endpoint.inputs).toHaveLength(1);
+      await hygiene.assertClean();
+    } finally {
+      await endpoint.stop();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add explicit event gates to prove partial rendering before stream completion.
- Cover text, structured output, and trusted UI in Angular and React.
- Verify fallback identity across partial updates while allowing final-component replacement.
- Test timeout, client-disconnect, and endpoint-stop cleanup.
- Allow separate test-server ports without interrupting running demos.

## Verification
- 42 harness unit tests passed after rebasing onto merged #537.
- 14 focused interop/progressive browser tests passed after rebase.
- Before rebase: full 38 browser tests, 4 Smart Home example tests, and 18 repeated gated cases passed.
- Negative control confirmed both frameworks fail when partial delivery is withheld.
- Builds, lint, typecheck, and formatting passed.
- Independent review: no remaining findings.

## Scope
No production API or dependency changes. Local design notes excluded. Existing tooling and bundle-size warnings remain.